### PR TITLE
Assume TUF repo server is Hub creds provider

### DIFF
--- a/src/composeappmanager.cc
+++ b/src/composeappmanager.cc
@@ -43,6 +43,10 @@ ComposeAppManager::Config::Config(const PackageConfig& pconfig) {
   if (raw.count("force_update") > 0) {
     force_update = boost::lexical_cast<bool>(raw.at("force_update"));
   }
+
+  if (raw.count("hub_auth_creds_endpoint") == 1) {
+    hub_auth_creds_endpoint = raw.at("hub_auth_creds_endpoint");
+  }
 }
 
 ComposeAppManager::ComposeAppManager(const PackageConfig& pconfig, const BootloaderConfig& bconfig,
@@ -57,7 +61,7 @@ ComposeAppManager::ComposeAppManager(const PackageConfig& pconfig, const Bootloa
     app_engine_ = std::make_shared<Docker::ComposeAppEngine>(
         cfg_.apps_root, boost::filesystem::canonical(cfg_.compose_bin).string() + " ",
         std::make_shared<Docker::DockerClient>(),
-        std::make_shared<Docker::RegistryClient>(pconfig.ostree_server, http));
+        std::make_shared<Docker::RegistryClient>(http, cfg_.hub_auth_creds_endpoint));
   }
 
   try {

--- a/src/composeappmanager.h
+++ b/src/composeappmanager.h
@@ -28,6 +28,7 @@ class ComposeAppManager : public OstreeManager {
     bool create_apps_tree{false};
     boost::filesystem::path images_data_root{"/var/lib/docker"};
     std::string docker_images_reload_cmd{"systemctl reload docker"};
+    std::string hub_auth_creds_endpoint{Docker::RegistryClient::DefAuthCredsEndpoint};
   };
 
   using AppsContainer = std::unordered_map<std::string, std::string>;

--- a/src/docker/docker.cc
+++ b/src/docker/docker.cc
@@ -65,24 +65,11 @@ const std::string RegistryClient::ManifestEndpoint{"/manifests/"};
 const std::string RegistryClient::BlobEndpoint{"/blobs/"};
 const std::string RegistryClient::SupportedRegistryVersion{"/v2/"};
 
-RegistryClient::RegistryClient(const std::string& treehub_endpoint, std::shared_ptr<HttpInterface> ota_lite_client,
+RegistryClient::RegistryClient(std::shared_ptr<HttpInterface> ota_lite_client, std::string auth_creds_endpoint,
                                HttpClientFactory http_client_factory)
-    : ota_lite_client_{std::move(ota_lite_client)}, http_client_factory_{std::move(http_client_factory)} {
-  // There is an assumption that the treehub and the registry auth endpoints share the same base URL,
-  // so let's try to deduce the registry auth endpoint from the received URL to the treehub
-  // TODO: introduce dedicated configuration parameter to specify registry auth endpoint
-  if (!treehub_endpoint.empty()) {
-    auto endpoint_pos = treehub_endpoint.rfind('/');
-    if (endpoint_pos != std::string::npos) {
-      auth_creds_endpoint_ = treehub_endpoint.substr(0, endpoint_pos);
-      auth_creds_endpoint_.append("/hub-creds/");
-    }
-  }
-  // if treehub URL is not specified/empty or we cannot extract its base URL just use the default Auth endpoint
-  if (auth_creds_endpoint_.empty()) {
-    auth_creds_endpoint_ = DefAuthCredsEndpoint;
-  }
-}
+    : auth_creds_endpoint_{std::move(auth_creds_endpoint)},
+      ota_lite_client_{std::move(ota_lite_client)},
+      http_client_factory_{std::move(http_client_factory)} {}
 
 Json::Value RegistryClient::getAppManifest(const Uri& uri, const std::string& format) const {
   const std::string manifest_url{composeManifestUrl(uri)};

--- a/src/docker/docker.h
+++ b/src/docker/docker.h
@@ -50,7 +50,7 @@ class RegistryClient {
   using Ptr = std::shared_ptr<RegistryClient>;
 
  public:
-  RegistryClient(const std::string& treehub_endpoint, std::shared_ptr<HttpInterface> ota_lite_client,
+  RegistryClient(std::shared_ptr<HttpInterface> ota_lite_client, std::string auth_creds_endpoint = DefAuthCredsEndpoint,
                  HttpClientFactory http_client_factory = RegistryClient::DefaultHttpClientFactory);
 
   Json::Value getAppManifest(const Uri& uri, const std::string& format) const;
@@ -69,7 +69,7 @@ class RegistryClient {
   }
 
  private:
-  std::string auth_creds_endpoint_;
+  const std::string auth_creds_endpoint_;
   std::shared_ptr<HttpInterface> ota_lite_client_;
   HttpClientFactory http_client_factory_;
 };

--- a/tests/fixtures/composeappenginetest.cc
+++ b/tests/fixtures/composeappenginetest.cc
@@ -16,8 +16,7 @@ class AppEngineTest : virtual public ::testing::Test {
 
     apps_root_dir = test_dir_.Path() / "compose-apps";
     app_engine = std::make_shared<Docker::ComposeAppEngine>(apps_root_dir, compose_cmd, std::make_shared<Docker::DockerClient>(daemon_.getClient()),
-        std::make_shared<Docker::RegistryClient>("https://ota-lite.foundries.io:8443/", registry.getClient(),
-                                                 registry.getClientFactory()));
+                                                            std::make_shared<Docker::RegistryClient>(registry.getClient(), registry.authURL(), registry.getClientFactory()));
   }
 
  protected:

--- a/tests/fixtures/dockerregistry.cc
+++ b/tests/fixtures/dockerregistry.cc
@@ -38,6 +38,8 @@ class DockerRegistry {
     return blob2app_.at(digest)->archive();
   }
 
+  const std::string& authURL() const { return auth_url_; }
+
  private:
   class HttpClient: public BaseHttpClient {
    public:


### PR DESCRIPTION
Use the TUF repo (DG) URL to compose an URL to obtain creds from for Docker Registry.
Previously, the URL to Treehub/Ostree server was used for this purpose.
Since we are splitting Device Gateway into two servers, Device Gateway (TUF) and OstreeProxy then their URLs will differ and the Auth endpoint is exposed by Device Gateway/TUF server.
