### PR TITLE
Wait for the 'interval' if metadata update fails

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -208,8 +208,9 @@ static int daemon_main(LiteClient& client, const bpo::variables_map& variables_m
     LOG_INFO << "Active Target: " << current.filename() << ", sha256: " << current.sha256Hash();
     LOG_INFO << "Checking for a new Target...";
     if (!client.checkForUpdates()) {
-      LOG_WARNING << "Unable to update latest metadata";
-      std::this_thread::sleep_for(std::chrono::seconds(10));
+      LOG_WARNING << "Unable to update latest metadata, going to sleep for " << interval
+                  << " seconds before starting a new update cycle";
+      std::this_thread::sleep_for(std::chrono::seconds(interval));
       continue;  // There's no point trying to look for an update
     }
 


### PR DESCRIPTION
If the check for new TUF metadata fails then wait for the TUF cycle
interval time which is specified in sota.toml. In other words, don't
start the next update cycle straight away if TUF metadata update fails,
wait for a configurable amount of time before doing it.

Signed-off-by: Mike Sul <mike.sul@foundries.io>