### PR TITLE
[for ideas] - a way to make daemon just worry about current and desired targets

### DIFF
--- a/src/composeapp.cc
+++ b/src/composeapp.cc
@@ -169,6 +169,7 @@ bool ComposeApp::download(const std::string& app_uri) {
 
     registry_client_.downloadBlob(archive_uri, root_ / archive_file_name, manifest.archiveSize());
     extractAppArchive(archive_file_name);
+    Utils::writeFile(root_ / ".app_uri", app_uri);
 
     result = true;
     LOG_DEBUG << name_ << ": App has been downloaded";

--- a/src/composeappmanager.h
+++ b/src/composeappmanager.h
@@ -55,6 +55,8 @@ class ComposeAppManager : public OstreeManager {
   void setAppsNotChecked() { are_apps_checked_ = false; }
   void handleRemovedApps(const Uptane::Target& target) const;
 
+  Uptane::Target getCurrent() const override;
+
  private:
   std::string getCurrentHash() const override;
   // Return a description of what `docker ps` sees

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -5,15 +5,7 @@
 
 #include "liteclient.h"
 
-struct Version {
-  std::string raw_ver;
-  Version(std::string version) : raw_ver(std::move(version)) {}
-
-  bool operator<(const Version& other) { return strverscmp(raw_ver.c_str(), other.raw_ver.c_str()) < 0; }
-};
-
 void generate_correlation_id(Uptane::Target& t);
-bool target_has_tags(const Uptane::Target& t, const std::vector<std::string>& config_tags);
 bool known_local_target(LiteClient& client, const Uptane::Target& t, std::vector<Uptane::Target>& installed_versions);
 void get_known_but_not_installed_versions(LiteClient& client,
                                           std::vector<Uptane::Target>& known_but_not_installed_versions);

--- a/src/liteclient.h
+++ b/src/liteclient.h
@@ -22,6 +22,14 @@ class Lock {
   int fd_;
 };
 
+struct Version {
+  std::string raw_ver;
+  Version(std::string version) : raw_ver(std::move(version)) {}
+
+  bool operator<(const Version& other) { return strverscmp(raw_ver.c_str(), other.raw_ver.c_str()) < 0; }
+};
+bool target_has_tags(const Uptane::Target& t, const std::vector<std::string>& config_tags);
+
 class LiteClient {
  public:
   LiteClient(Config& config_in);
@@ -34,6 +42,8 @@ class LiteClient {
   std::shared_ptr<HttpClient> http_client;
   boost::filesystem::path download_lockfile;
   boost::filesystem::path update_lockfile;
+
+  std::unique_ptr<Uptane::Target> findTarget(const std::string& version);
 
   bool checkForUpdates();
   data::ResultCode::Numeric download(const Uptane::Target& target, const std::string& reason);

--- a/src/main.cc
+++ b/src/main.cc
@@ -87,51 +87,6 @@ static int list_main(LiteClient& client, const bpo::variables_map& unused) {
   return 0;
 }
 
-static std::unique_ptr<Uptane::Target> find_target(LiteClient& client, Uptane::HardwareIdentifier& hwid,
-                                                   const std::vector<std::string>& tags, const std::string& version) {
-  std::unique_ptr<Uptane::Target> rv;
-  if (!client.updateImageMeta()) {
-    LOG_WARNING << "Unable to update latest metadata, using local copy";
-    if (!client.checkImageMetaOffline()) {
-      LOG_ERROR << "Unable to use local copy of TUF data";
-      throw std::runtime_error("Unable to find update");
-    }
-  }
-
-  // if a new version of targets.json hasn't been downloaded why do we do the following search
-  // for the latest ??? It's really needed just for the forced update to a specific version
-  bool find_latest = (version == "latest");
-  std::unique_ptr<Uptane::Target> latest = nullptr;
-  for (const auto& t : client.allTargets()) {
-    if (!t.IsValid()) {
-      continue;
-    }
-
-    if (!t.IsOstree()) {
-      continue;
-    }
-
-    if (!target_has_tags(t, tags)) {
-      continue;
-    }
-    for (auto const& it : t.hardwareIds()) {
-      if (it == hwid) {
-        if (find_latest) {
-          if (latest == nullptr || Version(latest->custom_version()) < Version(t.custom_version())) {
-            latest = std_::make_unique<Uptane::Target>(t);
-          }
-        } else if (version == t.filename() || version == t.custom_version()) {
-          return std_::make_unique<Uptane::Target>(t);
-        }
-      }
-    }
-  }
-  if (find_latest && latest != nullptr) {
-    return latest;
-  }
-  throw std::runtime_error("Unable to find update");
-}
-
 static data::ResultCode::Numeric do_update(LiteClient& client, Uptane::Target target, const std::string& reason) {
   log_info_target("Updating Active Target: ", client.config, client.getCurrent());
   log_info_target("To New Target: ", client.config, target);
@@ -175,10 +130,7 @@ static data::ResultCode::Numeric do_app_sync(LiteClient& client) {
 }
 
 static int update_main(LiteClient& client, const bpo::variables_map& variables_map) {
-  Uptane::HardwareIdentifier hwid(client.config.provision.primary_ecu_hardware_id);
-
   std::string version("latest");
-
   if (variables_map.count("update-name") > 0) {
     version = variables_map["update-name"].as<std::string>();
   }
@@ -190,7 +142,7 @@ static int update_main(LiteClient& client, const bpo::variables_map& variables_m
   }
 
   LOG_INFO << "Finding " << version << " to update to...";
-  auto target_to_install = find_target(client, hwid, client.tags, version);
+  auto target_to_install = client.findTarget(version);
 
   std::string reason = "Manual update to " + version;
   data::ResultCode::Numeric rc = do_update(client, *target_to_install, reason);
@@ -209,7 +161,6 @@ static int daemon_main(LiteClient& client, const bpo::variables_map& variables_m
     return EXIT_FAILURE;
   }
 
-  Uptane::HardwareIdentifier hwid(client.config.provision.primary_ecu_hardware_id);
   if (variables_map.count("update-lockfile") > 0) {
     client.update_lockfile = variables_map["update-lockfile"].as<boost::filesystem::path>();
   }
@@ -245,7 +196,7 @@ static int daemon_main(LiteClient& client, const bpo::variables_map& variables_m
 
     try {
       // target cannot be nullptr, an exception will be yielded if no target
-      auto found_latest_target = find_target(client, hwid, client.tags, "latest");
+      auto found_latest_target = client.findTarget("latest");
 
       // This is a workaround for finding and avoiding bad updates after a rollback.
       // Rollback sets the installed version state to none instead of broken, so there is no


### PR DESCRIPTION
This is purely for ideas on how we can simplify without re-working so much code. Its totally untested, and the HEAD commit doesn't compile. I believe this would allow us to then delete some code from the packagemanager that's been stateful and hard to reason about.