### PR TITLE
helpers: Fix concurrency problem found with HSMs

### DIFF
--- a/src/helpers.h
+++ b/src/helpers.h
@@ -87,6 +87,7 @@ class LiteClient {
 
  private:
   boost::filesystem::path callback_program;
+  std::unique_ptr<KeyManager> key_manager_;
   std::shared_ptr<PackageManagerInterface> package_manager_;
   std::unique_ptr<ReportQueue> report_queue;
 


### PR DESCRIPTION
This code has always been wrong and I think we were seeing curl complain
about this in the past. However, it wasn't problematic until we started
testing with SoftHSM more. The HSM needs critical sections around access
to it from a process. The KeyManager by way of the P11EngineGuard does
this. However, it does on the object instance. By sharing the instance
we get the proper locking required.

Signed-off-by: Andy Doan <andy@foundries.io>
Signed-off-by: Ricardo Salveti <ricardo@foundries.io>