### PR TITLE
liteclient_test: extend test suite

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -74,3 +74,5 @@ target_include_directories(t_liteclient PRIVATE ${TEST_INCS} ${AKTUALIZR_DIR}/te
 target_link_libraries(t_liteclient ${TEST_LIBS} uptane_generator_lib testutilities)
 add_dependencies(t_liteclient make_ostree_sysroot)
 set_tests_properties(test_liteclient PROPERTIES LABELS "aklite:liteclient")
+
+aktualizr_source_file_checks(liteclient_test.cc)


### PR DESCRIPTION
The following tests have been added:

 OstreeUpdateWhenNoInstalledVersions
   perform an update when the initial version is not available

 OstreeUpdateInstalledVersionsCorrupted1
   invalidate the installed_verion json by corrupting the sysroot hash

 OstreeUpdateInstalledVersionsCorrupted2
   write an invalid json to the filesystem

Also refactored the code a little bit to improve its readability.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>