### PR TITLE
Encapsulate Target-related functionality

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,7 +11,8 @@ set(SRC helpers.cc
         dockerclient.cc
         docker.cc
         liteclient.cc
-        yaml2json.cc )
+        yaml2json.cc
+        target.cc)
 
 set(HEADERS helpers.h
         compose/composeappmanager.h
@@ -24,7 +25,8 @@ set(HEADERS helpers.h
         dockerclient.h
         docker.h
         liteclient.h
-        yaml2json.h)
+        yaml2json.h
+        target.h)
 
 add_executable(${TARGET_EXE} main.cc)
 add_library(${TARGET} OBJECT ${SRC})

--- a/src/helpers.cc
+++ b/src/helpers.cc
@@ -5,36 +5,6 @@
 
 #include "composeappmanager.h"
 
-void log_info_target(const std::string& prefix, const Config& config, const Uptane::Target& t) {
-  auto name = t.filename();
-  if (t.custom_version().length() > 0) {
-    name = t.custom_version();
-  }
-  LOG_INFO << prefix + name << "\tsha256:" << t.sha256Hash();
-
-  if (config.pacman.type == ComposeAppManager::Name) {
-    bool shown = false;
-    auto config_apps = ComposeAppManager::Config(config.pacman).apps;
-    auto bundles = t.custom_data()["docker_compose_apps"];
-    for (Json::ValueIterator i = bundles.begin(); i != bundles.end(); ++i) {
-      if (!shown) {
-        shown = true;
-        LOG_INFO << "\tDocker Compose Apps:";
-      }
-      if ((*i).isObject() && (*i).isMember("uri")) {
-        const auto& app = i.key().asString();
-        std::string app_status =
-            (!config_apps || (*config_apps).end() != std::find((*config_apps).begin(), (*config_apps).end(), app))
-                ? "on"
-                : "off";
-        LOG_INFO << "\t" << app_status << ": " << app << " -> " << (*i)["uri"].asString();
-      } else {
-        LOG_ERROR << "\t\tInvalid custom data for docker_compose_apps: " << i.key().asString();
-      }
-    }
-  }
-}
-
 static bool appListChanged(const Json::Value& target_apps, std::vector<std::string>& cfg_apps_in,
                            const boost::filesystem::path& apps_dir) {
   // Did the list of installed versus running apps change:

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -5,18 +5,10 @@
 
 #include "liteclient.h"
 
-struct Version {
-  std::string raw_ver;
-  Version(std::string version) : raw_ver(std::move(version)) {}
-
-  bool operator<(const Version& other) { return strverscmp(raw_ver.c_str(), other.raw_ver.c_str()) < 0; }
-};
-
 void generate_correlation_id(Uptane::Target& t);
 bool target_has_tags(const Uptane::Target& t, const std::vector<std::string>& config_tags);
 bool known_local_target(LiteClient& client, const Uptane::Target& t, std::vector<Uptane::Target>& installed_versions);
 void get_known_but_not_installed_versions(LiteClient& client,
                                           std::vector<Uptane::Target>& known_but_not_installed_versions);
-void log_info_target(const std::string& prefix, const Config& config, const Uptane::Target& t);
 
 #endif  // AKTUALIZR_LITE_HELPERS_

--- a/src/liteclient.h
+++ b/src/liteclient.h
@@ -62,6 +62,8 @@ class LiteClient {
                                      PackageConfig& config);
   bool finalizeInstallation();
 
+  void logTarget(const std::string& prefix, const Uptane::Target& target) const;
+
  private:
   FRIEND_TEST(helpers, locking);
   FRIEND_TEST(helpers, callback);

--- a/src/main.cc
+++ b/src/main.cc
@@ -9,6 +9,7 @@
 #include "helpers.h"
 #include "libaktualizr/config.h"
 
+#include "target.h"
 #include "utilities/aktualizr_version.h"
 
 namespace bpo = boost::program_options;
@@ -47,7 +48,7 @@ static int status_main(LiteClient& client, const bpo::variables_map& unused) {
     if (target.custom_version().length() > 0) {
       name = target.custom_version();
     }
-    log_info_target("Active image is: ", client.config, target);
+    client.logTarget("Active image is: ", target);
   }
   return 0;
 }
@@ -87,7 +88,7 @@ static int list_main(LiteClient& client, const bpo::variables_map& unused) {
 
   LOG_INFO << "Updates available to " << hwid << ":";
   for (auto& pair : sorted_targets) {
-    log_info_target("", client.config, pair.second);
+    client.logTarget("", pair.second);
   }
   return 0;
 }
@@ -122,7 +123,7 @@ static std::unique_ptr<Uptane::Target> find_target(LiteClient& client, Uptane::H
     for (auto const& it : t.hardwareIds()) {
       if (it == hwid) {
         if (find_latest) {
-          if (latest == nullptr || Version(latest->custom_version()) < Version(t.custom_version())) {
+          if (latest == nullptr || Target::Version(latest->custom_version()) < Target::Version(t.custom_version())) {
             latest = std_::make_unique<Uptane::Target>(t);
           }
         } else if (version == t.filename() || version == t.custom_version()) {
@@ -138,8 +139,8 @@ static std::unique_ptr<Uptane::Target> find_target(LiteClient& client, Uptane::H
 }
 
 static data::ResultCode::Numeric do_update(LiteClient& client, Uptane::Target target, const std::string& reason) {
-  log_info_target("Updating Active Target: ", client.config, client.getCurrent());
-  log_info_target("To New Target: ", client.config, target);
+  client.logTarget("Updating Active Target: ", client.getCurrent());
+  client.logTarget("To New Target: ", target);
 
   generate_correlation_id(target);
 

--- a/src/target.cc
+++ b/src/target.cc
@@ -1,0 +1,76 @@
+#include "target.h"
+
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
+
+#include "logging/logging.h"
+
+bool Target::hasTag(const Uptane::Target& target, const std::vector<std::string>& tags) {
+  if (tags.empty()) {
+    return true;
+  }
+
+  const auto target_tags = target.custom_data()[TagField];
+  for (Json::ValueConstIterator ii = target_tags.begin(); ii != target_tags.end(); ++ii) {
+    auto target_tag = (*ii).asString();
+    if (std::find(tags.begin(), tags.end(), target_tag) != tags.end()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void Target::setCorrelationID(Uptane::Target& target) {
+  std::string id = target.custom_version();
+  if (id.empty()) {
+    id = target.filename();
+  }
+  boost::uuids::uuid tmp = boost::uuids::random_generator()();
+  target.setCorrelationId(id + "-" + boost::uuids::to_string(tmp));
+}
+
+std::string Target::ostreeURI(const Uptane::Target& target) {
+  std::string uri;
+  auto uri_json = target.custom_data().get("compose-apps-uri", Json::Value(Json::nullValue));
+  if (!uri_json.empty()) {
+    uri = uri_json.asString();
+  }
+  return uri;
+}
+
+Json::Value Target::appsJson(const Uptane::Target& target) {
+  return target.custom_data().get(Target::ComposeAppField, Json::Value(Json::nullValue));
+}
+
+std::string Target::appsStr(const Uptane::Target& target, boost::optional<std::vector<std::string>> app_shortlist) {
+  std::vector<std::string> apps;
+  for (const auto& app : Target::Apps(target)) {
+    if (!app_shortlist ||
+        (*app_shortlist).end() != std::find((*app_shortlist).begin(), (*app_shortlist).end(), app.name)) {
+      apps.push_back(app.name);
+    }
+  }
+  return boost::algorithm::join(apps, ",");
+}
+
+void Target::log(const std::string& prefix, const Uptane::Target& target,
+                 boost::optional<std::vector<std::string>> app_shortlist) {
+  auto name = target.filename();
+  if (target.custom_version().length() > 0) {
+    name = target.custom_version();
+  }
+  LOG_INFO << prefix + name << "\tsha256:" << target.sha256Hash();
+
+  bool print_title{true};
+  for (const auto& app : Target::Apps(target)) {
+    if (print_title) {
+      LOG_INFO << "\tDocker Compose Apps:";
+      print_title = false;
+    }
+    std::string app_status =
+        (!app_shortlist || std::find(app_shortlist->begin(), app_shortlist->end(), app.name) != app_shortlist->end())
+            ? "on "
+            : "off";
+    LOG_INFO << "\t" << app_status << ": " << app.name << " -> " << app.uri;
+  }
+}

--- a/src/target.h
+++ b/src/target.h
@@ -1,0 +1,78 @@
+#ifndef AKTUALIZR_LITE_TARGET_H_
+#define AKTUALIZR_LITE_TARGET_H_
+
+#include <boost/optional.hpp>
+#include "logging/logging.h"
+
+#include "uptane/tuf.h"
+
+class Target {
+ public:
+  static constexpr const char* const TagField{"tags"};
+  static constexpr const char* const ComposeAppField{"docker_compose_apps"};
+  static constexpr const char* const ComposeAppOstreeUri{"compose-apps-uri"};
+
+  struct Version {
+    std::string raw_ver;
+    Version(std::string version) : raw_ver(std::move(version)) {}
+
+    bool operator<(const Version& other) { return strverscmp(raw_ver.c_str(), other.raw_ver.c_str()) < 0; }
+  };
+
+ public:
+  static bool hasTag(const Uptane::Target& target, const std::vector<std::string>& tags);
+  static void setCorrelationID(Uptane::Target& target);
+  static std::string ostreeURI(const Uptane::Target& target);
+  static Json::Value appsJson(const Uptane::Target& target);
+  static std::string appsStr(const Uptane::Target& target,
+                             boost::optional<std::vector<std::string>> app_shortlist = boost::none);
+  static void log(const std::string& prefix, const Uptane::Target& target,
+                  boost::optional<std::vector<std::string>> app_shortlist = boost::none);
+
+  class Apps {
+   public:
+    struct AppDesc {
+      AppDesc(const std::string& app_name, const Json::Value& app_json) : name{app_name} {
+        if (app_json.isNull() || !app_json.isObject() || !app_json.isMember("uri")) {
+          throw std::runtime_error("Invalid format of App in Target json: " + app_json.toStyledString());
+        }
+        uri = app_json["uri"].asString();
+      }
+      AppDesc() = delete;
+      bool operator==(const AppDesc& app_desc) const { return name == app_desc.name && uri == app_desc.uri; }
+
+      std::string name;
+      std::string uri;
+    };
+
+   public:
+    Apps(const Uptane::Target& target) : target_apps_json_{Target::appsJson(target)} {}
+
+    class Iterator {
+     public:
+      bool operator!=(const Iterator& rhs) const { return json_iter_ != rhs.json_iter_; }
+      AppDesc operator*() const { return {json_iter_.key().asString(), *json_iter_}; }
+      Iterator operator++() {
+        ++json_iter_;
+        return *this;
+      }
+
+     private:
+      friend class Target::Apps;
+      Iterator() = delete;
+      Iterator& operator=(const Iterator&) = delete;
+      Iterator(Json::ValueConstIterator&& json_iter) : json_iter_{json_iter} {}
+
+     private:
+      Json::ValueConstIterator json_iter_;
+    };
+
+    Iterator begin() const { return target_apps_json_.begin(); }
+    Iterator end() const { return target_apps_json_.end(); }
+
+   private:
+    Json::Value target_apps_json_;
+  };  // Apps
+};    // Target
+
+#endif  // AKTUALIZR_LITE_TARGET_H_

--- a/tests/helpers_test.cc
+++ b/tests/helpers_test.cc
@@ -2,24 +2,25 @@
 
 #include "helpers.h"
 #include "composeappmanager.h"
+#include "target.h"
 
 static boost::filesystem::path test_sysroot;
 
 TEST(version, bad_versions) {
-  ASSERT_TRUE(Version("bar") < Version("foo"));
-  ASSERT_TRUE(Version("1.bar") < Version("2foo"));
-  ASSERT_TRUE(Version("1..0") < Version("1.1"));
-  ASSERT_TRUE(Version("1.-1") < Version("1.1"));
-  ASSERT_TRUE(Version("1.*bad #text") < Version("1.1"));  // ord('*') < ord('1')
+  ASSERT_TRUE(Target::Version("bar") < Target::Version("foo"));
+  ASSERT_TRUE(Target::Version("1.bar") < Target::Version("2foo"));
+  ASSERT_TRUE(Target::Version("1..0") < Target::Version("1.1"));
+  ASSERT_TRUE(Target::Version("1.-1") < Target::Version("1.1"));
+  ASSERT_TRUE(Target::Version("1.*bad #text") < Target::Version("1.1"));  // ord('*') < ord('1')
 }
 
 TEST(version, good_versions) {
-  ASSERT_TRUE(Version("1.0.1") < Version("1.0.1.1"));
-  ASSERT_TRUE(Version("1.0.1") < Version("1.0.2"));
-  ASSERT_TRUE(Version("0.9") < Version("1.0.1"));
-  ASSERT_TRUE(Version("1.0.0.0") < Version("1.0.0.1"));
-  ASSERT_TRUE(Version("1") < Version("1.0.0.1"));
-  ASSERT_TRUE(Version("1.9.0") < Version("1.10"));
+  ASSERT_TRUE(Target::Version("1.0.1") < Target::Version("1.0.1.1"));
+  ASSERT_TRUE(Target::Version("1.0.1") < Target::Version("1.0.2"));
+  ASSERT_TRUE(Target::Version("0.9") < Target::Version("1.0.1"));
+  ASSERT_TRUE(Target::Version("1.0.0.0") < Target::Version("1.0.0.1"));
+  ASSERT_TRUE(Target::Version("1") < Target::Version("1.0.0.1"));
+  ASSERT_TRUE(Target::Version("1.9.0") < Target::Version("1.10"));
 }
 
 // Ensure we finalize an install if completed


### PR DESCRIPTION
This is the first "cherry-pick" from the "simplification" branch https://github.com/foundriesio/aktualizr-lite/tree/refact/update-logic-simplification. It defines a new class/namespace aimed to encapsulate all Target-related functionality and decouple its clients from implementation details as well as avoid hard coding and copy-pasting. It's not fully leveraged in the given PR as its full utilization require further changes/refactoring in the code base, but will be so later.