### PR TITLE
Refact/drop full status check flag

### DIFF
--- a/src/composeappmanager.h
+++ b/src/composeappmanager.h
@@ -25,7 +25,6 @@ class ComposeAppManager : public OstreeManager {
     boost::filesystem::path docker_bin{"/usr/bin/docker"};
     bool docker_prune{true};
     bool force_update{false};
-    bool full_status_check{false};
     boost::filesystem::path apps_tree{"/var/sota/compose-apps-tree"};
     bool create_apps_tree{false};
     boost::filesystem::path images_data_root{"/var/lib/docker"};
@@ -50,8 +49,8 @@ class ComposeAppManager : public OstreeManager {
   // Returns an intersection of Target's Apps and Apps listed in the config (sota.toml:compose_apps)
   // If Apps are not specified in the config then all Target's Apps are returned
   AppsContainer getApps(const Uptane::Target& t) const;
-  AppsContainer getAppsToUpdate(const Uptane::Target& t, bool full_status_check) const;
-  bool checkForAppsToUpdate(const Uptane::Target& target, boost::optional<bool> full_status_check_in);
+  AppsContainer getAppsToUpdate(const Uptane::Target& t) const;
+  bool checkForAppsToUpdate(const Uptane::Target& target);
   void setAppsNotChecked() { are_apps_checked_ = false; }
   void handleRemovedApps(const Uptane::Target& target) const;
   std::string getCurrentHash() const override;

--- a/src/liteclient.cc
+++ b/src/liteclient.cc
@@ -425,7 +425,7 @@ bool LiteClient::isTargetActive(const Uptane::Target& target) const {
   return target.filename() == getCurrent().filename();
 }
 
-bool LiteClient::appsInSync(bool full_check) const {
+bool LiteClient::appsInSync() const {
   if (package_manager_->name() == ComposeAppManager::Name) {
     auto* compose_pacman = dynamic_cast<ComposeAppManager*>(package_manager_.get());
     if (compose_pacman == nullptr) {
@@ -433,8 +433,8 @@ bool LiteClient::appsInSync(bool full_check) const {
       return false;
     }
     LOG_INFO << "Checking Active Target status...";
-    auto no_any_app_to_update = compose_pacman->checkForAppsToUpdate(getCurrent(), full_check);
-    if (full_check && no_any_app_to_update) {
+    auto no_any_app_to_update = compose_pacman->checkForAppsToUpdate(getCurrent());
+    if (no_any_app_to_update) {
       compose_pacman->handleRemovedApps(getCurrent());
     }
 

--- a/src/liteclient.h
+++ b/src/liteclient.h
@@ -53,7 +53,7 @@ class LiteClient {
   void reportNetworkInfo();
   void reportHwInfo();
   bool isTargetActive(const Uptane::Target& target) const;
-  bool appsInSync(bool full_check) const;
+  bool appsInSync() const;
   void setAppsNotChecked();
   std::string getDeviceID() const;
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -208,7 +208,7 @@ static int daemon_main(LiteClient& client, const bpo::variables_map& variables_m
     LOG_ERROR << "reboot command: " << client.config.bootloader.reboot_command << " is not executable";
     return EXIT_FAILURE;
   }
-  bool first_loop = true;
+
   Uptane::HardwareIdentifier hwid(client.config.provision.primary_ecu_hardware_id);
   if (variables_map.count("update-lockfile") > 0) {
     client.update_lockfile = variables_map["update-lockfile"].as<boost::filesystem::path>();
@@ -271,7 +271,7 @@ static int daemon_main(LiteClient& client, const bpo::variables_map& variables_m
         }
 
       } else {
-        if (!client.appsInSync(first_loop)) {
+        if (!client.appsInSync()) {
           do_app_sync(client);
         }
         LOG_INFO << "Device is up-to-date";
@@ -282,9 +282,6 @@ static int daemon_main(LiteClient& client, const bpo::variables_map& variables_m
     }
 
     client.setAppsNotChecked();
-    if (first_loop) {
-      first_loop = false;
-    }
     std::this_thread::sleep_for(std::chrono::seconds(interval));
 
   }  // while true


### PR DESCRIPTION
Get rid of the flag indicating whether to perform a 'full' status check or not. It turned out to be too complicated and useless as well as the implementation was awkward. This commit drops the given flag and makes aklite perform the full status check unconditionally. The next step is to come up with a lighter/optimized way to perform a status check of running docker containers.
