### PR TITLE
Fix update resume

### DIFF
--- a/src/composeappmanager.h
+++ b/src/composeappmanager.h
@@ -17,7 +17,7 @@ class ComposeAppManager : public OstreeManager {
     Config(const PackageConfig& pconfig);
 
     std::vector<std::string> apps;
-    boost::filesystem::path apps_root;
+    boost::filesystem::path apps_root{"/var/sota/compose-apps"};
     boost::filesystem::path compose_bin{"/usr/bin/docker-compose"};
     boost::filesystem::path docker_bin{"/usr/bin/docker"};
     bool docker_prune{true};

--- a/src/composeappmanager.h
+++ b/src/composeappmanager.h
@@ -2,6 +2,7 @@
 #define AKTUALIZR_LITE_COMPOSE_APP_MANAGER_H_
 
 #include <functional>
+#include <unordered_map>
 
 #include "composeapp.h"
 #include "docker.h"
@@ -26,6 +27,7 @@ class ComposeAppManager : public OstreeManager {
   };
 
   using ComposeAppCtor = std::function<Docker::ComposeApp(const std::string& app)>;
+  using AppsContainer = std::unordered_map<std::string, std::string>;
 
   ComposeAppManager(const PackageConfig& pconfig, const BootloaderConfig& bconfig,
                     const std::shared_ptr<INvStorage>& storage, const std::shared_ptr<HttpInterface>& http,
@@ -39,9 +41,8 @@ class ComposeAppManager : public OstreeManager {
   data::InstallationResult install(const Uptane::Target& target) const override;
   std::string name() const override { return Name; };
 
-  std::vector<std::pair<std::string, std::string>> getApps(const Uptane::Target& t) const;
-  std::vector<std::pair<std::string, std::string>> getAppsToUpdate(const Uptane::Target& t,
-                                                                   bool full_status_check) const;
+  AppsContainer getApps(const Uptane::Target& t) const;
+  AppsContainer getAppsToUpdate(const Uptane::Target& t, bool full_status_check) const;
   bool checkForAppsToUpdate(const Uptane::Target& target, boost::optional<bool> full_status_check_in);
   void setAppsNotChecked() { are_apps_checked_ = false; }
   void handleRemovedApps(const Uptane::Target& target) const;
@@ -51,7 +52,7 @@ class ComposeAppManager : public OstreeManager {
   Config cfg_;
   std::shared_ptr<OSTree::Sysroot> sysroot_;
   Docker::RegistryClient registry_client_;
-  std::vector<std::pair<std::string, std::string>> cur_apps_to_fetch_and_update_;
+  mutable AppsContainer cur_apps_to_fetch_and_update_;
   bool are_apps_checked_{false};
   ComposeAppCtor app_ctor_;
 };

--- a/tests/compose_fake.sh
+++ b/tests/compose_fake.sh
@@ -3,13 +3,17 @@ set -eEo pipefail
 
 echo $0 called with $*
 
+exit_code=0
 for x in download config pull down up start; do
   if [ "$1" = "$x" ] ; then
     echo $* > $x.log
     if [ "$2" = "FAILTEST" ] ; then
       exit 1
     fi
-    exit 0
+    if [ -f "$1.res" ] ; then
+      exit_code=$(cat "$1.res")
+    fi
+    exit ${exit_code}
   fi
 done
 


### PR DESCRIPTION
This is the fix aimed to resume/retry a fetch or an update of Compose Apps that were not successfully fetched/updated during the previous update cycle if aklite is running in a daemon mode and no new Target. Configuration change along with aklite restart and new Target resets the given logic since a list of apps can be changed at the given circumstances.