### PR TITLE
helpers.cc: add missing includes

### DIFF
--- a/src/helpers.cc
+++ b/src/helpers.cc
@@ -1,5 +1,7 @@
 #include <sys/file.h>
 #include <unistd.h>
+#include <fcntl.h>
+#include <unistd.h>
 
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>


### PR DESCRIPTION
Fix a build failure with musl due missing open/O_RDWR/O_CREAT/O_APPEND.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>