### PR TITLE
liteclient: let storage know its client (TUF/Uptane)

### DIFF
--- a/src/liteclient.cc
+++ b/src/liteclient.cc
@@ -13,7 +13,7 @@
 LiteClient::LiteClient(Config& config_in)
     : config{std::move(config_in)}, primary_ecu{Uptane::EcuSerial::Unknown(), ""} {
   std::string pkey;
-  storage = INvStorage::newStorage(config.storage);
+  storage = INvStorage::newStorage(config.storage, false, StorageClient::kTUF);
   storage->importData(config.import);
 
   const std::map<std::string, std::string> raw = config.pacman.extra;


### PR DESCRIPTION
Instead of providing the client information in the configuration class
(which describes its fundamental characteristics but not how these will
be used) we choose to provide it as a parameter to the instantiation
of the class.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>