### PR TITLE
Add ability manually install old Targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 # OSTree is mandatory for aktualizr-lite
 option(BUILD_OSTREE "Set to ON to compile with ostree support" ON)
 
+option(ALLOW_MANUAL_ROLLBACK "Set to ON to build with support of manual rollbacks" OFF)
+
 # If we build the sota tools we don't need aklite (???) and vice versa
 # if we build aklite we don't need the sota tools
 # TODO: consider using the aktualizr repo/project for building the sota-tools
@@ -55,3 +57,4 @@ endif(BUILD_AKLITE)
 message(STATUS "BUILD_AKLITE: ${BUILD_AKLITE}")
 message(STATUS "BUILD_OSTREE: ${BUILD_OSTREE}")
 message(STATUS "BUILD_SOTA_TOOLS: ${BUILD_SOTA_TOOLS}")
+message(STATUS "ALLOW_MANUAL_ROLLBACK: ${ALLOW_MANUAL_ROLLBACK}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,10 @@ set(HEADERS helpers.h composeappmanager.h docker.h composeapp.h ostree.h)
 add_executable(${TARGET_EXE} main.cc)
 add_library(${TARGET} OBJECT ${SRC})
 
+if(ALLOW_MANUAL_ROLLBACK)
+  add_definitions(-DALLOW_MANUAL_ROLLBACK)
+endif(ALLOW_MANUAL_ROLLBACK)
+
 target_compile_definitions(${TARGET} PRIVATE BOOST_LOG_DYN_LINK)
 target_compile_definitions(${TARGET_EXE} PRIVATE BOOST_LOG_DYN_LINK)
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -159,6 +159,12 @@ static int update_main(LiteClient& client, const bpo::variables_map& variables_m
     version = variables_map["update-name"].as<std::string>();
   }
 
+  // This is only available if -DALLOW_MANUAL_ROLLBACK is set in the CLI args below.
+  if (variables_map.count("clear-installed-versions") > 0) {
+    LOG_WARNING << "Clearing installed version history!!!";
+    client.storage->clearInstalledVersions();
+  }
+
   LOG_INFO << "Finding " << version << " to update to...";
   auto target_to_install = find_target(client, hwid, client.tags, version);
 
@@ -304,6 +310,9 @@ bpo::variables_map parse_options(int argc, char** argv) {
       ("ostree-server", bpo::value<std::string>(), "URL of the Ostree repository")
       ("primary-ecu-hardware-id", bpo::value<std::string>(), "hardware ID of primary ecu")
       ("update-name", bpo::value<std::string>(), "optional name of the update when running \"update\". default=latest")
+#ifdef ALLOW_MANUAL_ROLLBACK
+      ("clear-installed-versions", "DANGER - clear the history of installed updates before applying the given update. This is handy when doing test/debug and you need to rollback to an old version manually.")
+#endif
       ("interval", bpo::value<uint64_t>(), "Override uptane.polling_secs interval to poll for update when in daemon mode.")
       ("update-lockfile", bpo::value<boost::filesystem::path>(), "If provided, an flock(2) is applied to this file before performing an update in daemon mode")
       ("download-lockfile", bpo::value<boost::filesystem::path>(), "If provided, an flock(2) is applied to this file before downloading an update in daemon mode")


### PR DESCRIPTION
This is a handy feature for debug/test. Sometimes you want to "go back
in time". However, the installed-versions DB prevents this. This new
flag allows you to:

 # You are on Target 5.
 $ aktualizr-lite update --update-name 4 --clear-installed-versions
 # Update will work, you are on Target 4.
 $ aktualizr-lite daemon  # will update to Target 5

Signed-off-by: Andy Doan <andy@foundries.io>