### PR TITLE
aklite: allow updating to previously successfully installed Target

### DIFF
--- a/src/helpers.h
+++ b/src/helpers.h
@@ -15,6 +15,8 @@ struct Version {
 void generate_correlation_id(Uptane::Target& t);
 bool target_has_tags(const Uptane::Target& t, const std::vector<std::string>& config_tags);
 bool known_local_target(LiteClient& client, const Uptane::Target& t, std::vector<Uptane::Target>& installed_versions);
+void get_known_but_not_installed_versions(LiteClient& client,
+                                          std::vector<Uptane::Target>& known_but_not_installed_versions);
 void log_info_target(const std::string& prefix, const Config& config, const Uptane::Target& t);
 
 #endif  // AKTUALIZR_LITE_HELPERS_


### PR DESCRIPTION
Currently aklite doesn't allow to install Target that it tried to install previously. Even if Target installation was successful it treats it as a "bad" Target that caused rollback and doesn't allow installing it.
The given change checks Target to be installed against Targets that aklite tried to install but never installed them except pending one, which can happen only in the case of rollback.

Signed-off-by: Mike Sul <mike.sul@foundries.io>