### PR TITLE
Check for update improvements

### DIFF
--- a/src/composeappmanager.cc
+++ b/src/composeappmanager.cc
@@ -82,6 +82,7 @@ ComposeAppManager::ComposeAppManager(const PackageConfig& pconfig, const Bootloa
   }
 }
 
+// Returns an intersection of apps specified in Target and the configuration
 ComposeAppManager::AppsContainer ComposeAppManager::getApps(const Uptane::Target& t) const {
   AppsContainer apps;
 

--- a/src/composeappmanager.cc
+++ b/src/composeappmanager.cc
@@ -311,6 +311,8 @@ void ComposeAppManager::handleRemovedApps(const Uptane::Target& target) const {
   }
   std::vector<std::string> target_apps = target.custom_data()["docker_compose_apps"].getMemberNames();
 
+  // an intersection of apps specified in Target and the configuration
+  // i.e. the apps that are supposed to be installed and running
   const auto& current_apps = getApps(target);
 
   for (auto& entry : boost::make_iterator_range(boost::filesystem::directory_iterator(cfg_.apps_root), {})) {

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -63,8 +63,8 @@ class LiteClient {
   void reportAktualizrConfiguration();
   void reportNetworkInfo();
   void reportHwInfo();
-  bool isTargetCurrent(const Uptane::Target& target) const;
-  bool checkAppsToUpdate(const Uptane::Target& target) const;
+  bool isTargetActive(const Uptane::Target& target) const;
+  bool appsInSync(bool full_check) const;
   void setAppsNotChecked();
   std::string getDeviceID() const;
 

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -58,7 +58,7 @@ class LiteClient {
   Uptane::Target getCurrent() const { return package_manager_->getCurrent(); }
   bool updateImageMeta();
   bool checkImageMetaOffline();
-  Uptane::LazyTargetsList allTargets() const { return Uptane::LazyTargetsList(image_repo_, storage, uptane_fetcher_); }
+  const std::vector<Uptane::Target>& allTargets() const { return image_repo_.getTargets()->targets; }
   TargetStatus VerifyTarget(const Uptane::Target& target) const { return package_manager_->verifyTarget(target); }
   void reportAktualizrConfiguration();
   void reportNetworkInfo();

--- a/src/main.cc
+++ b/src/main.cc
@@ -98,6 +98,8 @@ static std::unique_ptr<Uptane::Target> find_target(LiteClient& client, Uptane::H
     }
   }
 
+  // if a new version of targets.json hasn't been downloaded why do we do the following search
+  // for the latest ??? It's really needed just for the forced update to a specific version
   bool find_latest = (version == "latest");
   std::unique_ptr<Uptane::Target> latest = nullptr;
   for (const auto& t : client.allTargets()) {


### PR DESCRIPTION
1) FIO OTA Lite solution does not need/support delegations, so no need in getting a target list in the way that the delegations require, specifically, using the complex iterator logic over a simple vector of target objects/json. Just simply fetch that target list as a vector.

2) At first, check if there is a new Target, and if so then proceed with new
    Target update. If there is no new Target then check if the apps list changed in the config (first run) and if all current Target' apps are installed and running. There is no reason to perform current Target' apps check and sync if there is a new Target since the new Target can have a different list of apps.


Signed-off-by: Mike Sul <mike.sul@foundries.io>