### PR TITLE
apps: send app list in a header unconditionally

### DIFF
--- a/src/liteclient.cc
+++ b/src/liteclient.cc
@@ -478,18 +478,16 @@ void LiteClient::update_request_headers(std::shared_ptr<HttpClient>& http_client
   if (config.type == ComposeAppManager::Name) {
     ComposeAppManager::Config cfg(config);
 
-    // If App list was not specified in the config then we need to update the request header with a list of
-    // Apps specified in the currently installed Target
-    if (!cfg.apps) {
-      std::list<std::string> apps;
-      auto target_apps = target.custom_data()["docker_compose_apps"];
-      for (Json::ValueIterator ii = target_apps.begin(); ii != target_apps.end(); ++ii) {
-        if ((*ii).isObject() && (*ii).isMember("uri")) {
-          const auto& target_app_name = ii.key().asString();
+    std::list<std::string> apps;
+    auto target_apps = target.custom_data()["docker_compose_apps"];
+    for (Json::ValueIterator ii = target_apps.begin(); ii != target_apps.end(); ++ii) {
+      if ((*ii).isObject() && (*ii).isMember("uri")) {
+        const auto& target_app_name = ii.key().asString();
+        if (!cfg.apps || (*cfg.apps).end() != std::find((*cfg.apps).begin(), (*cfg.apps).end(), target_app_name)) {
           apps.push_back(target_app_name);
         }
       }
-      http_client->updateHeader("x-ats-dockerapps", boost::algorithm::join(apps, ","));
     }
+    http_client->updateHeader("x-ats-dockerapps", boost::algorithm::join(apps, ","));
   }
 }

--- a/src/liteclient.h
+++ b/src/liteclient.h
@@ -58,6 +58,8 @@ class LiteClient {
   bool appsInSync() const;
   void setAppsNotChecked();
   std::string getDeviceID() const;
+  static void update_request_headers(std::shared_ptr<HttpClient>& http_client, const Uptane::Target& target,
+                                     PackageConfig& config);
 
  private:
   FRIEND_TEST(helpers, locking);
@@ -79,8 +81,6 @@ class LiteClient {
   std::pair<bool, Uptane::Target> downloadImage(const Uptane::Target& target,
                                                 const api::FlowControlToken* token = nullptr);
   static void add_apps_header(std::vector<std::string>& headers, PackageConfig& config);
-  static void update_request_headers(std::shared_ptr<HttpClient>& http_client, const Uptane::Target& target,
-                                     PackageConfig& config);
 
  private:
   boost::filesystem::path callback_program;

--- a/src/main.cc
+++ b/src/main.cc
@@ -261,7 +261,7 @@ static int daemon_main(LiteClient& client, const bpo::variables_map& variables_m
         data::ResultCode::Numeric rc = do_update(client, *found_latest_target, reason);
         if (rc == data::ResultCode::Numeric::kOk) {
           current = *found_latest_target;
-          client.http_client->updateHeader("x-ats-target", current.filename());
+          LiteClient::update_request_headers(client.http_client, current, client.config.pacman);
           // Start the loop over to call updateImagesMeta which will update this
           // device's target name on the server.
           continue;


### PR DESCRIPTION
- send a currently installed app list in a header request to the backend
unconditionally, regadles if an app shortlist specified or not;
- add tests to verify the given use-case

Signed-off-by: Mike Sul <mike.sul@foundries.io>