### PR TITLE
Refact/reuse libaktualizr finalization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ if(BUILD_AKLITE)
   add_dependencies(aklite aktualizr-lite)
 
   add_custom_target(aklite-tests)
-  add_dependencies(aklite-tests aklite t_lite-helpers uptane-generator t_compose-apps t_ostree)
+  add_dependencies(aklite-tests aklite t_lite-helpers uptane-generator t_compose-apps t_ostree t_liteclient)
 
   set(CMAKE_MODULE_PATH "${AKTUALIZR_DIR}/cmake-modules;${CMAKE_MODULE_PATH}")
 

--- a/src/composeappmanager.cc
+++ b/src/composeappmanager.cc
@@ -276,6 +276,15 @@ data::InstallationResult ComposeAppManager::install(const Uptane::Target& target
   return res;
 }
 
+data::InstallationResult ComposeAppManager::finalizeInstall(const Uptane::Target& target) {
+  auto ir = OstreeManager::finalizeInstall(target);
+  if (ir.result_code != data::ResultCode::Numeric::kAlreadyProcessed ||
+      ir.result_code != data::ResultCode::Numeric::kNeedCompletion) {
+    ir.description += "\n# Apps running:\n" + containerDetails();
+  }
+  return ir;
+}
+
 // Handle the case like:
 //  1) sota.toml is configured with 2 compose apps: "app1, app2"
 //  2) update is applied, so we are now running both app1 and app2

--- a/src/composeappmanager.h
+++ b/src/composeappmanager.h
@@ -40,11 +40,12 @@ class ComposeAppManager : public OstreeManager {
                     Docker::RegistryClient::HttpClientFactory registry_http_client_factory =
                         Docker::RegistryClient::DefaultHttpClientFactory);
 
+  std::string name() const override { return Name; };
   bool fetchTarget(const Uptane::Target& target, Uptane::Fetcher& fetcher, const KeyManager& keys,
                    const FetcherProgressCb& progress_cb, const api::FlowControlToken* token) override;
 
   data::InstallationResult install(const Uptane::Target& target) const override;
-  std::string name() const override { return Name; };
+  data::InstallationResult finalizeInstall(const Uptane::Target& target) override;
 
   // Returns an intersection of Target's Apps and Apps listed in the config (sota.toml:compose_apps)
   // If Apps are not specified in the config then all Target's Apps are returned
@@ -53,6 +54,8 @@ class ComposeAppManager : public OstreeManager {
   bool checkForAppsToUpdate(const Uptane::Target& target);
   void setAppsNotChecked() { are_apps_checked_ = false; }
   void handleRemovedApps(const Uptane::Target& target) const;
+
+ private:
   std::string getCurrentHash() const override;
   // Return a description of what `docker ps` sees
   std::string containerDetails() const;

--- a/src/liteclient.cc
+++ b/src/liteclient.cc
@@ -67,8 +67,6 @@ LiteClient::LiteClient(Config& config_in)
   headers.push_back(header);
   add_apps_header(headers, config.pacman);
 
-  headers.emplace_back("x-ats-target: unknown");
-
   if (!config.telemetry.report_network) {
     // Provide the random primary ECU serial so our backend will have some
     // idea of the number of unique devices using the system
@@ -81,21 +79,10 @@ LiteClient::LiteClient(Config& config_in)
   uptane_fetcher_ = std::make_shared<Uptane::Fetcher>(config, http_client);
   report_queue = std_::make_unique<ReportQueue>(config, http_client, storage);
 
-  // finalizeIfNeeded it looks like copy-paste of SotaUptaneClient::finalizeAfterReboot
-  // can we use just SotaUptaneClient::finalizeAfterReboot or even maybe SotaUptaneClient::initialize ???
-  // in this case we could do our specific finalization, including starting apps, in ComposeAppManager::finalizeInstall
-  Uptane::Target current_target{Uptane::Target::Unknown()};
-  Uptane::Target target_been_applied{Uptane::Target::Unknown()};
-  data::InstallationResult target_installation_result;
-  std::tie(current_target, target_been_applied, target_installation_result) =
-      finalizeIfNeeded(*ostree_sysroot, *storage, config);
-  update_request_headers(http_client, current_target, config.pacman);
-
   key_manager_ = std_::make_unique<KeyManager>(storage, config.keymanagerConfig());
   key_manager_->loadKeys();
   key_manager_->copyCertsToCurl(*http_client);
 
-  // TODO: consider improving this factory method
   if (config.pacman.type == ComposeAppManager::Name) {
     package_manager_ =
         std::make_shared<ComposeAppManager>(config.pacman, config.bootloader, storage, http_client, ostree_sysroot);
@@ -105,9 +92,33 @@ LiteClient::LiteClient(Config& config_in)
     throw std::runtime_error("Unsupported package manager type: " + config.pacman.type);
   }
 
+  data::InstallationResult update_finalization_result{data::ResultCode::Numeric::kNeedCompletion, ""};
+
+  // check if there is a pending update/installation/Target
+  boost::optional<Uptane::Target> pending_target;
+  storage->loadInstalledVersions("", nullptr, &pending_target);
+
+  // finalize a pending update/installation if any
+  if (!!pending_target) {
+    // if there is a pending update/installation/Target then try to apply/finalize it
+    update_finalization_result = package_manager_->finalizeInstall(*pending_target);
+    if (update_finalization_result.isSuccess()) {
+      LOG_INFO << "Marking target install complete for: " << *pending_target;
+      storage->saveInstalledVersion("", *pending_target, InstalledVersionUpdateMode::kCurrent);
+    } else if (data::ResultCode::Numeric::kInstallFailed == update_finalization_result.result_code.num_code) {
+      // rollback has happenned, unset is_pending and was_installed flags of the given Target record in DB
+      storage->saveInstalledVersion("", *pending_target, InstalledVersionUpdateMode::kNone);
+    }
+  }
+
+  const auto current_target = getCurrent();
+  update_request_headers(http_client, current_target, config.pacman);
   writeCurrentTarget(current_target);
-  if (target_installation_result.result_code != data::ResultCode::Numeric::kAlreadyProcessed) {
-    notifyInstallFinished(target_been_applied, target_installation_result);
+
+  if (data::ResultCode::Numeric::kNeedCompletion != update_finalization_result.result_code.num_code) {
+    // if finalization has happened, either succefully (kOk) or not (kInstallFailed)
+    // we send the installation finished report event.
+    notifyInstallFinished(*pending_target, update_finalization_result);
   }
 }
 
@@ -194,15 +205,6 @@ void LiteClient::notifyInstallFinished(const Uptane::Target& t, data::Installati
     callback("install-post", t, "NEEDS_COMPLETION");
     notify(t, std_::make_unique<DetailedAppliedReport>(primary_ecu.first, t.correlation_id(), ir.description));
     return;
-  }
-
-  if (package_manager_->name() == ComposeAppManager::Name) {
-    auto* compose_pacman = dynamic_cast<ComposeAppManager*>(package_manager_.get());
-    if (compose_pacman == nullptr) {
-      LOG_ERROR << "Cannot downcast the package manager to a specific type";
-    } else {
-      ir.description += "\n# Apps running:\n" + compose_pacman->containerDetails();
-    }
   }
 
   if (ir.result_code == data::ResultCode::Numeric::kOk) {
@@ -466,67 +468,6 @@ void LiteClient::add_apps_header(std::vector<std::string>& headers, PackageConfi
       headers.emplace_back("x-ats-dockerapps: ");
     }
   }
-}
-
-std::tuple<Uptane::Target, Uptane::Target, data::InstallationResult> LiteClient::finalizeIfNeeded(
-    OSTree::Sysroot& sysroot, INvStorage& storage, Config& config) {
-  data::InstallationResult ir{data::ResultCode::Numeric::kUnknown, ""};
-  boost::optional<Uptane::Target> pending_version;
-  boost::optional<Uptane::Target> current_version;
-  storage.loadInstalledVersions("", &current_version, &pending_version);
-
-  std::string current_hash = sysroot.getCurDeploymentHash();
-  if (current_hash.empty()) {
-    throw std::runtime_error("Could not get " + sysroot.type() + " deployment in " + sysroot.path());
-  }
-
-  Bootloader bootloader(config.bootloader, storage);
-
-  if (!!pending_version) {
-    const Uptane::Target& target = *pending_version;
-    if (current_hash == target.sha256Hash()) {
-      LOG_INFO << "Marking target install complete for: " << target;
-      storage.saveInstalledVersion("", target, InstalledVersionUpdateMode::kCurrent);
-      ir.result_code = data::ResultCode::Numeric::kOk;
-      if (bootloader.rebootDetected()) {
-        bootloader.rebootFlagClear();
-      }
-      // Installation was successful, so both currently installed Target and Target that has been applied are the same
-      return std::tie(target, target, ir);
-    } else {
-      if (bootloader.rebootDetected()) {
-        std::string err = "Expected to boot on " + target.sha256Hash() + " buf found " + current_hash +
-                          ", system might have experienced a rollback";
-        LOG_ERROR << err;
-        storage.saveInstalledVersion("", target, InstalledVersionUpdateMode::kNone);
-        bootloader.rebootFlagClear();
-        ir.result_code = data::ResultCode::Numeric::kInstallFailed;
-        ir.description = err;
-      } else {
-        // Update still pending as no reboot was detected
-        ir.result_code = data::ResultCode::Numeric::kNeedCompletion;
-      }
-      // Installation was not successful
-      return std::tie(*current_version, target, ir);
-    }
-  }
-
-  std::vector<Uptane::Target> installed_versions;
-  storage.loadPrimaryInstallationLog(&installed_versions, false);
-
-  // Version should be in installed versions. Its possible that multiple
-  // targets could have the same sha256Hash. In this case the safest assumption
-  // is that the most recent (the reverse of the vector) target is what we
-  // should return.
-  std::vector<Uptane::Target>::reverse_iterator it;
-  for (it = installed_versions.rbegin(); it != installed_versions.rend(); it++) {
-    if (it->sha256Hash() == current_hash) {
-      ir.result_code = data::ResultCode::Numeric::kAlreadyProcessed;
-      return std::tie(*it, *it, ir);
-    }
-  }
-  Uptane::Target unknown_target{Uptane::Target::Unknown()};
-  return std::tie(unknown_target, unknown_target, ir);
 }
 
 void LiteClient::update_request_headers(std::shared_ptr<HttpClient>& http_client, const Uptane::Target& target,

--- a/src/liteclient.h
+++ b/src/liteclient.h
@@ -77,10 +77,6 @@ class LiteClient {
   std::pair<bool, Uptane::Target> downloadImage(const Uptane::Target& target,
                                                 const api::FlowControlToken* token = nullptr);
   static void add_apps_header(std::vector<std::string>& headers, PackageConfig& config);
-
-  static std::tuple<Uptane::Target, Uptane::Target, data::InstallationResult> finalizeIfNeeded(OSTree::Sysroot& sysroot,
-                                                                                               INvStorage& storage,
-                                                                                               Config& config);
   static void update_request_headers(std::shared_ptr<HttpClient>& http_client, const Uptane::Target& target,
                                      PackageConfig& config);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ add_test(test_aktualizr-lite
 )
 
 set_tests_properties(test_aktualizr-lite PROPERTIES DEPENDS uptane-generator)
+set_tests_properties(test_aktualizr-lite PROPERTIES LABELS "aklite:aktualizr-lite")
 
 set(TEST_DEFS BOOST_LOG_DYN_LINK)
 set(TEST_INCS
@@ -36,6 +37,7 @@ add_aktualizr_test(NAME compose-apps
 target_compile_definitions(t_compose-apps PRIVATE ${TEST_DEFS})
 target_include_directories(t_compose-apps PRIVATE ${AKTUALIZR_DIR}/tests ${TEST_INCS})
 target_link_libraries(t_compose-apps ${TEST_LIBS})
+set_tests_properties(test_compose-apps PROPERTIES LABELS "aklite:compose-apps")
 
 add_aktualizr_test(NAME lite-helpers
   SOURCES $<TARGET_OBJECTS:${MAIN_TARGET_LIB}> helpers_test.cc
@@ -45,8 +47,8 @@ add_aktualizr_test(NAME lite-helpers
 target_compile_definitions(t_lite-helpers PRIVATE ${TEST_DEFS})
 target_include_directories(t_lite-helpers PRIVATE ${AKTUALIZR_DIR}/tests ${TEST_INCS})
 target_link_libraries(t_lite-helpers ${TEST_LIBS})
-
 add_dependencies(t_lite-helpers make_ostree_sysroot)
+set_tests_properties(test_lite-helpers PROPERTIES LABELS "aklite:helpers")
 
 add_aktualizr_test(NAME ostree
   SOURCES $<TARGET_OBJECTS:${MAIN_TARGET_LIB}> test_ostree.cc
@@ -56,3 +58,17 @@ add_aktualizr_test(NAME ostree
 target_compile_definitions(t_ostree PRIVATE ${TEST_DEFS})
 target_include_directories(t_ostree PRIVATE ${TEST_INCS})
 target_link_libraries(t_ostree ${TEST_LIBS})
+set_tests_properties(test_ostree PROPERTIES LABELS "aklite:ostree")
+
+add_aktualizr_test(NAME liteclient
+  SOURCES $<TARGET_OBJECTS:${MAIN_TARGET_LIB}> test_liteclient.cc
+  PROJECT_WORKING_DIRECTORY ARGS ${AKTUALIZR_DIR}/tests/fake_http_server/fake_test_server.py
+	${AKTUALIZR_DIR}/tests/sota_tools/treehub_server.py
+	${PROJECT_SOURCE_DIR}/tests/make_sys_rootfs.sh
+)
+
+target_compile_definitions(t_liteclient PRIVATE ${TEST_DEFS})
+target_include_directories(t_liteclient PRIVATE ${TEST_INCS} ${AKTUALIZR_DIR}/tests/ ${AKTUALIZR_DIR}/src/)
+target_link_libraries(t_liteclient ${TEST_LIBS} uptane_generator_lib testutilities)
+add_dependencies(t_liteclient make_ostree_sysroot)
+set_tests_properties(test_liteclient PROPERTIES LABELS "aklite:liteclient")

--- a/tests/helpers_test.cc
+++ b/tests/helpers_test.cc
@@ -100,6 +100,8 @@ TEST(helpers, locking) {
   config.storage.path = cfg_dir.Path();
   config.pacman.sysroot = test_sysroot;
   config.pacman.extra["booted"] = "0";
+  config.pacman.os = "dummy-os";
+  config.pacman.type = ComposeAppManager::Name;
 
   LiteClient client(config);
   client.update_lockfile = cfg_dir / "update_lock";
@@ -130,6 +132,8 @@ TEST(helpers, callback) {
   bad_config.bootloader.reboot_sentinel_dir = cfg_dir.Path();
   bad_config.pacman.sysroot = test_sysroot;
   bad_config.pacman.extra["booted"] = "0";
+  bad_config.pacman.os = "dummy-os";
+  bad_config.pacman.type = ComposeAppManager::Name;
   bad_config.storage.path = cfg_dir.Path();
   bad_config.pacman.extra["callback_program"] = "This does not exist";
 
@@ -142,6 +146,8 @@ TEST(helpers, callback) {
   config.bootloader.reboot_sentinel_dir = cfg_dir.Path();
   config.pacman.sysroot = test_sysroot;
   config.pacman.extra["booted"] = "0";
+  config.pacman.os = "dummy-os";
+  config.pacman.type = ComposeAppManager::Name;
   config.storage.path = cfg_dir.Path();
 
   std::string cb = (cfg_dir / "callback.sh").native();

--- a/tests/make_sys_rootfs.sh
+++ b/tests/make_sys_rootfs.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "$#" -ne 4 ]; then
+  echo "Usage: ./make_sys_rootfs.sh <rootfs-dir> <branch> <hardware-id> <os-name>"
+  exit 1
+fi
+
+TARGETDIR=$1
+BRANCHNAME=$2
+HARDWARE=$3
+OS=$4
+
+#usr
+mkdir -p "$TARGETDIR/usr/share/sota"
+echo "$BRANCHNAME" > "$TARGETDIR/usr/share/sota/branchname"
+
+#var
+mkdir -p "$TARGETDIR/var/sota"
+
+#etc
+mkdir -p "$TARGETDIR/usr/etc"
+echo "$HARDWARE" > "$TARGETDIR/usr/etc/hostname"
+cat << EOF > "$TARGETDIR/usr/etc/os-release"
+ID="${OS}"
+NAME="Generated OSTree-enabled OS"
+VERSION="3.14159"
+EOF
+
+#boot
+mkdir -p "$TARGETDIR/boot/loader.0"
+mkdir -p "$TARGETDIR/boot/loader.1"
+
+ln -sf boot/loader.0 "$TARGETDIR/boot/loader"
+echo "I'm a kernel" > "$TARGETDIR/boot/vmlinuz"
+echo "I'm an initrd" > "$TARGETDIR/boot/initramfs"
+
+checksum=$(sha256sum "$TARGETDIR/boot/vmlinuz" | cut -f 1 -d " ")
+mv "$TARGETDIR/boot/vmlinuz" "$TARGETDIR/boot/vmlinuz-$checksum"
+mv "$TARGETDIR/boot/initramfs" "$TARGETDIR/boot/initramfs-$checksum"

--- a/tests/test_liteclient.cc
+++ b/tests/test_liteclient.cc
@@ -1,0 +1,387 @@
+#include <gtest/gtest.h>
+
+#include <boost/filesystem.hpp>
+#include <boost/process.hpp>
+#include <boost/process/env.hpp>
+
+#include "libaktualizr/types.h"
+#include "logging/logging.h"
+#include "test_utils.h"
+#include "uptane_generator/image_repo.h"
+#include "utilities/utils.h"
+
+#include "liteclient.h"
+#include "composeappmanager.h"
+
+#include <string>
+#include <iostream>
+
+#include "ostree/repo.h"
+#include "helpers.h"
+
+static std::string run_cmd(const std::string &executable_to_run,
+                           const std::vector<std::string> &executable_args,
+                           const std::string& cmd_desc) {
+  auto res = Process::spawn(executable_to_run, executable_args);
+  if (std::get<0>(res) != 0) {
+    throw std::runtime_error("Failed to " + cmd_desc + ": " + std::get<2>(res));
+  }
+
+  auto std_out = std::get<1>(res);
+  boost::trim_right_if(std_out, boost::is_any_of(" \t\r\n"));
+  return std_out;
+}
+
+class SysRootFS {
+ public:
+  static std::string GeneratorPath;
+ public:
+  SysRootFS(std::string path_in, std::string branch_in, std::string hw_id_in, std::string os_in):
+      path{std::move(path_in)}, branch{std::move(branch_in)}, hw_id{std::move(hw_id_in)}, os{std::move(os_in)} {
+    run_cmd(GeneratorPath, { path, branch, hw_id, os }, "generate a system rootfs template");
+  }
+
+  const std::string path;
+  const std::string branch;
+  const std::string hw_id;
+  const std::string os;
+};
+
+std::string SysRootFS::GeneratorPath;
+
+class OSTreeMock {
+ public:
+  OSTreeMock(std::string repo_path, bool create = false, std::string mode = "archive"): path_{std::move(repo_path)} {
+
+    if (create) {
+      run_cmd("ostree", {"init", "--repo", path_, "--mode=" + mode}, "init an ostree repo at " + path_);
+      LOG_INFO << "OSTree repo was created at " + path_;
+    }
+  }
+
+  std::string commit(const std::string& src_dir, const std::string& branch) {
+    return run_cmd("ostree", { "commit", "--repo", path_, "--branch", branch, "--tree=dir=" + src_dir },
+                   "commit from " + src_dir + " to " + path_);
+  }
+
+  void set_mode(const std::string& mode) {
+    run_cmd("ostree", {"config", "--repo",  path_, "set", "core.mode", mode}, "set mode for repo " + path_);
+  }
+
+ private:
+  const std::string path_;
+};
+
+class SysOSTreeMock {
+ public:
+  SysOSTreeMock(std::string sysroot_path,
+                std::string os_name):
+                  path_{sysroot_path},
+                  os_{os_name},
+                  repo_{path_ + "/ostree/repo"} {
+
+    boost::filesystem::create_directories(sysroot_path);
+
+    run_cmd("ostree", {"admin", "init-fs", path_}, "init a system rootfs at " + path_);
+    run_cmd("ostree", {"admin", "--sysroot=" + sysroot_path, "os-init", os_name},
+            "init OS in a system rootfs at " + path_);
+
+    repo_.set_mode("bare-user-only");
+    LOG_INFO << "System ostree-based repo has been initialized at " << path_;
+  }
+
+  const std::string& path() const { return path_; }
+  OSTreeMock& repo() { return repo_; }
+
+
+  void deploy(const std::string& commit_hash) {
+    run_cmd("ostree", {"admin", "--sysroot=" + path_, "deploy", "--os=" + os_, commit_hash}, "deploy " + commit_hash);
+  }
+
+ private:
+  const std::string path_;
+  const std::string os_;
+  OSTreeMock repo_;
+};
+
+
+class TreehubMock {
+ public:
+  static std::string ServerPath;
+ public:
+  TreehubMock(const std::string& repo_path):
+    repo_{repo_path, true},
+    port_{TestUtils::getFreePort()},
+    process_{ServerPath, "-p", port_, "-d", repo_path} {
+    LOG_INFO << "Treehub is running on port " << port_;
+  }
+  ~TreehubMock() {
+    process_.terminate();
+    process_.wait_for(std::chrono::seconds(10));
+  }
+
+  OSTreeMock& repo() { return repo_; }
+  std::string url() { return "http://localhost:" + port_; }
+
+ private:
+  OSTreeMock repo_;
+  std::string port_;
+  boost::process::child process_;
+};
+
+std::string TreehubMock::ServerPath;
+
+class TufRepoMock {
+ public:
+  static std::string ServerPath;
+ public:
+  TufRepoMock(const boost::filesystem::path& root_dir, std::string expires = "",
+              std::string correlation_id = "corellatio-id")
+      : repo_{root_dir, expires, correlation_id},
+        port_{TestUtils::getFreePort()},
+        url_{"http://localhost:" + port_}, process_{ServerPath, port_, "-m", root_dir} {
+    repo_.generateRepo(KeyType::kED25519);
+    TestUtils::waitForServer(url_ + "/");
+  }
+  ~TufRepoMock() {
+    process_.terminate();
+    process_.wait_for(std::chrono::seconds(10));
+  }
+
+ public:
+  const std::string& url() { return url_; }
+
+  Uptane::Target add_target(const std::string& target_name, const std::string& hash, const std::string& hardware_id) {
+    Delegation empty_delegetion{};
+    Hash hash_obj{Hash::Type::kSha256, hash};
+    Json::Value custom_json;
+    custom_json["targetFormat"] = "OSTREE";
+
+    repo_.addCustomImage(target_name, hash_obj, 0, hardware_id, "", empty_delegetion, custom_json);
+
+    Json::Value target;
+    target["length"] = 0;
+    target["hashes"]["sha256"] = hash;
+    target["custom"] = custom_json;
+
+    return Uptane::Target(target_name, target);
+  }
+
+ private:
+  ImageRepo repo_;
+  std::string port_;
+  std::string url_;
+  boost::process::child process_;
+};
+
+std::string TufRepoMock::ServerPath;
+
+
+class LiteClientTest : public ::testing::Test {
+ public:
+  static std::string SysRootSrc;
+
+ protected:
+  LiteClientTest(): sysrootfs_{(test_dir_.Path() / "sysroot-fs").string(), branch, hw_id, os},
+                    sysrepo_{(test_dir_.Path() / "sysrepo").string(), os},
+                    tuf_repo_{test_dir_.Path() / "repo"},
+                    treehub_{(test_dir_.Path() / "treehub").string()},
+                    initial_target_{Uptane::Target::Unknown()} {
+
+    auto initial_sysroot_commit_hash = sysrepo_.repo().commit(sysrootfs_.path, sysrootfs_.branch);
+    sysrepo_.deploy(initial_sysroot_commit_hash);
+
+    Json::Value target_json;
+    target_json["hashes"]["sha256"] = initial_sysroot_commit_hash;
+    target_json["custom"]["targetFormat"] = "OSTREE";
+    target_json["length"] = 0;
+    initial_target_ = Uptane::Target{hw_id + "-" + os + "-1", target_json};
+  }
+
+  std::shared_ptr<LiteClient> create_liteclient(bool initial_version = true) {
+    Config conf;
+    conf.uptane.repo_server = tufRepo().url() + "/repo";
+    conf.provision.primary_ecu_hardware_id = hw_id;
+    conf.storage.path = test_dir_.Path();
+
+    conf.pacman.type = ComposeAppManager::Name;
+    conf.pacman.sysroot = sysrepo_.path();
+    conf.pacman.os = os;
+    conf.pacman.extra["booted"] = "0";
+    conf.pacman.ostree_server = treehub_.url();
+
+    conf.bootloader.reboot_command = "/bin/true";
+    conf.bootloader.reboot_sentinel_dir = conf.storage.path;
+    conf.import.base_path = test_dir_ / "import";
+
+    if (initial_version) {
+      Json::Value ins_ver;
+      ins_ver[initial_target_.sha256Hash()] = initial_target_.filename();
+      std::string installed_version = Utils::jsonToCanonicalStr(ins_ver);
+      Utils::writeFile(conf.import.base_path / "installed_versions", installed_version, true);
+    }
+    return std::make_shared<LiteClient>(conf);
+  }
+
+  Uptane::Target createNewTarget(const std::string& version_number) {
+    // update rootfs and commit it into Treehub's repo
+    const std::string unique_file = Utils::randomUuid();
+    const std::string unique_content = Utils::randomUuid();
+    Utils::writeFile(sysrootfs().path + "/" + unique_file, unique_content, true);
+    auto update_commit_hash = treehub().repo().commit(sysrootfs().path, "lmp");
+
+    // add new target to TUF repo
+    const std::string target_name = hw_id + "-" + os + "-" + version_number;
+    return tufRepo().add_target(target_name, update_commit_hash, hw_id);
+  }
+
+  void update(LiteClient& client, const Uptane::Target& from_target, const Uptane::Target& to_target) {
+    // TODO: remove it once aklite is moved to the newer version of LiteClient that exposes update() method
+    ASSERT_TRUE(client.checkForUpdates());
+    // TODO: call client->getTarget() once the method is moved to LiteClient
+    ASSERT_EQ(client.download(to_target, ""), data::ResultCode::Numeric::kOk);
+    ASSERT_EQ(client.install(to_target), data::ResultCode::Numeric::kNeedCompletion);
+    // make sure that the new Target hasn't been applied/finalized before reboot
+    ASSERT_EQ(client.getCurrent().sha256Hash(), from_target.sha256Hash());
+    ASSERT_EQ(client.getCurrent().filename(), from_target.filename());
+  }
+
+  bool areTargetsEqual(const Uptane::Target& lhs, const Uptane::Target& rhs) {
+    return (lhs.sha256Hash() == rhs.sha256Hash()) && (lhs.filename() == rhs.filename());
+  }
+
+  void reboot(std::shared_ptr<LiteClient>& client) {
+    boost::filesystem::remove(test_dir_.Path() / "need_reboot");
+    client = create_liteclient(false);
+  }
+
+  void restart(std::shared_ptr<LiteClient>& client) {
+    client = create_liteclient(false);
+  }
+
+  TufRepoMock& tufRepo() { return tuf_repo_; }
+  const Uptane::Target& initial_target() const { return initial_target_; }
+  TreehubMock& treehub() { return treehub_; }
+  SysRootFS& sysrootfs() { return sysrootfs_; }
+  SysOSTreeMock& sysrepo() { return sysrepo_; }
+
+ protected:
+  static const std::string branch;
+  static const std::string hw_id;
+  static const std::string os;
+
+ private:
+  TemporaryDirectory test_dir_;
+  SysRootFS sysrootfs_;
+  SysOSTreeMock sysrepo_;
+  TufRepoMock tuf_repo_;
+  TreehubMock treehub_;
+
+  Uptane::Target initial_target_;
+};
+
+std::string LiteClientTest::SysRootSrc;
+const std::string LiteClientTest::branch{"lmp"};
+const std::string LiteClientTest::hw_id{"raspberrypi4-64"};
+const std::string LiteClientTest::os{"lmp"};
+
+
+TEST_F(LiteClientTest, OstreeUpdate) {
+  // boot device
+  auto client = create_liteclient();
+  ASSERT_TRUE(areTargetsEqual(client->getCurrent(), initial_target()));
+  // Create a new Target: update rootfs and commit it into Treehub's repo
+  auto new_target = createNewTarget("2");
+  // update
+  update(*client, initial_target(), new_target);
+  // reboot device
+  reboot(client);
+  ASSERT_TRUE(areTargetsEqual(client->getCurrent(), new_target));
+}
+
+TEST_F(LiteClientTest, OstreeUpdateRollback) {
+  // boot device
+  auto client = create_liteclient();
+  ASSERT_TRUE(areTargetsEqual(client->getCurrent(), initial_target()));
+
+  // Create a new Target: update rootfs and commit it into Treehub's repo
+  auto new_target = createNewTarget("2");
+
+  // update
+  update(*client, initial_target(), new_target);
+
+  // deploy the initial version/commit to emulate rollback
+  sysrepo().deploy(initial_target().sha256Hash());
+  // reboot
+  reboot(client);
+  // make sure that a rollback has happened and a client is still running the initial Target
+  ASSERT_TRUE(areTargetsEqual(client->getCurrent(), initial_target()));
+
+  // make sure we cannot install the bad version
+  std::vector<Uptane::Target> known_but_not_installed_versions;
+  get_known_but_not_installed_versions(*client, known_but_not_installed_versions);
+  ASSERT_TRUE(known_local_target(*client, new_target, known_but_not_installed_versions));
+
+  // make sure we can update a device with a new valid Target
+  auto new_target_03 = createNewTarget("3");
+
+  // update
+  update(*client, initial_target(), new_target_03);
+
+  // reboot
+  reboot(client);
+  ASSERT_TRUE(areTargetsEqual(client->getCurrent(), new_target_03));
+}
+
+TEST_F(LiteClientTest, OstreeUpdateToLatestAfterManualUpdate) {
+  // boot device
+  auto client = create_liteclient();
+  ASSERT_TRUE(areTargetsEqual(client->getCurrent(), initial_target()));
+
+  // Create a new Target: update rootfs and commit it into Treehub's repo
+  auto new_target = createNewTarget("2");
+
+  // update
+  update(*client, initial_target(), new_target);
+
+  // reboot device
+  reboot(client);
+  ASSERT_TRUE(areTargetsEqual(client->getCurrent(), new_target));
+
+  // emulate manuall update to the previous version
+  update(*client, new_target, initial_target());
+
+  // reboot device and make sure that the previous version is installed
+  reboot(client);
+  ASSERT_TRUE(areTargetsEqual(client->getCurrent(), initial_target()));
+
+  // make sure we can install the latest version that has been installed before
+  // the succesfully installed Target should be "not known"
+  std::vector<Uptane::Target> known_but_not_installed_versions;
+  get_known_but_not_installed_versions(*client, known_but_not_installed_versions);
+  ASSERT_FALSE(known_local_target(*client, new_target, known_but_not_installed_versions));
+
+  // emulate auto update to the latest
+  update(*client, initial_target(), new_target);
+
+  // reboot device
+  reboot(client);
+  ASSERT_TRUE(areTargetsEqual(client->getCurrent(), new_target));
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+
+  logger_init();
+
+  if (argc != 4) {
+    std::cerr << "Error: " << argv[0] << " requires the path to the fake TUF repo server\n";
+    return EXIT_FAILURE;
+  }
+
+  TufRepoMock::ServerPath = argv[1];
+  TreehubMock::ServerPath = argv[2];
+  SysRootFS::GeneratorPath = argv[3];
+
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Since the libaktualizr maintainer accepted some patches into the upstream (e.g. getCurrentHash) we can make use of OstreeManager::finalizeInstall instead of copy-pasting it in the lite client.
