### PR TITLE
Fix a race condition in the event reporting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,9 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # OSTree is mandatory for aktualizr-lite
 option(BUILD_OSTREE "Set to ON to compile with ostree support" ON)
-option(BUILD_DOCKERAPP "Set to ON to compile with package manager support of docker-app" OFF)
+option(BUILD_DOCKERAPP "Set to ON to compile with package manager support of docker-app" ON)
+# always build with DOCKERAPP for aktualizr-lite, optional only for aktualizr
+set(BUILD_DOCKERAPP ON)
 option(BUILD_WITH_CLANG_TIDY "Set to ON to do clang-tidy during source compilation" OFF)
 
 # If we build the sota tools we don't need aklite (???) and vice versa

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,10 +19,6 @@ if(BUILD_WITH_CLANG_TIDY)
 
 endif(BUILD_WITH_CLANG_TIDY)
 
-if(BUILD_DOCKERAPP)
-  target_compile_definitions(${TARGET} PRIVATE BUILD_DOCKERAPP)
-endif(BUILD_DOCKERAPP)
-
 target_compile_definitions(${TARGET} PRIVATE BOOST_LOG_DYN_LINK)
 target_compile_definitions(${TARGET_EXE} PRIVATE BOOST_LOG_DYN_LINK)
 

--- a/src/composeappmanager.cc
+++ b/src/composeappmanager.cc
@@ -70,11 +70,6 @@ std::vector<std::pair<std::string, std::string>> ComposeAppManager::getApps(cons
 }
 
 std::vector<std::pair<std::string, std::string>> ComposeAppManager::getAppsToUpdate(const Uptane::Target& t) const {
-  if (cfg_.force_update) {
-    LOG_INFO << "All Apps are forced to be updated";
-    return getApps(t);
-  }
-
   std::vector<std::pair<std::string, std::string>> apps_to_update;
 
   auto currently_installed_target_apps = OstreeManager::getCurrent().custom_data()["docker_compose_apps"];
@@ -114,8 +109,14 @@ bool ComposeAppManager::fetchTarget(const Uptane::Target& target, Uptane::Fetche
     return false;
   }
 
-  LOG_INFO << "Looking for Compose Apps to be installed or updated...";
-  cur_apps_to_fetch_and_update_ = getAppsToUpdate(target);
+  if (cfg_.force_update) {
+    LOG_INFO << "All Apps are forced to be updated...";
+    cur_apps_to_fetch_and_update_ = getApps(target);
+  } else {
+    LOG_INFO << "Looking for Compose Apps to be installed or updated...";
+    cur_apps_to_fetch_and_update_ = getAppsToUpdate(target);
+  }
+
   LOG_INFO << "Found " << cur_apps_to_fetch_and_update_.size() << " Apps to update";
 
   bool passed = true;

--- a/src/helpers.cc
+++ b/src/helpers.cc
@@ -256,7 +256,6 @@ LiteClient::LiteClient(Config& config_in)
   primary_ecu = ecu_serials[0];
 
   std::vector<std::string> headers;
-  bool booted_sysroot = true;
   if (config.pacman.extra.count("booted") == 1) {
     booted_sysroot = boost::lexical_cast<bool>(config.pacman.extra.at("booted"));
   }
@@ -554,6 +553,7 @@ data::ResultCode::Numeric LiteClient::install(const Uptane::Target& target) {
   if (iresult.result_code.num_code == data::ResultCode::Numeric::kNeedCompletion) {
     LOG_INFO << "Update complete. Please reboot the device to activate";
     storage->savePrimaryInstalledVersion(target, InstalledVersionUpdateMode::kPending);
+    is_reboot_required_ = booted_sysroot;
   } else if (iresult.result_code.num_code == data::ResultCode::Numeric::kOk) {
     LOG_INFO << "Update complete. No reboot needed";
     storage->savePrimaryInstalledVersion(target, InstalledVersionUpdateMode::kCurrent);

--- a/src/helpers.cc
+++ b/src/helpers.cc
@@ -12,7 +12,6 @@
 #include "package_manager/ostreemanager.h"
 #include "package_manager/packagemanagerfactory.h"
 
-#ifdef BUILD_DOCKERAPP
 #include "composeappmanager.h"
 #include "package_manager/dockerappmanager.h"
 
@@ -141,26 +140,6 @@ bool LiteClient::dockerAppsChanged() {
 
   return false;
 }
-#else /* ! BUILD_DOCKERAPP */
-void log_info_target(const std::string& prefix, const Config& config, const Uptane::Target& t) {
-  auto name = t.filename();
-  if (t.custom_version().length() > 0) {
-    name = t.custom_version();
-  }
-  LOG_INFO << prefix + name << "\tsha256:" << t.sha256Hash();
-}
-
-#define add_apps_header(headers, config) \
-  {}
-
-bool should_compare_docker_apps(const Config& config) {
-  (void)config;
-  return false;
-}
-
-void LiteClient::storeDockerParamsDigest() {}
-bool LiteClient::dockerAppsChanged() { return false; }
-#endif
 
 static std::pair<Uptane::Target, data::ResultCode::Numeric> finalizeIfNeeded(OSTree::Sysroot& sysroot,
                                                                              INvStorage& storage, Config& config) {

--- a/src/helpers.cc
+++ b/src/helpers.cc
@@ -456,14 +456,6 @@ std::pair<bool, Uptane::Target> LiteClient::downloadImage(const Uptane::Target& 
     }
   }
 
-  if (target.correlation_id().size() > 0) {
-    // send this asynchronously before `sendEvent`, so that the report timestamp
-    // would not be delayed by callbacks on events
-    for (const auto& ecu : target.ecus()) {
-      report_queue->enqueue(std_::make_unique<EcuDownloadCompletedReport>(ecu.first, target.correlation_id(), success));
-    }
-  }
-
   return {success, target};
 }
 

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -50,6 +50,9 @@ class LiteClient {
   data::ResultCode::Numeric download(const Uptane::Target& target);
   data::ResultCode::Numeric install(const Uptane::Target& target);
   void notifyInstallFinished(const Uptane::Target& t, data::ResultCode::Numeric rc);
+  std::pair<bool, std::string> isRebootRequired() const {
+    return {is_reboot_required_, config.bootloader.reboot_command};
+  }
 
   bool dockerAppsChanged();
   void storeDockerParamsDigest();
@@ -92,6 +95,8 @@ class LiteClient {
   Uptane::Exception last_exception_{"", ""};
   Json::Value last_network_info_reported_;
   Json::Value last_hw_info_reported_;
+  bool is_reboot_required_{false};
+  bool booted_sysroot{true};
 };
 
 bool should_compare_docker_apps(const Config& config);

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -63,6 +63,7 @@ class LiteClient {
   TargetStatus VerifyTarget(const Uptane::Target& target) const { return package_manager_->verifyTarget(target); }
   void reportNetworkInfo();
   void reportHwInfo();
+  bool isTargetCurrent(const Uptane::Target& target) const;
 
  private:
   FRIEND_TEST(helpers, locking);
@@ -102,8 +103,7 @@ class LiteClient {
 bool should_compare_docker_apps(const Config& config);
 void generate_correlation_id(Uptane::Target& t);
 bool target_has_tags(const Uptane::Target& t, const std::vector<std::string>& config_tags);
-bool targets_eq(const Uptane::Target& t1, const Uptane::Target& t2, bool compareDockerApps,
-                const boost::filesystem::path& app_root = "");
+bool targets_eq(const Uptane::Target& t1, const Uptane::Target& t2, bool compareDockerApps);
 bool known_local_target(LiteClient& client, const Uptane::Target& t, std::vector<Uptane::Target>& installed_versions);
 void log_info_target(const std::string& prefix, const Config& config, const Uptane::Target& t);
 

--- a/src/ostree.cc
+++ b/src/ostree.cc
@@ -7,12 +7,12 @@ Sysroot::Sysroot(const std::string& sysroot_path, bool booted) : path_{sysroot_p
 }
 
 std::string Sysroot::getCurDeploymentHash() const {
+  g_autoptr(GPtrArray) deployments = nullptr;
   OstreeDeployment* deployment = nullptr;
 
   if (booted_) {
     deployment = ostree_sysroot_get_booted_deployment(sysroot_.get());
   } else {
-    GPtrArray* deployments = nullptr;
     deployments = ostree_sysroot_get_deployments(sysroot_.get());
     if (deployments != nullptr && deployments->len > 0) {
       // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,7 +46,3 @@ target_include_directories(t_lite-helpers PRIVATE ${AKTUALIZR_DIR}/tests ${TEST_
 target_link_libraries(t_lite-helpers ${TEST_LIBS})
 
 add_dependencies(t_lite-helpers make_ostree_sysroot)
-
-if (BUILD_DOCKERAPP)
-  target_compile_definitions(t_lite-helpers PRIVATE BUILD_DOCKERAPP)
-endif(BUILD_DOCKERAPP)

--- a/tests/helpers_test.cc
+++ b/tests/helpers_test.cc
@@ -252,8 +252,6 @@ TEST(helpers, callback) {
   ASSERT_TRUE(found_result);
 }
 
-#ifdef BUILD_DOCKERAPP
-
 static LiteClient createClient(TemporaryDirectory& cfg_dir,
                                std::map<std::string, std::string> extra,
                                std::string pacman_type = ComposeAppManager::Name) {
@@ -362,7 +360,6 @@ TEST(helpers, compose_containers_initialize) {
   boost::filesystem::create_directories(apps_root / "app1");
   ASSERT_FALSE(createClient(cfg_dir, apps_cfg).dockerAppsChanged());
 }
-#endif
 
 #ifndef __NO_MAIN__
 int main(int argc, char **argv) {

--- a/tests/helpers_test.cc
+++ b/tests/helpers_test.cc
@@ -43,7 +43,7 @@ TEST(helpers, lite_client_finalize) {
   Uptane::Target target("test-finalize", target_json);
 
   storage->savePrimaryInstalledVersion(target, InstalledVersionUpdateMode::kPending);
-  ASSERT_TRUE(target.MatchHash(LiteClient(config).primary->getCurrent().hashes()[0]));
+  ASSERT_TRUE(target.MatchHash(LiteClient(config).getCurrent().hashes()[0]));
 
   config = Config();  // Create a new config since LiteClient std::move's it
   config.storage.path = cfg_dir.Path();
@@ -56,7 +56,7 @@ TEST(helpers, lite_client_finalize) {
   target_json["hashes"]["sha256"] = "abcd";
   Uptane::Target new_target("test-finalize", target_json);
   storage->savePrimaryInstalledVersion(target, InstalledVersionUpdateMode::kPending);
-  ASSERT_FALSE(new_target.MatchHash(LiteClient(config).primary->getCurrent().hashes()[0]));
+  ASSERT_FALSE(new_target.MatchHash(LiteClient(config).getCurrent().hashes()[0]));
 }
 
 TEST(helpers, target_has_tags) {


### PR DESCRIPTION
1) It turned out that there are two instances of ReportQueue running in the
context of aktualizr-lite. One instance is owned by LiteClient the
second one by SotaUptaneClient. Each instance runs a thread that fetches
events from the DB and sends them to the backend, this procedure is not
synchronized what causes the race condition with side effects like
sending the same event twice.
The key question here is why do we need both clients LiteClient and SotaUptaneClient?
Taking into account that SotaUptaneClient is tuned for the Uptane
use-case it doesn't make sense to use it as it requires hacking around in order
to eliminate the Uptane specific logic that is not required in the TUF
case as well as the logic around Secondary support. Instead we can just
reuse the libaktualizr's mechanisms in LiteClient in the way required to fulfil our
specific use-cases. Doing so helps us to fix the immediate issue with
two ReportQueue instances as well as achieve the strategic goal with
minimizing dependency on and vulnerability to changes in libaktualizr.

2) Fix sending the installation applied event
    
    The event EcuInstallationApplied should be sent to the backend if an
    ostree update is successfully fetched and installed (checkout but system
    is not booted into it yet). The issue was that a system reboot was
    invoked in the context of running LiteClient without doing
    its tearing down prior to it. As result, the event was either persisted in
    the DB and sent after reboot or sent actually before reboot if
    ReportQueue's thread managed to fetch and sent it before reboot
    or simply lost due to the race condition caused by two active ReportQueue
    instances and on-going reboot.
    This fix just simply lets LiteClient to deinitialize/teardown its context
    properly including flushing ReportQueue before triggering a system
    reboot.

3) Fix comparision of a new and installed Targets
    
    A list of apps specified in the sota.toml configuration
    as well as what is actually located on a file system should be
    taken into account during comparision of the new and currently
    installed Targets. Otherwise, aklite will keep trying to fetch and
    install Target that is actually installed or never re-install an app
    that has been removed from a file system.
    Use cases:
     - a list of apps in the config is subset of Target's list of apps
     - an app has been removed from a file system


Signed-off-by: Mike Sul <mike.sul@foundries.io>