### PR TITLE
Add ability manually install old Targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 option(BUILD_OSTREE "Set to ON to compile with ostree support" ON)
 option(BUILD_WITH_CLANG_TIDY "Set to ON to do clang-tidy during source compilation" OFF)
 
+option(ALLOW_MANUAL_ROLLBACK "Set to ON to build with support of manual rollbacks" OFF)
+
 # If we build the sota tools we don't need aklite (???) and vice versa
 # if we build aklite we don't need the sota tools
 # TODO: consider using the aktualizr repo/project for building the sota-tools
@@ -57,3 +59,4 @@ message(STATUS "BUILD_AKLITE: ${BUILD_AKLITE}")
 message(STATUS "BUILD_OSTREE: ${BUILD_OSTREE}")
 message(STATUS "BUILD_SOTA_TOOLS: ${BUILD_SOTA_TOOLS}")
 message(STATUS "BUILD_WITH_CLANG_TIDY: ${BUILD_WITH_CLANG_TIDY}")
+message(STATUS "ALLOW_MANUAL_ROLLBACK: ${ALLOW_MANUAL_ROLLBACK}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,10 @@ if(BUILD_WITH_CLANG_TIDY)
 
 endif(BUILD_WITH_CLANG_TIDY)
 
+if(ALLOW_MANUAL_ROLLBACK)
+  add_definitions(-DALLOW_MANUAL_ROLLBACK)
+endif(ALLOW_MANUAL_ROLLBACK)
+
 target_compile_definitions(${TARGET} PRIVATE BOOST_LOG_DYN_LINK)
 target_compile_definitions(${TARGET_EXE} PRIVATE BOOST_LOG_DYN_LINK)
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -140,6 +140,12 @@ static int update_main(LiteClient& client, const bpo::variables_map& variables_m
     version = variables_map["update-name"].as<std::string>();
   }
 
+  // This is only available if -DALLOWED_OPTIONS is set in the CLI args below.
+  if (variables_map.count("clear-installed-versions") > 0) {
+    LOG_WARNING << "Clearing installed version history!!!";
+    client.storage->clearInstalledVersions();
+  }
+
   LOG_INFO << "Finding " << version << " to update to...";
   auto target_to_install = find_target(client, hwid, client.tags, version);
 
@@ -285,6 +291,9 @@ bpo::variables_map parse_options(int argc, char** argv) {
       ("ostree-server", bpo::value<std::string>(), "URL of the Ostree repository")
       ("primary-ecu-hardware-id", bpo::value<std::string>(), "hardware ID of primary ecu")
       ("update-name", bpo::value<std::string>(), "optional name of the update when running \"update\". default=latest")
+#ifdef ALLOW_MANUAL_ROLLBACK
+      ("clear-installed-versions", "DANGER - clear the history of installed updates before applying the given update. This is handy when doing test/debug and you need to rollback to an old version manually.")
+#endif
       ("interval", bpo::value<uint64_t>(), "Override uptane.polling_secs interval to poll for update when in daemon mode.")
       ("update-lockfile", bpo::value<boost::filesystem::path>(), "If provided, an flock(2) is applied to this file before performing an update in daemon mode")
       ("download-lockfile", bpo::value<boost::filesystem::path>(), "If provided, an flock(2) is applied to this file before downloading an update in daemon mode")


### PR DESCRIPTION
This is a handy feature for debug/test. Sometimes you want to "go back
in time". However, the installed-versions DB prevents this. This new
flag allows you to:
~~~
 # You are on Target 5.
 $ aktualizr-lite update --update-name 4 --clear-installed-versions
 # Update will work, you are on Target 4.
 $ aktualizr-lite daemon  # move back to target 5
~~~
Signed-off-by: Andy Doan <andy@foundries.io>