### PR TITLE
bootloader/masked: call fw_printenv without variable name

### DIFF
--- a/src/bootloader/rollbacks/masked.h
+++ b/src/bootloader/rollbacks/masked.h
@@ -37,7 +37,7 @@ class MaskedRollback : public Rollback {
       return;
     }
     std::string sink;
-    if (Utils::shell("fw_printenv bootfirmware_version", &sink) != 0) {
+    if (Utils::shell("fw_printenv -n bootfirmware_version", &sink) != 0) {
       LOG_WARNING << "Failed to read bootfirmware_version";
       return;
     }


### PR DESCRIPTION
Call fw_printenv with no-header (-n) when extracting the
bootfirmware_version content, otherwise it will be printed together with
the variable name, invalidating the string comparison logic to decide
when to set bootupgrade_available to 1.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>