### PR TITLE
app: let dockerd manage App's container life

### DIFF
--- a/src/docker/dockerclient.cc
+++ b/src/docker/dockerclient.cc
@@ -48,14 +48,14 @@ std::string DockerClient::runningApps() {
 void DockerClient::refresh(Json::Value& root) {
   std::string cmd;
   if (!http_client_) {
-    cmd = "/usr/bin/curl --unix-socket /var/run/docker.sock http://localhost/containers/json";
+    cmd = "/usr/bin/curl --unix-socket /var/run/docker.sock http://localhost/containers/json?all=1";
     std::string data;
     if (Utils::shell(cmd, &data, false) == EXIT_SUCCESS) {
       std::istringstream sin(data);
       sin >> root;
     }
   } else {
-    cmd = "http://localhost/containers/json";
+    cmd = "http://localhost/containers/json?all=1";
     auto resp = http_client_->get(cmd, HttpInterface::kNoLimit);
     if (resp.isOk()) {
       root = resp.getJson();


### PR DESCRIPTION
Once aklite starts App by calling `docker-compose up` this is dockerd's
responsibility to manage App's containers lifecycle according to the
restart policy defined in the compose file.
Therefore, by getting a list of *all* containers, not just running one, we
make sure that aklite considers all successfully started App as running,
even though the App's container is actually not. It guarantees that
aklite won't restart such Apps and won't interfere with the dockerd's
container lifetime management.
For example, started container can end up at "exited" state (one-shot
app, restart: "no") or "restarting" state (restart: "on-failure"/"unless-stopped"/"always")
and aklite should NOT restart such App/container.

This is not an ideal solution to support the restart policy and "one-shot" apps but it doesn't make the current implementation worse (no new bugs/issues) and is quite minimalistic.

Signed-off-by: Mike Sul <mike.sul@foundries.io>