### PR TITLE
callback: explicit Target name as callback context

### DIFF
--- a/src/liteclient.cc
+++ b/src/liteclient.cc
@@ -157,9 +157,13 @@ void LiteClient::callback(const char* msg, const Uptane::Target& install_target,
   boost::process::environment env_copy = env;
   env_copy["MESSAGE"] = msg;
   env_copy["CURRENT_TARGET"] = (config.storage.path / "current-target").string();
+  auto current = getCurrent();
+  if (!current.MatchTarget(Uptane::Target::Unknown())) {
+    env_copy["CURRENT_TARGET_NAME"] = current.filename();
+  }
 
   if (!install_target.MatchTarget(Uptane::Target::Unknown())) {
-    env_copy["INSTALL_TARGET"] = install_target.filename();
+    env_copy["INSTALL_TARGET_NAME"] = install_target.filename();
   }
   if (!result.empty()) {
     env_copy["RESULT"] = result;

--- a/tests/test_lite.sh
+++ b/tests/test_lite.sh
@@ -144,11 +144,22 @@ env >> ${sota_dir}/\$MESSAGE.log
 EOF
 chmod +x $sota_dir/callback.sh
 $valgrind $aklite --loglevel 1 -c $sota_dir/sota.toml update | grep "To New Target: promoted-zlast"
-for callback in download-pre download-post install-pre install-post ; do
+for callback in download-pre download-post install-pre ; do
   if [ -f ${sota_dir}/${callback}.log ] ; then
-    grep "INSTALL_TARGET=promoted-zlast" ${sota_dir}/${callback}.log
+    grep "INSTALL_TARGET_NAME=promoted-zlast" ${sota_dir}/${callback}.log
+    grep "CURRENT_TARGET_NAME=zlast" ${sota_dir}/${callback}.log
   else
     echo "ERROR: Callback not performed for $callback"
     exit 1
   fi
 done
+callback=install-post
+if [ -f ${sota_dir}/${callback}.log ] ; then
+    grep "INSTALL_TARGET_NAME=promoted-zlast" ${sota_dir}/${callback}.log
+    grep "CURRENT_TARGET_NAME=promoted-zlast" ${sota_dir}/${callback}.log
+    grep "RESULT=OK" ${sota_dir}/${callback}.log
+  else
+    echo "ERROR: Callback not performed for $callback"
+    exit 1
+fi
+


### PR DESCRIPTION
Add/change the following in the callback context/env variables

- add CURRENT_TARGET_NAME env. variable
- rename INSTALL_TARGET to INSTALL_TARGET_NAME

Signed-off-by: Mike Sul <mike.sul@foundries.io>