### PR TITLE
callback: extend the post check callback context

### DIFF
--- a/src/liteclient.h
+++ b/src/liteclient.h
@@ -37,7 +37,8 @@ class LiteClient {
   boost::filesystem::path download_lockfile;
   boost::filesystem::path update_lockfile;
 
-  bool checkForUpdates();
+  bool checkForUpdatesBegin();
+  void checkForUpdatesEnd(const Uptane::Target& target);
   bool complete(bool finalize);
   data::ResultCode::Numeric download(const Uptane::Target& target, const std::string& reason);
   data::ResultCode::Numeric install(const Uptane::Target& target);
@@ -48,7 +49,7 @@ class LiteClient {
 
   bool composeAppsChanged() const;
   Uptane::Target getCurrent() const { return package_manager_->getCurrent(); }
-  bool updateImageMeta();
+  std::tuple<bool, std::string> updateImageMeta();
   bool checkImageMetaOffline();
   const std::vector<Uptane::Target>& allTargets() const { return image_repo_.getTargets()->targets; }
   TargetStatus VerifyTarget(const Uptane::Target& target) const { return package_manager_->verifyTarget(target); }

--- a/tests/fixtures/liteclienttest.cc
+++ b/tests/fixtures/liteclienttest.cc
@@ -192,7 +192,7 @@ class ClientTest :virtual public ::testing::Test {
    */
   void update(LiteClient& client, const Uptane::Target& from, const Uptane::Target& to) {
     // TODO: remove it once aklite is moved to the newer version of LiteClient that exposes update() method
-    ASSERT_TRUE(client.checkForUpdates());
+    ASSERT_TRUE(client.checkForUpdatesBegin());
 
     // TODO: call client->getTarget() once the method is moved to LiteClient
     ASSERT_EQ(client.download(to, ""), data::ResultCode::Numeric::kOk);
@@ -211,7 +211,7 @@ class ClientTest :virtual public ::testing::Test {
                   data::ResultCode::Numeric expected_download_code = data::ResultCode::Numeric::kOk,
                   data::ResultCode::Numeric expected_install_code = data::ResultCode::Numeric::kOk) {
     // TODO: remove it once aklite is moved to the newer version of LiteClient that exposes update() method
-    ASSERT_TRUE(client.checkForUpdates());
+    ASSERT_TRUE(client.checkForUpdatesBegin());
 
     // TODO: call client->getTarget() once the method is moved to LiteClient
     ASSERT_EQ(client.download(to, ""), expected_download_code);
@@ -293,7 +293,7 @@ class ClientTest :virtual public ::testing::Test {
    */
   void checkHeaders(LiteClient& client, const Uptane::Target& target) {
     // check for a new Target in order to send requests with headers we are interested in
-    ASSERT_TRUE(client.checkForUpdates());
+    ASSERT_TRUE(client.checkForUpdatesBegin());
     if (target.MatchTarget(Uptane::Target::Unknown())) return;
 
     auto req_headers = getDeviceGateway().getReqHeaders();


### PR DESCRIPTION
Extend a context of `check-for-update-post` callback.
RESULT is set to OK if the check is successful, otherwise, it's set to FAILED.
INSTALL_TARGET is empty if `FAILED` or no new Target nor current Target sync.
INSTALL_TARGET is set to the Target name to be installed or synced.

Signed-off-by: Mike Sul <mike.sul@foundries.io>