### PR TITLE
Don't (re-)start apps containers if reboot

### DIFF
--- a/src/composeapp.cc
+++ b/src/composeapp.cc
@@ -22,7 +22,17 @@ bool ComposeApp::fetch(const std::string& app_uri) {
   return false;
 };
 
-bool ComposeApp::start() { return cmd_streaming(compose_ + "up --remove-orphans -d"); }
+bool ComposeApp::up(bool no_start) {
+  auto mode = no_start ? "--no-start" : "-d";
+
+  if (no_start) {
+    boost::filesystem::ofstream flag_file(root_ / NeedStartFile);
+  }
+
+  return cmd_streaming(compose_ + "up --remove-orphans " + mode);
+}
+
+bool ComposeApp::start() { return cmd_streaming(compose_ + "start"); }
 
 void ComposeApp::remove() {
   if (cmd_streaming(compose_ + "down")) {

--- a/src/composeapp.h
+++ b/src/composeapp.h
@@ -12,12 +12,14 @@ namespace Docker {
 class ComposeApp {
  public:
   static constexpr const char* const ArchiveExt{".tgz"};
+  static constexpr const char* const NeedStartFile{".need_start"};
 
  public:
   ComposeApp(std::string name, const boost::filesystem::path& root_dir, const std::string& compose_bin,
              const Docker::RegistryClient& registry_client);
 
   bool fetch(const std::string& app_uri);
+  bool up(bool no_start = false);
   bool start();
   void remove();
 

--- a/src/helpers.cc
+++ b/src/helpers.cc
@@ -303,6 +303,9 @@ LiteClient::LiteClient(Config& config_in)
   http_client = std::make_shared<HttpClient>(&headers);
   report_queue = std_::make_unique<ReportQueue>(config, http_client, storage);
 
+  // finalizeIfNeeded it looks like copy-paste of SotaUptaneClient::finalizeAfterReboot
+  // can we use just SotaUptaneClient::finalizeAfterReboot or even maybe SotaUptaneClient::initialize ???
+  // in this case we could do our specific finalization, including starting apps, in ComposeAppManager::finalizeInstall
   std::pair<Uptane::Target, data::ResultCode::Numeric> pair = finalizeIfNeeded(*ostree_sysroot, *storage, config);
   http_client->updateHeader("x-ats-target", pair.first.filename());
 


### PR DESCRIPTION
This change makes compose apps's containers not to (re-)start
just after their update and (re-)creation if we are about to reboot a
system in order to apply an ostree-based rootfs update.
The updated apps will be started just after a system boot if aklite runs in a daemon mode.
If it is at a non-daemon mode then the updated apps will be started on a first run
of aklite or they can be started manually.

Signed-off-by: Mike Sul <mike.sul@foundries.io>