### PR TITLE
Add support for configurable "callbacks"

### DIFF
--- a/src/helpers.cc
+++ b/src/helpers.cc
@@ -313,11 +313,9 @@ data::ResultCode::Numeric LiteClient::download(const Uptane::Target &target) {
   }
   notifyDownloadStarted(target);
   if (!primary->downloadImage(target).first) {
-    lock->release();
     notifyDownloadFinished(target, false);
     return data::ResultCode::Numeric::kDownloadFailed;
   }
-  lock->release();
   notifyDownloadFinished(target, true);
   return data::ResultCode::Numeric::kOk;
 }
@@ -336,11 +334,9 @@ data::ResultCode::Numeric LiteClient::install(const Uptane::Target &target) {
   } else if (iresult.result_code.num_code == data::ResultCode::Numeric::kOk) {
     LOG_INFO << "Update complete. No reboot needed";
     storage->savePrimaryInstalledVersion(target, InstalledVersionUpdateMode::kCurrent);
-    lock->release();
   } else {
     LOG_ERROR << "Unable to install update: " << iresult.description;
     // let go of the lock since we couldn't update
-    lock->release();
   }
   notifyInstallFinished(target, iresult.result_code.num_code);
   return iresult.result_code.num_code;

--- a/src/helpers.cc
+++ b/src/helpers.cc
@@ -255,6 +255,14 @@ void LiteClient::callback(const char *msg, const Uptane::Target &install_target,
   }
 }
 
+bool LiteClient::checkForUpdates() {
+  Uptane::Target t = Uptane::Target::Unknown();
+  callback("check-for-update-pre", t);
+  bool rc = primary->updateImageMeta();
+  callback("check-for-update-post", t);
+  return rc;
+}
+
 void LiteClient::notify(const Uptane::Target &t, std::unique_ptr<ReportEvent> event) {
   if (!config.tls.server.empty()) {
     event->custom["targetName"] = t.filename();

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -50,6 +50,10 @@ class LiteClient {
 
  private:
   FRIEND_TEST(helpers, locking);
+  FRIEND_TEST(helpers, callback);
+
+  void callback(const char* msg, const Uptane::Target& install_target, const std::string& result = "");
+
   std::unique_ptr<Lock> getDownloadLock();
   std::unique_ptr<Lock> getUpdateLock();
 
@@ -60,6 +64,7 @@ class LiteClient {
 
   void writeCurrentTarget(const Uptane::Target& t);
 
+  boost::filesystem::path callback_program;
   std::shared_ptr<PackageManagerInterface> package_manager;
   std::unique_ptr<ReportQueue> report_queue;
 };

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -46,6 +46,9 @@ struct LiteClient {
   std::unique_ptr<Lock> getDownloadLock();
   std::unique_ptr<Lock> getUpdateLock();
 
+  data::ResultCode::Numeric download(const Uptane::Target& target);
+  data::ResultCode::Numeric install(const Uptane::Target& target);
+
   void notifyDownloadStarted(const Uptane::Target& t);
   void notifyDownloadFinished(const Uptane::Target& t, bool success);
   void notifyInstallStarted(const Uptane::Target& t);

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -18,8 +18,7 @@ struct Version {
 class Lock {
  public:
   Lock(int fd) : fd_(fd) {}
-
-  void release() {
+  ~Lock() {
     if (fd_ != -1) {
       close(fd_);
     }

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -41,6 +41,7 @@ class LiteClient {
   boost::filesystem::path download_lockfile;
   boost::filesystem::path update_lockfile;
 
+  bool checkForUpdates();
   data::ResultCode::Numeric download(const Uptane::Target& target);
   data::ResultCode::Numeric install(const Uptane::Target& target);
   void notifyInstallFinished(const Uptane::Target& t, data::ResultCode::Numeric rc);

--- a/src/helpers_test.cc
+++ b/src/helpers_test.cc
@@ -134,9 +134,8 @@ TEST(helpers, locking) {
   // 1. Create a lock and hold in inside a thread for a small amount of time
   std::unique_ptr<Lock> lock = client.getUpdateLock();
   std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
-  std::thread t([&lock] {
+  std::thread t([_ = std::move(lock)] {  // pass ownership of ptr into lambda
     std::this_thread::sleep_for(std::chrono::milliseconds{500});
-    lock->release();
   });
 
   // 2. Get the lock - this should take a short period of time while its blocked

--- a/src/main.cc
+++ b/src/main.cc
@@ -117,18 +117,10 @@ static data::ResultCode::Numeric do_update(LiteClient &client, Uptane::Target ta
   target.InsertEcu({client.primary_ecu.first, client.primary_ecu.second});
   generate_correlation_id(target);
 
-  std::unique_ptr<Lock> lock = client.getDownloadLock();
-  if (lock == nullptr) {
-    return data::ResultCode::Numeric::kInternalError;
+  data::ResultCode::Numeric rc = client.download(target);
+  if (rc != data::ResultCode::Numeric::kOk) {
+    return rc;
   }
-  client.notifyDownloadStarted(target);
-  if (!client.primary->downloadImage(target).first) {
-    lock->release();
-    client.notifyDownloadFinished(target, false);
-    return data::ResultCode::Numeric::kDownloadFailed;
-  }
-  lock->release();
-  client.notifyDownloadFinished(target, true);
 
   if (client.primary->VerifyTarget(target) != TargetStatus::kGood) {
     client.notifyInstallFinished(target, data::ResultCode::Numeric::kVerificationFailed);
@@ -136,27 +128,7 @@ static data::ResultCode::Numeric do_update(LiteClient &client, Uptane::Target ta
     return data::ResultCode::Numeric::kVerificationFailed;
   }
 
-  lock = client.getUpdateLock();
-  if (lock == nullptr) {
-    return data::ResultCode::Numeric::kInternalError;
-  }
-
-  client.notifyInstallStarted(target);
-  auto iresult = client.primary->PackageInstall(target);
-  if (iresult.result_code.num_code == data::ResultCode::Numeric::kNeedCompletion) {
-    LOG_INFO << "Update complete. Please reboot the device to activate";
-    client.storage->savePrimaryInstalledVersion(target, InstalledVersionUpdateMode::kPending);
-  } else if (iresult.result_code.num_code == data::ResultCode::Numeric::kOk) {
-    LOG_INFO << "Update complete. No reboot needed";
-    client.storage->savePrimaryInstalledVersion(target, InstalledVersionUpdateMode::kCurrent);
-    lock->release();
-  } else {
-    LOG_ERROR << "Unable to install update: " << iresult.description;
-    // let go of the lock since we couldn't update
-    lock->release();
-  }
-  client.notifyInstallFinished(target, iresult.result_code.num_code);
-  return iresult.result_code.num_code;
+  return client.install(target);
 }
 
 static int update_main(LiteClient &client, const bpo::variables_map &variables_map) {

--- a/src/main.cc
+++ b/src/main.cc
@@ -184,7 +184,7 @@ static int daemon_main(LiteClient &client, const bpo::variables_map &variables_m
 
   while (true) {
     LOG_INFO << "Refreshing Targets metadata";
-    if (!client.primary->updateImageMeta()) {
+    if (!client.checkForUpdates()) {
       LOG_WARNING << "Unable to update latest metadata";
       std::this_thread::sleep_for(std::chrono::seconds(10));
       continue;  // There's no point trying to look for an update


### PR DESCRIPTION
The lockfile approach isn't rich enough to allow clients to control how the deamon runs. We've discussed doing a daemon like docker does where clients can talk to the aklite daemon over a socket. However, that requires clients to implement a bit of code. The idea here is that clients can implement a potentially simple shell script that is called synchronously by the daemon. This gives it a chance to wait until its ready before doing something like downloading or installing an update.