### PR TITLE
apps: don't check if Target Apps are running

### DIFF
--- a/src/appengine.h
+++ b/src/appengine.h
@@ -19,6 +19,7 @@ class AppEngine {
   virtual bool run(const App& app) = 0;
   virtual void remove(const App& app) = 0;
   virtual bool isRunning(const App& app) const = 0;
+  virtual bool isInstalled(const App& app) const = 0;
   virtual std::string runningApps() const = 0;
 
  public:

--- a/src/appengine.h
+++ b/src/appengine.h
@@ -18,8 +18,8 @@ class AppEngine {
   virtual bool install(const App& app) = 0;
   virtual bool run(const App& app) = 0;
   virtual void remove(const App& app) = 0;
-  virtual bool isRunning(const App& app) const = 0;
   virtual bool isInstalled(const App& app) const = 0;
+  virtual bool isStarted(const App& app) const = 0;
   virtual std::string runningApps() const = 0;
 
  public:

--- a/src/composeappmanager.cc
+++ b/src/composeappmanager.cc
@@ -130,19 +130,19 @@ ComposeAppManager::AppsContainer ComposeAppManager::getAppsToUpdate(const Uptane
 
     if (!boost::filesystem::exists(cfg_.apps_root / app_name) ||
         !boost::filesystem::exists(cfg_.apps_root / app_name / Docker::ComposeAppEngine::ComposeFile)) {
-      // an App that is supposed to be installed has been removed somehow, let's install it again
+      // an App is supposed to be installed, has been removed somehow, or a new app was added to the app shortlist
       apps_to_update.insert(app_pair);
       LOG_INFO << app_name << " will be re-installed";
       continue;
     }
 
-    LOG_DEBUG << app_name << " performing full status check";
-    if (!app_engine_->isRunning({app_name, app_pair.second})) {
-      // an App that is supposed to be installed and running is not fully installed or running
-      apps_to_update.insert(app_pair);
-      LOG_INFO << app_name << " update will be re-installed or completed";
-      continue;
-    }
+//    LOG_DEBUG << app_name << " performing full status check";
+//    if (!app_engine_->isRunning({app_name, app_pair.second})) {
+//      // an App that is supposed to be installed and running is not fully installed or running
+//      apps_to_update.insert(app_pair);
+//      LOG_INFO << app_name << " update will be re-installed or completed";
+//      continue;
+//    }
   }
 
   return apps_to_update;

--- a/src/composeappmanager.cc
+++ b/src/composeappmanager.cc
@@ -134,6 +134,12 @@ ComposeAppManager::AppsContainer ComposeAppManager::getAppsToUpdate(const Uptane
       LOG_INFO << app_name << " will be re-installed";
       continue;
     }
+
+    if (!app_engine_->isStarted({app_name, app_pair.second})) {
+      apps_to_update.insert(app_pair);
+      LOG_INFO << app_name << " will be started";
+      continue;
+    }
   }
 
   return apps_to_update;

--- a/src/composeappmanager.cc
+++ b/src/composeappmanager.cc
@@ -128,21 +128,12 @@ ComposeAppManager::AppsContainer ComposeAppManager::getAppsToUpdate(const Uptane
       continue;
     }
 
-    if (!boost::filesystem::exists(cfg_.apps_root / app_name) ||
-        !boost::filesystem::exists(cfg_.apps_root / app_name / Docker::ComposeAppEngine::ComposeFile)) {
+    if (!app_engine_->isInstalled({app_name, app_pair.second})) {
       // an App is supposed to be installed, has been removed somehow, or a new app was added to the app shortlist
       apps_to_update.insert(app_pair);
       LOG_INFO << app_name << " will be re-installed";
       continue;
     }
-
-//    LOG_DEBUG << app_name << " performing full status check";
-//    if (!app_engine_->isRunning({app_name, app_pair.second})) {
-//      // an App that is supposed to be installed and running is not fully installed or running
-//      apps_to_update.insert(app_pair);
-//      LOG_INFO << app_name << " update will be re-installed or completed";
-//      continue;
-//    }
   }
 
   return apps_to_update;

--- a/src/docker/composeappengine.cc
+++ b/src/docker/composeappengine.cc
@@ -68,6 +68,13 @@ bool ComposeAppEngine::isRunning(const App& app) const {
   return false;
 }
 
+bool ComposeAppEngine::isInstalled(const App& app) const {
+  // make sure the App root dir and compose file exists
+  bool result = boost::filesystem::exists(appRoot(app)) &&
+                boost::filesystem::exists(appRoot(app) / Docker::ComposeAppEngine::ComposeFile);
+  return result;
+}
+
 std::string ComposeAppEngine::runningApps() const { return docker_client_->runningApps(); }
 
 // Private implementation

--- a/src/docker/composeappengine.h
+++ b/src/docker/composeappengine.h
@@ -26,6 +26,7 @@ class ComposeAppEngine : public AppEngine {
   bool run(const App& app) override;
   void remove(const App& app) override;
   bool isRunning(const App& app) const override;
+  bool isInstalled(const App& app) const override;
   std::string runningApps() const override;
 
  private:

--- a/src/docker/composeappengine.h
+++ b/src/docker/composeappengine.h
@@ -37,6 +37,10 @@ class ComposeAppEngine : public AppEngine {
   void extractAppArchive(const App& app, const std::string& archive_file_name, bool delete_after_extraction = true);
   boost::filesystem::path appRoot(const App& app) const { return root_ / app.name; }
 
+  bool checkVersion(const App& app) const;
+  void setVersion(const App& app) const;
+  boost::filesystem::path appVersionFile(const App& app) const { return appRoot(app) / ".meta" / "version"; }
+
  private:
   const boost::filesystem::path root_;
   const std::string compose_;

--- a/src/docker/composeappengine.h
+++ b/src/docker/composeappengine.h
@@ -40,6 +40,7 @@ class ComposeAppEngine : public AppEngine {
   bool checkVersion(const App& app) const;
   void setVersion(const App& app) const;
   boost::filesystem::path appVersionFile(const App& app) const { return appRoot(app) / ".meta" / "version"; }
+  bool areAppImagesPulled(const App& app) const;
 
  private:
   const boost::filesystem::path root_;

--- a/src/docker/composeappengine.h
+++ b/src/docker/composeappengine.h
@@ -25,8 +25,8 @@ class ComposeAppEngine : public AppEngine {
   bool install(const App& app) override;
   bool run(const App& app) override;
   void remove(const App& app) override;
-  bool isRunning(const App& app) const override;
   bool isInstalled(const App& app) const override;
+  bool isStarted(const App& app) const override;
   std::string runningApps() const override;
 
  private:
@@ -41,6 +41,7 @@ class ComposeAppEngine : public AppEngine {
   void setVersion(const App& app) const;
   boost::filesystem::path appVersionFile(const App& app) const { return appRoot(app) / ".meta" / "version"; }
   bool areAppImagesPulled(const App& app) const;
+  bool areAppServicesStarted(const App& app) const;
 
  private:
   const boost::filesystem::path root_;

--- a/src/docker/dockerclient.cc
+++ b/src/docker/dockerclient.cc
@@ -12,22 +12,6 @@ DockerClient::HttpClientFactory DockerClient::DefaultHttpClientFactory = []() {
 
 DockerClient::DockerClient(std::shared_ptr<HttpInterface> http_client) : http_client_{std::move(http_client)} {}
 
-bool DockerClient::isRunning(const std::string& app, const std::string& service, const std::string& hash) {
-  Json::Value root;
-  refresh(root);
-  for (Json::ValueIterator ii = root.begin(); ii != root.end(); ++ii) {
-    Json::Value val = *ii;
-    if (val["Labels"]["com.docker.compose.project"].asString() == app) {
-      if (val["Labels"]["com.docker.compose.service"].asString() == service) {
-        if (val["Labels"]["io.compose-spec.config-hash"].asString() == hash) {
-          return true;
-        }
-      }
-    }
-  }
-  return false;
-}
-
 bool DockerClient::getImages(Json::Value& images) {
   const auto* const cmd = "http://localhost/images/json";
   auto resp = http_client_->get(cmd, HttpInterface::kNoLimit);
@@ -50,6 +34,40 @@ bool DockerClient::getImages(Json::Value& images) {
 
 bool DockerClient::isImagePresent(const Json::Value& images, const std::string& image_url) {
   return images.isMember(image_url);
+}
+
+bool DockerClient::getContainers(Json::Value& containers) {
+  const auto* const cmd = "http://localhost/containers/json?all=1";
+  auto resp = http_client_->get(cmd, HttpInterface::kNoLimit);
+  if (!resp.isOk()) {
+    return false;
+  }
+
+  bool result{false};
+  try {
+    Json::Value cont_all = resp.getJson();
+    for (Json::ValueConstIterator ii = cont_all.begin(); ii != cont_all.end(); ++ii) {
+      const auto image_url = (*ii)["Image"].asString();
+      containers[image_url]["service"] = (*ii)["Labels"]["com.docker.compose.service"];
+      containers[(*ii)["Image"].asString()]["service_hash"] = (*ii)["Labels"].get("io.compose-spec.config-hash", "");
+      containers[(*ii)["Image"].asString()]["state"] = (*ii)["State"];
+    }
+    result = true;
+  } catch (const std::exception& e) {
+    LOG_ERROR << "Failed to parse received response: " << e.what();
+  }
+  return result;
+}
+
+bool DockerClient::isContainerStarted(const Json::Value& containers, const std::string& image_url,
+                                      const std::string& service, const std::string& service_hash) {
+  const auto& cont_info = containers.get(image_url, Json::nullValue);
+  if (cont_info.empty()) {
+    return false;
+  }
+
+  return cont_info["service"] == service && cont_info["service_hash"] == service_hash &&
+         (cont_info["state"] == "running" || cont_info["state"] == "exited" || cont_info["state"] == "dead");
 }
 
 std::string DockerClient::runningApps() {

--- a/src/docker/dockerclient.cc
+++ b/src/docker/dockerclient.cc
@@ -28,6 +28,30 @@ bool DockerClient::isRunning(const std::string& app, const std::string& service,
   return false;
 }
 
+bool DockerClient::getImages(Json::Value& images) {
+  const auto* const cmd = "http://localhost/images/json";
+  auto resp = http_client_->get(cmd, HttpInterface::kNoLimit);
+  if (!resp.isOk()) {
+    return false;
+  }
+
+  bool result{false};
+  try {
+    Json::Value images_all = resp.getJson();
+    for (Json::ValueConstIterator ii = images_all.begin(); ii != images_all.end(); ++ii) {
+      images[(*ii)["RepoDigests"][0].asString()] = "";
+    }
+    result = true;
+  } catch (const std::exception& e) {
+    LOG_ERROR << "Failed to parse received response: " << e.what();
+  }
+  return result;
+}
+
+bool DockerClient::isImagePresent(const Json::Value& images, const std::string& image_url) {
+  return images.isMember(image_url);
+}
+
 std::string DockerClient::runningApps() {
   std::string runningApps;
   Json::Value root;

--- a/src/docker/dockerclient.h
+++ b/src/docker/dockerclient.h
@@ -16,10 +16,15 @@ class DockerClient {
 
  public:
   DockerClient(std::shared_ptr<HttpInterface> http_client = DefaultHttpClientFactory());
+
   std::string runningApps();
-  bool isRunning(const std::string& app, const std::string& service, const std::string& hash);
+
   bool getImages(Json::Value& images);
   static bool isImagePresent(const Json::Value& images, const std::string& image_url);
+
+  bool getContainers(Json::Value& containers);
+  static bool isContainerStarted(const Json::Value& containers, const std::string& image_url,
+                                 const std::string& service, const std::string& service_hash);
 
  private:
   void refresh(Json::Value& root);

--- a/src/docker/dockerclient.h
+++ b/src/docker/dockerclient.h
@@ -18,6 +18,8 @@ class DockerClient {
   DockerClient(std::shared_ptr<HttpInterface> http_client = DefaultHttpClientFactory());
   std::string runningApps();
   bool isRunning(const std::string& app, const std::string& service, const std::string& hash);
+  bool getImages(Json::Value& images);
+  static bool isImagePresent(const Json::Value& images, const std::string& image_url);
 
  private:
   void refresh(Json::Value& root);

--- a/tests/aklite_test.cc
+++ b/tests/aklite_test.cc
@@ -59,6 +59,7 @@ TEST_F(AkliteTest, AppUpdate) {
 
   updateApps(*client, getInitialTarget(), target01);
   ASSERT_TRUE(targetsMatch(client->getCurrent(), target01));
+  ASSERT_TRUE(app_engine->isInstalled(app01));
   ASSERT_TRUE(app_engine->isRunning(app01));
 
   // update app
@@ -66,6 +67,7 @@ TEST_F(AkliteTest, AppUpdate) {
   auto target02 = createAppTarget({app01_updated});
   updateApps(*client, target01, target02);
   ASSERT_TRUE(targetsMatch(client->getCurrent(), target02));
+  ASSERT_TRUE(app_engine->isInstalled(app01_updated));
   ASSERT_TRUE(app_engine->isRunning(app01_updated));
 }
 
@@ -83,11 +85,13 @@ TEST_F(AkliteTest, OstreeAndAppUpdate) {
   update(*client, getInitialTarget(), new_target);
   // make sure that the installed Target is not "finalized"/applied and Apps are not running
   ASSERT_TRUE(targetsMatch(client->getCurrent(), getInitialTarget()));
+  ASSERT_TRUE(app_engine->isInstalled(app01));
   ASSERT_FALSE(app_engine->isRunning(app01));
 
   reboot(client);
   ASSERT_TRUE(targetsMatch(client->getCurrent(), new_target));
   checkHeaders(*client, new_target);
+  ASSERT_TRUE(app_engine->isInstalled(app01));
   ASSERT_TRUE(app_engine->isRunning(app01));
   checkEvents(*client, new_target, UpdateType::kOstree);
 }
@@ -107,6 +111,8 @@ TEST_F(AkliteTest, OstreeAndAppUpdateWithShortlist) {
   update(*client, getInitialTarget(), new_target);
   // make sure that the installed Target is not "finalized"/applied and Apps are not running
   ASSERT_TRUE(targetsMatch(client->getCurrent(), getInitialTarget()));
+  ASSERT_FALSE(app_engine->isInstalled(app01));
+  ASSERT_TRUE(app_engine->isInstalled(app02));
   ASSERT_FALSE(app_engine->isRunning(app01));
   ASSERT_FALSE(app_engine->isRunning(app02));
 
@@ -114,6 +120,8 @@ TEST_F(AkliteTest, OstreeAndAppUpdateWithShortlist) {
   ASSERT_TRUE(targetsMatch(client->getCurrent(), new_target));
   checkHeaders(*client, new_target);
   checkEvents(*client, new_target, UpdateType::kOstree);
+  ASSERT_FALSE(app_engine->isInstalled(app01));
+  ASSERT_TRUE(app_engine->isInstalled(app02));
   ASSERT_FALSE(app_engine->isRunning(app01));
   ASSERT_TRUE(app_engine->isRunning(app02));
 }
@@ -133,6 +141,8 @@ TEST_F(AkliteTest, OstreeAndAppUpdateWithEmptyShortlist) {
   update(*client, getInitialTarget(), new_target);
   // make sure that the installed Target is not "finalized"/applied and Apps are not running
   ASSERT_TRUE(targetsMatch(client->getCurrent(), getInitialTarget()));
+  ASSERT_FALSE(app_engine->isInstalled(app01));
+  ASSERT_FALSE(app_engine->isInstalled(app02));
   ASSERT_FALSE(app_engine->isRunning(app01));
   ASSERT_FALSE(app_engine->isRunning(app02));
 
@@ -140,6 +150,8 @@ TEST_F(AkliteTest, OstreeAndAppUpdateWithEmptyShortlist) {
   ASSERT_TRUE(targetsMatch(client->getCurrent(), new_target));
   checkHeaders(*client, new_target);
   checkEvents(*client, new_target, UpdateType::kOstree);
+  ASSERT_FALSE(app_engine->isInstalled(app01));
+  ASSERT_FALSE(app_engine->isInstalled(app02));
   ASSERT_FALSE(app_engine->isRunning(app01));
   ASSERT_FALSE(app_engine->isRunning(app02));
 }
@@ -174,6 +186,7 @@ TEST_F(AkliteTest, OstreeAndAppUpdateIfRollback) {
     auto target_02 = createTarget(&apps);
     // update to the latest version
     update(*client, target_01, target_02);
+    ASSERT_TRUE(app_engine->isInstalled(app01_updated));
     // deploy the previous version/commit to emulate rollback
     getSysRepo().deploy(target_01.sha256Hash());
 

--- a/tests/aklite_test.cc
+++ b/tests/aklite_test.cc
@@ -196,13 +196,17 @@ TEST_F(AkliteTest, OstreeAndAppUpdateIfRollback) {
     // we stopped the original app before update
     ASSERT_FALSE(app_engine->isRunning(app01));
     ASSERT_FALSE(app_engine->isRunning(app01_updated));
+    // just after reboot the updated app is still installed
+    ASSERT_TRUE(app_engine->isInstalled(app01_updated));
     checkHeaders(*client, target_01);
     checkEvents(*client, target_01, UpdateType::kOstree);
 
     // emulate do_app_sync
     updateApps(*client, target_01, client->getCurrent());
     ASSERT_TRUE(targetsMatch(client->getCurrent(), target_01));
+    // app rollback
     ASSERT_TRUE(app_engine->isRunning(app01));
+    ASSERT_TRUE(app_engine->isInstalled(app01));
   }
 }
 

--- a/tests/aklite_test.cc
+++ b/tests/aklite_test.cc
@@ -31,7 +31,7 @@ TEST_F(AkliteTest, OstreeUpdate) {
 
   auto client = createLiteClient();
   ASSERT_TRUE(targetsMatch(client->getCurrent(), getInitialTarget()));
-  ASSERT_FALSE(app_engine->isRunning(app01));
+  ASSERT_FALSE(app_engine->isStarted(app01));
 
   auto new_target = createTarget();
 
@@ -39,13 +39,13 @@ TEST_F(AkliteTest, OstreeUpdate) {
   update(*client, getInitialTarget(), new_target);
   // make sure that the installed Target is not "finalized"/applied and Apps are not running
   ASSERT_TRUE(targetsMatch(client->getCurrent(), getInitialTarget()));
-  ASSERT_FALSE(app_engine->isRunning(app01));
+  ASSERT_FALSE(app_engine->isStarted(app01));
 
   reboot(client);
   ASSERT_TRUE(targetsMatch(client->getCurrent(), new_target));
   checkHeaders(*client, new_target);
   checkEvents(*client, new_target, UpdateType::kOstree);
-  ASSERT_FALSE(app_engine->isRunning(app01));
+  ASSERT_FALSE(app_engine->isStarted(app01));
 }
 
 TEST_F(AkliteTest, AppUpdate) {
@@ -53,14 +53,14 @@ TEST_F(AkliteTest, AppUpdate) {
 
   auto client = createLiteClient();
   ASSERT_TRUE(targetsMatch(client->getCurrent(), getInitialTarget()));
-  ASSERT_FALSE(app_engine->isRunning(app01));
+  ASSERT_FALSE(app_engine->isStarted(app01));
 
   auto target01 = createAppTarget({app01});
 
   updateApps(*client, getInitialTarget(), target01);
   ASSERT_TRUE(targetsMatch(client->getCurrent(), target01));
   ASSERT_TRUE(app_engine->isInstalled(app01));
-  ASSERT_TRUE(app_engine->isRunning(app01));
+  ASSERT_TRUE(app_engine->isStarted(app01));
 
   // update app
   auto app01_updated = registry.addApp(fixtures::ComposeApp::create("app-01", "service-01", "image-02"));
@@ -68,7 +68,7 @@ TEST_F(AkliteTest, AppUpdate) {
   updateApps(*client, target01, target02);
   ASSERT_TRUE(targetsMatch(client->getCurrent(), target02));
   ASSERT_TRUE(app_engine->isInstalled(app01_updated));
-  ASSERT_TRUE(app_engine->isRunning(app01_updated));
+  ASSERT_TRUE(app_engine->isStarted(app01_updated));
 }
 
 TEST_F(AkliteTest, OstreeAndAppUpdate) {
@@ -76,7 +76,7 @@ TEST_F(AkliteTest, OstreeAndAppUpdate) {
 
   auto client = createLiteClient();
   ASSERT_TRUE(targetsMatch(client->getCurrent(), getInitialTarget()));
-  ASSERT_FALSE(app_engine->isRunning(app01));
+  ASSERT_FALSE(app_engine->isStarted(app01));
 
   std::vector<AppEngine::App> apps{app01};
   auto new_target = createTarget(&apps);
@@ -86,13 +86,13 @@ TEST_F(AkliteTest, OstreeAndAppUpdate) {
   // make sure that the installed Target is not "finalized"/applied and Apps are not running
   ASSERT_TRUE(targetsMatch(client->getCurrent(), getInitialTarget()));
   ASSERT_TRUE(app_engine->isInstalled(app01));
-  ASSERT_FALSE(app_engine->isRunning(app01));
+  ASSERT_FALSE(app_engine->isStarted(app01));
 
   reboot(client);
   ASSERT_TRUE(targetsMatch(client->getCurrent(), new_target));
   checkHeaders(*client, new_target);
   ASSERT_TRUE(app_engine->isInstalled(app01));
-  ASSERT_TRUE(app_engine->isRunning(app01));
+  ASSERT_TRUE(app_engine->isStarted(app01));
   checkEvents(*client, new_target, UpdateType::kOstree);
 }
 
@@ -113,8 +113,8 @@ TEST_F(AkliteTest, OstreeAndAppUpdateWithShortlist) {
   ASSERT_TRUE(targetsMatch(client->getCurrent(), getInitialTarget()));
   ASSERT_FALSE(app_engine->isInstalled(app01));
   ASSERT_TRUE(app_engine->isInstalled(app02));
-  ASSERT_FALSE(app_engine->isRunning(app01));
-  ASSERT_FALSE(app_engine->isRunning(app02));
+  ASSERT_FALSE(app_engine->isStarted(app01));
+  ASSERT_FALSE(app_engine->isStarted(app02));
 
   reboot(client);
   ASSERT_TRUE(targetsMatch(client->getCurrent(), new_target));
@@ -122,8 +122,8 @@ TEST_F(AkliteTest, OstreeAndAppUpdateWithShortlist) {
   checkEvents(*client, new_target, UpdateType::kOstree);
   ASSERT_FALSE(app_engine->isInstalled(app01));
   ASSERT_TRUE(app_engine->isInstalled(app02));
-  ASSERT_FALSE(app_engine->isRunning(app01));
-  ASSERT_TRUE(app_engine->isRunning(app02));
+  ASSERT_FALSE(app_engine->isStarted(app01));
+  ASSERT_TRUE(app_engine->isStarted(app02));
 }
 
 TEST_F(AkliteTest, OstreeAndAppUpdateWithEmptyShortlist) {
@@ -143,8 +143,8 @@ TEST_F(AkliteTest, OstreeAndAppUpdateWithEmptyShortlist) {
   ASSERT_TRUE(targetsMatch(client->getCurrent(), getInitialTarget()));
   ASSERT_FALSE(app_engine->isInstalled(app01));
   ASSERT_FALSE(app_engine->isInstalled(app02));
-  ASSERT_FALSE(app_engine->isRunning(app01));
-  ASSERT_FALSE(app_engine->isRunning(app02));
+  ASSERT_FALSE(app_engine->isStarted(app01));
+  ASSERT_FALSE(app_engine->isStarted(app02));
 
   reboot(client);
   ASSERT_TRUE(targetsMatch(client->getCurrent(), new_target));
@@ -152,8 +152,8 @@ TEST_F(AkliteTest, OstreeAndAppUpdateWithEmptyShortlist) {
   checkEvents(*client, new_target, UpdateType::kOstree);
   ASSERT_FALSE(app_engine->isInstalled(app01));
   ASSERT_FALSE(app_engine->isInstalled(app02));
-  ASSERT_FALSE(app_engine->isRunning(app01));
-  ASSERT_FALSE(app_engine->isRunning(app02));
+  ASSERT_FALSE(app_engine->isStarted(app01));
+  ASSERT_FALSE(app_engine->isStarted(app02));
 }
 
 TEST_F(AkliteTest, OstreeAndAppUpdateIfRollback) {
@@ -176,7 +176,7 @@ TEST_F(AkliteTest, OstreeAndAppUpdateIfRollback) {
     ASSERT_TRUE(targetsMatch(client->getCurrent(), target_01));
     checkHeaders(*client, target_01);
     checkEvents(*client, target_01, UpdateType::kOstree);
-    ASSERT_TRUE(app_engine->isRunning(app01));
+    ASSERT_TRUE(app_engine->isStarted(app01));
   }
 
   {
@@ -194,8 +194,8 @@ TEST_F(AkliteTest, OstreeAndAppUpdateIfRollback) {
     // make sure that a rollback has happened and a client is still running the previous Target
     ASSERT_TRUE(targetsMatch(client->getCurrent(), target_01));
     // we stopped the original app before update
-    ASSERT_FALSE(app_engine->isRunning(app01));
-    ASSERT_FALSE(app_engine->isRunning(app01_updated));
+    ASSERT_FALSE(app_engine->isStarted(app01));
+    ASSERT_FALSE(app_engine->isStarted(app01_updated));
     // just after reboot the updated app is still installed
     ASSERT_TRUE(app_engine->isInstalled(app01_updated));
     checkHeaders(*client, target_01);
@@ -205,7 +205,7 @@ TEST_F(AkliteTest, OstreeAndAppUpdateIfRollback) {
     updateApps(*client, target_01, client->getCurrent());
     ASSERT_TRUE(targetsMatch(client->getCurrent(), target_01));
     // app rollback
-    ASSERT_TRUE(app_engine->isRunning(app01));
+    ASSERT_TRUE(app_engine->isStarted(app01));
     ASSERT_TRUE(app_engine->isInstalled(app01));
   }
 }

--- a/tests/composeappengine_test.cc
+++ b/tests/composeappengine_test.cc
@@ -18,23 +18,23 @@ class ComposeAppEngineTest : public fixtures::AppEngineTest {};
 TEST_F(ComposeAppEngineTest, Fetch) {
   auto app = registry.addApp(fixtures::ComposeApp::create("app-01"));
   ASSERT_TRUE(app_engine->fetch(app));
-  // TODO: AppEngine API doesn't provide mean(s) to check if App is fetched
-  ASSERT_FALSE(app_engine->isRunning(app));
+  ASSERT_TRUE(app_engine->isInstalled(app));
+  ASSERT_FALSE(app_engine->isStarted(app));
 }
 
 TEST_F(ComposeAppEngineTest, FetchAndInstall) {
   auto app = registry.addApp(fixtures::ComposeApp::create("app-01"));
   ASSERT_TRUE(app_engine->fetch(app));
-  // TODO: AppEngine API doesn't provide mean(s) to check if App is installed
-  ASSERT_TRUE(app_engine->install(app));
-  ASSERT_FALSE(app_engine->isRunning(app));
+  ASSERT_TRUE(app_engine->isInstalled(app));
+  ASSERT_FALSE(app_engine->isStarted(app));
 }
 
 TEST_F(ComposeAppEngineTest, FetchAndRun) {
   auto app = registry.addApp(fixtures::ComposeApp::create("app-01"));
   ASSERT_TRUE(app_engine->fetch(app));
   ASSERT_TRUE(app_engine->run(app));
-  ASSERT_TRUE(app_engine->isRunning(app));
+  ASSERT_TRUE(app_engine->isInstalled(app));
+  ASSERT_TRUE(app_engine->isStarted(app));
 }
 
 TEST_F(ComposeAppEngineTest, FetchInstallAndRun) {
@@ -42,23 +42,27 @@ TEST_F(ComposeAppEngineTest, FetchInstallAndRun) {
   ASSERT_TRUE(app_engine->fetch(app));
   ASSERT_TRUE(app_engine->install(app));
   ASSERT_TRUE(app_engine->run(app));
-  ASSERT_TRUE(app_engine->isRunning(app));
+  ASSERT_TRUE(app_engine->isInstalled(app));
+  ASSERT_TRUE(app_engine->isStarted(app));
 }
 
 TEST_F(ComposeAppEngineTest, FetchRunAndUpdate) {
   auto app = registry.addApp(fixtures::ComposeApp::create("app-01"));
   ASSERT_TRUE(app_engine->fetch(app));
   ASSERT_TRUE(app_engine->run(app));
-  ASSERT_TRUE(app_engine->isRunning(app));
+  ASSERT_TRUE(app_engine->isInstalled(app));
+  ASSERT_TRUE(app_engine->isStarted(app));
 
   // update App, image URL has changed
   auto updated_app = registry.addApp(fixtures::ComposeApp::create("app-01", "service-01", "image-02"));
   ASSERT_TRUE(app_engine->fetch(updated_app));
-  ASSERT_FALSE(app_engine->isRunning(updated_app));
+  ASSERT_TRUE(app_engine->isInstalled(updated_app));
+  ASSERT_FALSE(app_engine->isStarted(updated_app));
 
   // run updated App
   ASSERT_TRUE(app_engine->run(updated_app));
-  ASSERT_TRUE(app_engine->isRunning(updated_app));
+  ASSERT_TRUE(app_engine->isInstalled(updated_app));
+  ASSERT_TRUE(app_engine->isStarted(updated_app));
 }
 
 TEST_F(ComposeAppEngineTest, FetchRunCompare) {
@@ -69,12 +73,14 @@ TEST_F(ComposeAppEngineTest, FetchRunCompare) {
   std::string id = boost::str(format % "app-02" % "service-02");
 
   ASSERT_TRUE(app_engine->fetch(updated_app));
-  ASSERT_FALSE(app_engine->isRunning(updated_app));
+  ASSERT_TRUE(app_engine->isInstalled(updated_app));
+  ASSERT_FALSE(app_engine->isStarted(updated_app));
   ASSERT_FALSE(boost::icontains(app_engine->runningApps(), id));
 
   // run updated App
   ASSERT_TRUE(app_engine->run(updated_app));
-  ASSERT_TRUE(app_engine->isRunning(updated_app));
+  ASSERT_TRUE(app_engine->isInstalled(updated_app));
+  ASSERT_TRUE(app_engine->isStarted(updated_app));
   ASSERT_TRUE(boost::icontains(app_engine->runningApps(), id));
 }
 

--- a/tests/docker-compose_fake.py
+++ b/tests/docker-compose_fake.py
@@ -26,6 +26,8 @@ def up(out_dir, app_name, compose, flags):
         container["Labels"]["com.docker.compose.project"] = app_name
         container["Labels"]["com.docker.compose.service"] = service
         container["Labels"]["io.compose-spec.config-hash"] = compose["services"][service]["labels"]["io.compose-spec.config-hash"]
+        container["State"] = "running"
+        container["Image"] = compose["services"][service]["image"]
         containers.append(container)
 
     with open(os.path.join(out_dir, "containers.json"), "w") as f:

--- a/tests/docker-compose_fake.py
+++ b/tests/docker-compose_fake.py
@@ -26,7 +26,8 @@ def up(out_dir, app_name, compose, flags):
         container["Labels"]["com.docker.compose.project"] = app_name
         container["Labels"]["com.docker.compose.service"] = service
         container["Labels"]["io.compose-spec.config-hash"] = compose["services"][service]["labels"]["io.compose-spec.config-hash"]
-        container["State"] = "running"
+        logger.info(compose["services"][service]["restart"])
+        container["State"] = "exited" if compose["services"][service]["restart"] == "no" else "running"
         container["Image"] = compose["services"][service]["image"]
         containers.append(container)
 

--- a/tests/docker-compose_fake.py
+++ b/tests/docker-compose_fake.py
@@ -32,6 +32,22 @@ def up(out_dir, app_name, compose, flags):
         json.dump(containers, f)
 
 
+def pull(out_dir, app_name, compose):
+    logger.info("Pull images...")
+    with open(os.path.join(out_dir, "images.json"), "r") as f:
+        images = json.load(f)
+
+    for service in compose["services"]:
+        image = {"RepoDigests": []}
+        image_url = compose["services"][service]["image"]
+        logger.info("Pull image: " + image_url)
+        image["RepoDigests"].append(image_url)
+        images.append(image)
+
+    with open(os.path.join(out_dir, "images.json"), "w") as f:
+        json.dump(images, f)
+
+
 def main():
     exit_code = 0
     try:
@@ -49,6 +65,8 @@ def main():
         app_name = os.path.basename(os.getcwd())
         if cmd == "up":
             up(out_dir, app_name, compose, sys.argv[3:])
+        elif cmd == "pull":
+            pull(out_dir, app_name, compose)
     except Exception as exc:
         logger.error("Failed to process compose file: {}\n{}".format(exc, traceback.format_exc()))
         exit_code = 1

--- a/tests/fixtures/composeapp.cc
+++ b/tests/fixtures/composeapp.cc
@@ -7,6 +7,7 @@ class ComposeApp {
     services:
       %s:
         image: %s
+        restart: %s
         labels:
           io.compose-spec.config-hash: %s
     version: "3.2"
@@ -15,21 +16,23 @@ class ComposeApp {
   const std::string ServiceTemplate = R"(
     %s:
       image: %s
+      restart: %s
     )";
 
  public:
   static Ptr create(const std::string& name,
-                    const std::string& service = "service-01", const std::string& image = "image-01") {
+                    const std::string& service = "service-01", const std::string& image = "image-01",
+                    const std::string& restart = "always") {
     Ptr app{new ComposeApp(name)};
-    app->updateService(service, image);
+    app->updateService(service, image, restart);
     return app;
   }
 
-  const std::string& updateService(const std::string& service, const std::string& image) {
+  const std::string& updateService(const std::string& service, const std::string& image, const std::string& restart) {
     char service_content[1024];
-    sprintf(service_content, ServiceTemplate.c_str(), service.c_str(), image.c_str());
+    sprintf(service_content, ServiceTemplate.c_str(), service.c_str(), image.c_str(), restart.c_str());
     auto service_hash = boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha256digest(service_content)));
-    sprintf(content_, DefaultTemplate.c_str(), service.c_str(), image.c_str(), service_hash.c_str());
+    sprintf(content_, DefaultTemplate.c_str(), service.c_str(), image.c_str(), restart.c_str(), service_hash.c_str());
     return update();
   }
 

--- a/tests/fixtures/dockerdaemon.cc
+++ b/tests/fixtures/dockerdaemon.cc
@@ -6,21 +6,32 @@ class DockerDaemon {
  public:
   // tests/docker-compose_fake.py fills/populates this file with "running" containers
   static constexpr const char* const ContainersFile{"containers.json"};
+  static constexpr const char* const ImagesFile{"images.json"};
  public:
   DockerDaemon(boost::filesystem::path dir): dir_{std::move(dir)} {
-    // zero containers are running in the beginning
+    // zero containers are pulled and running in the beginning
     Utils::writeFile(dir_ / ContainersFile, std::string("[]"), true);
+    Utils::writeFile(dir_ / ImagesFile, std::string("[]"), true);
   }
 
   std::shared_ptr<HttpInterface> getClient() { return std::make_shared<DockerDaemon::HttpClient>(*this); }
   const boost::filesystem::path& dir() const { return dir_; }
   std::string getRunningContainers() const { return Utils::readFile(dir_ / ContainersFile); }
+  std::string getPulledImages() const { return Utils::readFile(dir_ / ImagesFile); }
 
  private:
   class HttpClient: public BaseHttpClient {
    public:
     HttpClient(DockerDaemon& daemon):daemon_{daemon} {}
-    HttpResponse get(const std::string &url, int64_t maxsize) override { return HttpResponse(daemon_.getRunningContainers(), 200, CURLE_OK, ""); }
+    HttpResponse get(const std::string &url, int64_t maxsize) override {
+      if (url.find("/images") != std::string::npos) {
+        return HttpResponse(daemon_.getPulledImages(), 200, CURLE_OK, "");
+      } else if (url.find("/containers") != std::string::npos) {
+        return HttpResponse(daemon_.getRunningContainers(), 200, CURLE_OK, "");
+      } else {
+        return HttpResponse("", 400, CURLE_OK, "Bad Request");
+      }
+    }
    private:
     DockerDaemon& daemon_;
   };

--- a/tests/liteclientHSM_test.cc
+++ b/tests/liteclientHSM_test.cc
@@ -40,6 +40,7 @@ class MockAppEngine : public AppEngine {
     ON_CALL(*this, install).WillByDefault(Return(true));
     ON_CALL(*this, run).WillByDefault(Return(true));
     ON_CALL(*this, isRunning).WillByDefault(Return(true));
+    ON_CALL(*this, isInstalled).WillByDefault(Return(true));
     ON_CALL(*this, runningApps)
         .WillByDefault(Return(
             "Apps(app-01) Service(test-factory 7ca42b1567ca068dfd6a5392432a5a36700a4aa3e321922e91d974f832a2f243"));
@@ -51,6 +52,7 @@ class MockAppEngine : public AppEngine {
   MOCK_METHOD(bool, run, (const App& app), (override));
   MOCK_METHOD(void, remove, (const App& app), (override));
   MOCK_METHOD(bool, isRunning, (const App& app), (const, override));
+  MOCK_METHOD(bool, isInstalled, (const App& app), (const, override));
   MOCK_METHOD(std::string, runningApps, (), (const, override));
 };
 

--- a/tests/liteclientHSM_test.cc
+++ b/tests/liteclientHSM_test.cc
@@ -39,8 +39,8 @@ class MockAppEngine : public AppEngine {
     ON_CALL(*this, fetch).WillByDefault(Return(true));
     ON_CALL(*this, install).WillByDefault(Return(true));
     ON_CALL(*this, run).WillByDefault(Return(true));
-    ON_CALL(*this, isRunning).WillByDefault(Return(true));
     ON_CALL(*this, isInstalled).WillByDefault(Return(true));
+    ON_CALL(*this, isStarted).WillByDefault(Return(true));
     ON_CALL(*this, runningApps)
         .WillByDefault(Return(
             "Apps(app-01) Service(test-factory 7ca42b1567ca068dfd6a5392432a5a36700a4aa3e321922e91d974f832a2f243"));
@@ -51,8 +51,8 @@ class MockAppEngine : public AppEngine {
   MOCK_METHOD(bool, install, (const App& app), (override));
   MOCK_METHOD(bool, run, (const App& app), (override));
   MOCK_METHOD(void, remove, (const App& app), (override));
-  MOCK_METHOD(bool, isRunning, (const App& app), (const, override));
   MOCK_METHOD(bool, isInstalled, (const App& app), (const, override));
+  MOCK_METHOD(bool, isStarted, (const App& app), (const, override));
   MOCK_METHOD(std::string, runningApps, (), (const, override));
 };
 
@@ -87,7 +87,7 @@ TEST_F(LiteClientHSMTest, OstreeAndAppUpdate) {
     EXPECT_CALL(*getAppEngine(), fetch).Times(1);
 
     // since the Target/app is not installed then no reason to check if the app is running
-    EXPECT_CALL(*getAppEngine(), isRunning).Times(0);
+    EXPECT_CALL(*getAppEngine(), isStarted).Times(0);
 
     // Just install no need too call run
     EXPECT_CALL(*getAppEngine(), install).Times(1);
@@ -116,7 +116,7 @@ TEST_F(LiteClientHSMTest, AppUpdate) {
   EXPECT_CALL(*getAppEngine(), fetch).Times(1);
 
   // since the Target/app is not installed then no reason to check if the app is running
-  EXPECT_CALL(*getAppEngine(), isRunning).Times(0);
+  EXPECT_CALL(*getAppEngine(), isStarted).Times(0);
   EXPECT_CALL(*getAppEngine(), install).Times(0);
 
   // just call run which includes install if necessary (no ostree update case)

--- a/tests/liteclient_test.cc
+++ b/tests/liteclient_test.cc
@@ -40,6 +40,7 @@ class MockAppEngine : public AppEngine {
     ON_CALL(*this, install).WillByDefault(Return(true));
     ON_CALL(*this, run).WillByDefault(Return(true));
     ON_CALL(*this, isRunning).WillByDefault(Return(true));
+    ON_CALL(*this, isInstalled).WillByDefault(Return(true));
     ON_CALL(*this, runningApps)
         .WillByDefault(
             Return("Apps(app-07) Service(nginx-07 16e36b4ab48cb19c7100a22686f85ffcbdce5694c936bda03cb12a2cce88efcf"));
@@ -51,6 +52,7 @@ class MockAppEngine : public AppEngine {
   MOCK_METHOD(bool, run, (const App& app), (override));
   MOCK_METHOD(void, remove, (const App& app), (override));
   MOCK_METHOD(bool, isRunning, (const App& app), (const, override));
+  MOCK_METHOD(bool, isInstalled, (const App& app), (const, override));
   MOCK_METHOD(std::string, runningApps, (), (const, override));
 };
 

--- a/tests/liteclient_test.cc
+++ b/tests/liteclient_test.cc
@@ -39,7 +39,7 @@ class MockAppEngine : public AppEngine {
     ON_CALL(*this, fetch).WillByDefault(Return(true));
     ON_CALL(*this, install).WillByDefault(Return(true));
     ON_CALL(*this, run).WillByDefault(Return(true));
-    ON_CALL(*this, isRunning).WillByDefault(Return(true));
+    ON_CALL(*this, isStarted).WillByDefault(Return(true));
     ON_CALL(*this, isInstalled).WillByDefault(Return(true));
     ON_CALL(*this, runningApps)
         .WillByDefault(
@@ -51,8 +51,8 @@ class MockAppEngine : public AppEngine {
   MOCK_METHOD(bool, install, (const App& app), (override));
   MOCK_METHOD(bool, run, (const App& app), (override));
   MOCK_METHOD(void, remove, (const App& app), (override));
-  MOCK_METHOD(bool, isRunning, (const App& app), (const, override));
   MOCK_METHOD(bool, isInstalled, (const App& app), (const, override));
+  MOCK_METHOD(bool, isStarted, (const App& app), (const, override));
   MOCK_METHOD(std::string, runningApps, (), (const, override));
 };
 
@@ -238,7 +238,7 @@ TEST_F(LiteClientTest, AppUpdate) {
   EXPECT_CALL(*getAppEngine(), fetch).Times(1);
 
   // since the Target/app is not installed then no reason to check if the app is running
-  EXPECT_CALL(*getAppEngine(), isRunning).Times(0);
+  EXPECT_CALL(*getAppEngine(), isStarted).Times(0);
   EXPECT_CALL(*getAppEngine(), install).Times(0);
 
   // just call run which includes install if necessary (no ostree update case)
@@ -257,7 +257,7 @@ TEST_F(LiteClientTest, AppUpdateWithShortlist) {
 
   // update to the latest version
   EXPECT_CALL(*getAppEngine(), fetch).Times(1);
-  EXPECT_CALL(*getAppEngine(), isRunning).Times(0);
+  EXPECT_CALL(*getAppEngine(), isStarted).Times(0);
   EXPECT_CALL(*getAppEngine(), install).Times(0);
   // run should be called once since only one app is specified in the config
   EXPECT_CALL(*getAppEngine(), run).Times(1);
@@ -275,7 +275,7 @@ TEST_F(LiteClientTest, AppUpdateWithEmptyShortlist) {
 
   // update to the latest version, nothing should be called since an empty app list is specified in the config
   EXPECT_CALL(*getAppEngine(), fetch).Times(0);
-  EXPECT_CALL(*getAppEngine(), isRunning).Times(0);
+  EXPECT_CALL(*getAppEngine(), isStarted).Times(0);
   EXPECT_CALL(*getAppEngine(), install).Times(0);
   EXPECT_CALL(*getAppEngine(), run).Times(0);
 
@@ -295,7 +295,7 @@ TEST_F(LiteClientTest, OstreeAndAppUpdate) {
     EXPECT_CALL(*getAppEngine(), fetch).Times(1);
 
     // since the Target/app is not installed then no reason to check if the app is running
-    EXPECT_CALL(*getAppEngine(), isRunning).Times(0);
+    EXPECT_CALL(*getAppEngine(), isStarted).Times(0);
 
     // Just install no need too call run
     EXPECT_CALL(*getAppEngine(), install).Times(1);
@@ -325,7 +325,7 @@ TEST_F(LiteClientTest, AppUpdateDownloadFailure) {
   // update to the latest version
   // fetch retry for three times
   EXPECT_CALL(*getAppEngine(), fetch).Times(3);
-  EXPECT_CALL(*getAppEngine(), isRunning).Times(0);
+  EXPECT_CALL(*getAppEngine(), isStarted).Times(0);
   EXPECT_CALL(*getAppEngine(), install).Times(0);
   EXPECT_CALL(*getAppEngine(), run).Times(0);
 
@@ -345,7 +345,7 @@ TEST_F(LiteClientTest, AppUpdateInstallFailure) {
   // update to the latest version
   // fetch retry for three times
   EXPECT_CALL(*getAppEngine(), fetch).Times(1);
-  EXPECT_CALL(*getAppEngine(), isRunning).Times(0);
+  EXPECT_CALL(*getAppEngine(), isStarted).Times(0);
   EXPECT_CALL(*getAppEngine(), install).Times(0);
   EXPECT_CALL(*getAppEngine(), run).Times(1);
 
@@ -366,7 +366,7 @@ TEST_F(LiteClientTest, OstreeAndAppUpdateIfRollback) {
     EXPECT_CALL(*getAppEngine(), fetch).Times(1);
 
     // since the Target/app is not installed then no reason to check if the app is running
-    EXPECT_CALL(*getAppEngine(), isRunning).Times(0);
+    EXPECT_CALL(*getAppEngine(), isStarted).Times(0);
 
     // Just install no need too call run
     EXPECT_CALL(*getAppEngine(), install).Times(1);


### PR DESCRIPTION
aklite doesn't need to check if Apps' containers are running and
(re-)start them. Let docker-compose/docker to monitor and maintain container status.
https://github.com/compose-spec/compose-spec/blob/master/spec.md#restart

Signed-off-by: Mike Sul <mike.sul@foundries.io>