### PR TITLE
aklite: Print device UUID and name

### DIFF
--- a/src/helpers.h
+++ b/src/helpers.h
@@ -66,6 +66,7 @@ class LiteClient {
   bool isTargetCurrent(const Uptane::Target& target) const;
   bool checkAppsToUpdate(const Uptane::Target& target) const;
   void setAppsNotChecked();
+  std::string getDeviceID() const { return key_manager_->getCN(); }
 
  private:
   FRIEND_TEST(helpers, locking);

--- a/src/main.cc
+++ b/src/main.cc
@@ -16,6 +16,24 @@ static int status_main(LiteClient& client, const bpo::variables_map& unused) {
   (void)unused;
   auto target = client.getCurrent();
 
+  try {
+    LOG_INFO << "Device UUID: " << client.getDeviceID();
+  } catch (const std::exception& exc) {
+    LOG_WARNING << "Failed to get a device UUID: " << exc.what();
+  }
+
+  const auto http_res = client.http_client->get(client.config.tls.server + "/device", HttpInterface::kNoLimit);
+  if (http_res.isOk()) {
+    const Json::Value device_info = http_res.getJson();
+    if (!device_info.empty()) {
+      LOG_INFO << "Device name: " << device_info["Name"].asString();
+    } else {
+      LOG_WARNING << "Failed to get a device name from a device info: " << device_info;
+    }
+  } else {
+    LOG_WARNING << "Failed to get a device info: " << http_res.getStatusStr();
+  }
+
   if (target.MatchTarget(Uptane::Target::Unknown())) {
     LOG_INFO << "No active deployment found";
   } else {


### PR DESCRIPTION
- Output device UUID and name on `aktualizr-lite status` call.

I will add a device name printing once this PR https://github.com/foundriesio/device-gateway/pull/3/ is merged.

Signed-off-by: Mike Sul <mike.sul@foundries.io>