### PR TITLE
Check App status and update if not running

### DIFF
--- a/src/composeapp.h
+++ b/src/composeapp.h
@@ -13,18 +13,21 @@ class ComposeApp {
  public:
   static constexpr const char* const ArchiveExt{".tgz"};
   static constexpr const char* const NeedStartFile{".need_start"};
+  static constexpr const char* const ComposeFile{"docker-compose.yml"};
 
  public:
   ComposeApp(std::string name, const boost::filesystem::path& root_dir, const std::string& compose_bin,
-             const Docker::RegistryClient& registry_client);
+             const std::string& docker_bin, const Docker::RegistryClient& registry_client);
 
   bool fetch(const std::string& app_uri);
   bool up(bool no_start = false);
   bool start();
   void remove();
+  bool isRunning();
 
  private:
   bool cmd_streaming(const std::string& cmd);
+  std::pair<bool, std::string> cmd(const std::string& cmd) const;
   bool download(const std::string& app_uri);
   static bool checkAvailableStorageSpace(const boost::filesystem::path& app_root, uint64_t& out_available_size);
   void extractAppArchive(const std::string& archive_file_name, bool delete_after_extraction = true);
@@ -33,6 +36,7 @@ class ComposeApp {
   const std::string name_;
   const boost::filesystem::path root_;
   const std::string compose_;
+  const std::string docker_;
   const Docker::RegistryClient& registry_client_;
 };
 

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -65,6 +65,8 @@ class LiteClient {
   void reportNetworkInfo();
   void reportHwInfo();
   bool isTargetCurrent(const Uptane::Target& target) const;
+  bool checkAppsToUpdate(const Uptane::Target& target) const;
+  void setAppsNotChecked();
 
  private:
   FRIEND_TEST(helpers, locking);

--- a/tests/docker_fake.sh
+++ b/tests/docker_fake.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+set -eEo pipefail
+
+for x in ps; do
+  if [ "$1" = "$x" ] ; then
+    cat "$(dirname $0)/$1.in"
+    exit 0
+  fi
+done
+
+echo "Unknown command: $*"
+exit 1


### PR DESCRIPTION
Add functionality for verification of Compose App containers status.
Status is fully checked:
- in non-daemon mode, `aktualizr-lite update`;
- on the first update cycle in daemon mode;
- if a new Target is available and about to be applied in a daemon mode.

Signed-off-by: Mike Sul <mike.sul@foundries.io>