### PR TITLE
bootloader: fiovb: don't set bootupgrade_available

### DIFF
--- a/src/bootloader/rollbacks/fiovb.h
+++ b/src/bootloader/rollbacks/fiovb.h
@@ -29,9 +29,6 @@ class FiovbRollback : public Rollback {
     if (Utils::shell("fiovb_setenv rollback 0", &sink) != 0) {
       LOG_WARNING << "Failed resetting rollback flag";
     }
-    if (Utils::shell("fiovb_setenv bootupgrade_available 1", &sink) != 0) {
-      LOG_WARNING << "Failed to set bootupgrade_available";
-    }
   }
 
   void installNotify(const Uptane::Target& target) {


### PR DESCRIPTION
```
Don't set bootupgrade_available flag in UpdateNotify(), as
during that step we're not able to detect if we have boot firmware
updates (this is decided conditionally in InstallNotify()).

Reported-by: Tim Anderson <tim.anderson@foundries.io>
Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>
```