### PR TITLE
aktualizr: switch to 2020.7+fio

### DIFF
--- a/scripts/clang-tidy-wrapper.sh
+++ b/scripts/clang-tidy-wrapper.sh
@@ -1,0 +1,1 @@
+../aktualizr/scripts/clang-tidy-wrapper.sh

--- a/src/composeappmanager.cc
+++ b/src/composeappmanager.cc
@@ -104,7 +104,7 @@ std::vector<std::pair<std::string, std::string>> ComposeAppManager::getAppsToUpd
 }
 
 bool ComposeAppManager::fetchTarget(const Uptane::Target& target, Uptane::Fetcher& fetcher, const KeyManager& keys,
-                                    FetcherProgressCb progress_cb, const api::FlowControlToken* token) {
+                                    const FetcherProgressCb& progress_cb, const api::FlowControlToken* token) {
   if (!OstreeManager::fetchTarget(target, fetcher, keys, progress_cb, token)) {
     return false;
   }

--- a/src/composeappmanager.h
+++ b/src/composeappmanager.h
@@ -27,7 +27,8 @@ class ComposeAppManager : public OstreeManager {
                         Docker::RegistryClient::DefaultHttpClientFactory);
 
   bool fetchTarget(const Uptane::Target& target, Uptane::Fetcher& fetcher, const KeyManager& keys,
-                   FetcherProgressCb progress_cb, const api::FlowControlToken* token) override;
+                   const FetcherProgressCb& progress_cb, const api::FlowControlToken* token) override;
+
   data::InstallationResult install(const Uptane::Target& target) const override;
   std::string name() const override { return Name; };
 


### PR DESCRIPTION
- switch to 2020.7+fio
- adjust aktualizr-lite to aktualizr 2020.7
  - changes in PackageManagerInterface::fetchTarget signature
  - added symlink to clang-tidy-wrapper.sh

Signed-off-by: Mike Sul <mike.sul@foundries.io>