### PR TITLE
aktualizr: switch to 2020.8+fio

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,6 +23,7 @@ target_compile_definitions(${TARGET} PRIVATE BOOST_LOG_DYN_LINK)
 target_compile_definitions(${TARGET_EXE} PRIVATE BOOST_LOG_DYN_LINK)
 
 set(INCS
+  ${AKTUALIZR_DIR}/include
   ${AKTUALIZR_DIR}/src/libaktualizr
   ${AKTUALIZR_DIR}/third_party/jsoncpp/include
   ${AKTUALIZR_DIR}/third_party/googletest/googletest/include

--- a/src/main.cc
+++ b/src/main.cc
@@ -4,8 +4,8 @@
 #include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
 
-#include "config/config.h"
 #include "helpers.h"
+#include "libaktualizr/config.h"
 
 #include "utilities/aktualizr_version.h"
 
@@ -334,7 +334,7 @@ int main(int argc, char* argv[]) {
     }
 
     Config config(commandline_map);
-    config.storage.uptane_metadata_path = BasedPath(config.storage.path / "metadata");
+    config.storage.uptane_metadata_path = utils::BasedPath(config.storage.path / "metadata");
     config.telemetry.report_network = !config.tls.server.empty();
     config.telemetry.report_config = !config.tls.server.empty();
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ set_tests_properties(test_aktualizr-lite PROPERTIES DEPENDS uptane-generator)
 
 set(TEST_DEFS BOOST_LOG_DYN_LINK)
 set(TEST_INCS
+  ${AKTUALIZR_DIR}/include
   ${AKTUALIZR_DIR}/src/libaktualizr
   ${AKTUALIZR_DIR}/third_party/jsoncpp/include
   ${GLIB_INCLUDE_DIRS}


### PR DESCRIPTION
- switch to 2020.8+fio
- adjust aktualizr-lite to aktualizr 2020.8, i.e. headers restructuring
  
Signed-off-by: Mike Sul <mike.sul@foundries.io>