### PR TITLE
Store and make use of App update state

### DIFF
--- a/src/appengine.h
+++ b/src/appengine.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <string>
+#include "json/json.h"
 
 class AppEngine {
  public:
@@ -19,7 +20,7 @@ class AppEngine {
   virtual bool run(const App& app) = 0;
   virtual void remove(const App& app) = 0;
   virtual bool isRunning(const App& app) const = 0;
-  virtual std::string runningApps() const = 0;
+  virtual Json::Value getRunningAppsInfo() const = 0;
 
  public:
   virtual ~AppEngine() = default;

--- a/src/composeappmanager.cc
+++ b/src/composeappmanager.cc
@@ -282,15 +282,10 @@ data::InstallationResult ComposeAppManager::install(const Uptane::Target& target
 data::InstallationResult ComposeAppManager::finalizeInstall(const Uptane::Target& target) {
   auto ir = OstreeManager::finalizeInstall(target);
 
-  const auto& current_apps = getApps(target);
-  for (const auto& app_pair : current_apps) {
-    const auto& app_name = app_pair.first;
-    auto need_start_flag = cfg_.apps_root / app_name / Docker::ComposeAppEngine::NeedStartFile;
-    if (boost::filesystem::exists(need_start_flag)) {
-      if (ir.result_code.num_code == data::ResultCode::Numeric::kOk) {
-        app_engine_->run({app_pair.first, app_pair.second});
-      }
-      boost::filesystem::remove(need_start_flag);
+  if (ir.result_code.num_code == data::ResultCode::Numeric::kOk) {
+    // "finalize" (run) Apps that were pulled and created before reboot
+    for (const auto& app_pair : getApps(target)) {
+      app_engine_->run({app_pair.first, app_pair.second});
     }
   }
 

--- a/src/composeappmanager.h
+++ b/src/composeappmanager.h
@@ -54,7 +54,8 @@ class ComposeAppManager : public OstreeManager {
 
  private:
   std::string getCurrentHash() const override;
-  std::string runningApps() const;
+  Json::Value getRunningAppsInfo() const;
+  std::string getRunningAppsInfoForReport() const;
 
  private:
   Config cfg_;

--- a/src/docker/composeappengine.cc
+++ b/src/docker/composeappengine.cc
@@ -324,7 +324,6 @@ bool ComposeAppEngine::pullImages(const App& app) {
 
 bool ComposeAppEngine::installApp(const App& app) {
   LOG_INFO << "Installing App";
-  boost::filesystem::ofstream flag_file(appRoot(app) / NeedStartFile);
   const auto result = cmd_streaming(compose_ + "up --remove-orphans --no-start", app);
   return result;
 }

--- a/src/docker/composeappengine.h
+++ b/src/docker/composeappengine.h
@@ -29,9 +29,73 @@ class ComposeAppEngine : public AppEngine {
   std::string runningApps() const override;
 
  private:
+  static constexpr const char* const MetaDir{".meta"};
+  static constexpr const char* const VersionFile{".version"};
+  static constexpr const char* const StateFile{".state"};
+
+  class AppState {
+   public:
+    class File {
+     public:
+      File(const std::string& path) : path_{path} {}
+      ~File() = default;
+
+      void write(int val);
+      void write(const std::string& val);
+
+      int read() const;
+      std::string readStr() const;
+
+     private:
+      static int open(const char* file);
+      void write(const void* data, ssize_t size);
+      void read(void* data, ssize_t size) const;
+
+      const std::string path_;
+      int fd_;
+    };
+
+   public:
+    enum class State {
+      kUnknown = 0,
+      kDownloaded = 0x10,
+      kDownloadFailed,
+      kVerified = 0x20,
+      kVerifyFailed,
+      kPulled = 0x30,
+      kPullFailed,
+      kInstalled = 0x40,
+      kInstallFail,
+      kStarted = 0x50,
+      kStartFailed
+    };
+
+    AppState(const App& app, const boost::filesystem::path& root, bool set_version = false);
+    ~AppState() = default;
+    AppState(const AppState&) = delete;
+    AppState& operator=(const AppState&) = delete;
+
+    void setState(const State& state);
+    const State& operator()() const { return state_; }
+
+   private:
+    std::string version_;
+    State state_;
+
+    File version_file_;
+    File state_file_;
+  };
+
+ private:
   bool cmd_streaming(const std::string& cmd, const App& app);
   static std::pair<bool, std::string> cmd(const std::string& cmd);
+
   bool download(const App& app);
+  bool verify(const App& app);
+  bool pullImages(const App& app);
+  bool installApp(const App& app);
+  bool start(const App& app);
+
   static bool checkAvailableStorageSpace(const boost::filesystem::path& app_root, uint64_t& out_available_size);
   void extractAppArchive(const App& app, const std::string& archive_file_name, bool delete_after_extraction = true);
   boost::filesystem::path appRoot(const App& app) const { return root_ / app.name; }

--- a/src/docker/composeappengine.h
+++ b/src/docker/composeappengine.h
@@ -14,7 +14,6 @@ namespace Docker {
 class ComposeAppEngine : public AppEngine {
  public:
   static constexpr const char* const ArchiveExt{".tgz"};
-  static constexpr const char* const NeedStartFile{".need_start"};
   static constexpr const char* const ComposeFile{"docker-compose.yml"};
 
  public:

--- a/src/docker/composeappengine.h
+++ b/src/docker/composeappengine.h
@@ -26,7 +26,7 @@ class ComposeAppEngine : public AppEngine {
   bool run(const App& app) override;
   void remove(const App& app) override;
   bool isRunning(const App& app) const override;
-  std::string runningApps() const override;
+  Json::Value getRunningAppsInfo() const override;
 
  private:
   static constexpr const char* const MetaDir{".meta"};
@@ -77,10 +77,28 @@ class ComposeAppEngine : public AppEngine {
 
     void setState(const State& state);
     const State& operator()() const { return state_; }
+    const std::string& version() const { return version_; }
+    std::string toStr() const {
+      static std::map<State, std::string> state2Str = {
+          {State::kUnknown, "Unknown"},
+          {State::kDownloaded, "Downloaded"},
+          {State::kDownloadFailed, "Download failed"},
+          {State::kVerified, "Compose file verified"},
+          {State::kVerifyFailed, "Compose file verification failure"},
+          {State::kPulled, "Images are pulled"},
+          {State::kPullFailed, "Image pull failed"},
+          {State::kInstalled, "Created"},
+          {State::kInstallFail, "Creation failed"},
+          {State::kStarted, "Started"},
+          {State::kStartFailed, "Start failed"},
+      };
+
+      return state2Str[state_];
+    }
 
    private:
-    std::string version_;
-    State state_;
+    std::string version_{""};
+    State state_{State::kUnknown};
 
     File version_file_;
     File state_file_;

--- a/src/docker/dockerclient.cc
+++ b/src/docker/dockerclient.cc
@@ -50,24 +50,4 @@ bool DockerClient::isRunning(const Json::Value& root, const std::string& app, co
   return false;
 }
 
-std::string DockerClient::runningApps() {
-  std::string runningApps;
-  Json::Value root;
-  getContainers(root);
-  for (Json::ValueIterator ii = root.begin(); ii != root.end(); ++ii) {
-    Json::Value val = *ii;
-    std::string app = val["Labels"]["com.docker.compose.project"].asString();
-    std::string service = val["Labels"]["com.docker.compose.service"].asString();
-    std::string hash = val["Labels"]["io.compose-spec.config-hash"].asString();
-    std::string image = val["Image"].asString();
-    std::string state = val["State"].asString();
-    std::string status = val["Status"].asString();
-
-    boost::format format("App(%s) Service(%-10s %s)\tImage(%-120s)\tState(%-10s)\tStatus(%-10s)\n");
-    std::string line = boost::str(format % app % service % hash % image % state % status);
-    runningApps += line;
-  }
-  return runningApps;
-}
-
 }  // namespace Docker

--- a/src/docker/dockerclient.cc
+++ b/src/docker/dockerclient.cc
@@ -42,7 +42,10 @@ bool DockerClient::isRunning(const Json::Value& root, const std::string& app, co
     if (val["Labels"]["com.docker.compose.project"].asString() == app) {
       if (val["Labels"]["com.docker.compose.service"].asString() == service) {
         if (val["Labels"]["io.compose-spec.config-hash"].asString() == hash) {
-          return true;
+          // All other states imply that a container was started
+          if (val["State"].asString() != "created") {
+            return true;
+          }
         }
       }
     }

--- a/src/docker/dockerclient.h
+++ b/src/docker/dockerclient.h
@@ -18,7 +18,6 @@ class DockerClient {
   DockerClient(std::shared_ptr<HttpInterface> http_client = DefaultHttpClientFactory());
   void getContainers(Json::Value& root);
 
-  std::string runningApps();
   static bool isRunning(const Json::Value& root, const std::string& app, const std::string& service,
                         const std::string& hash);
 

--- a/tests/composeappengine_test.cc
+++ b/tests/composeappengine_test.cc
@@ -70,12 +70,16 @@ TEST_F(ComposeAppEngineTest, FetchRunCompare) {
 
   ASSERT_TRUE(app_engine->fetch(updated_app));
   ASSERT_FALSE(app_engine->isRunning(updated_app));
-  ASSERT_FALSE(boost::icontains(app_engine->runningApps(), id));
+  ASSERT_FALSE(app_engine->getRunningAppsInfo().isMember("app-02"));
 
   // run updated App
   ASSERT_TRUE(app_engine->run(updated_app));
   ASSERT_TRUE(app_engine->isRunning(updated_app));
-  ASSERT_TRUE(boost::icontains(app_engine->runningApps(), id));
+
+  Json::Value apps_info = app_engine->getRunningAppsInfo();
+  ASSERT_TRUE(apps_info.isMember("app-02"));
+  ASSERT_TRUE(apps_info["app-02"]["services"].isMember("service-02"));
+  ASSERT_EQ(apps_info["app-02"]["services"]["service-02"]["image"].asString(), "image-02");
 }
 
 int main(int argc, char** argv) {

--- a/tests/docker-compose_fake.py
+++ b/tests/docker-compose_fake.py
@@ -26,6 +26,7 @@ def up(out_dir, app_name, compose, flags):
         container["Labels"]["com.docker.compose.project"] = app_name
         container["Labels"]["com.docker.compose.service"] = service
         container["Labels"]["io.compose-spec.config-hash"] = compose["services"][service]["labels"]["io.compose-spec.config-hash"]
+        container["Image"] = compose["services"][service]["image"]
         containers.append(container)
 
     with open(os.path.join(out_dir, "containers.json"), "w") as f:

--- a/tests/docker-compose_fake.py
+++ b/tests/docker-compose_fake.py
@@ -13,8 +13,6 @@ logger = logging.getLogger("Fake Docker Compose")
 
 def up(out_dir, app_name, compose, flags):
     logger.info("Up: " + flags[0] + " " + flags[1])
-    if "-d" not in flags:
-        return
 
     logger.info("Run services...")
     with open(os.path.join(out_dir, "containers.json"), "r") as f:
@@ -27,6 +25,7 @@ def up(out_dir, app_name, compose, flags):
         container["Labels"]["com.docker.compose.service"] = service
         container["Labels"]["io.compose-spec.config-hash"] = compose["services"][service]["labels"]["io.compose-spec.config-hash"]
         container["Image"] = compose["services"][service]["image"]
+        container["State"] = "running" if flags[1] == "-d" else "created"
         containers.append(container)
 
     with open(os.path.join(out_dir, "containers.json"), "w") as f:
@@ -43,10 +42,7 @@ def main():
         out_dir = sys.argv[1]
         cmd = sys.argv[2]
         logger.info("Command: " + cmd)
-        flags = sys.argv[3:]
-        if len(flags) > 2 and flags[1] == '--no-start':
-            logger.info(">>>>>>>>>>>> --no-start")
-            cmd = ""
+
         app_name = os.path.basename(os.getcwd())
         if cmd == "up":
             up(out_dir, app_name, compose, sys.argv[3:])

--- a/tests/liteclientHSM_test.cc
+++ b/tests/liteclientHSM_test.cc
@@ -40,9 +40,10 @@ class MockAppEngine : public AppEngine {
     ON_CALL(*this, install).WillByDefault(Return(true));
     ON_CALL(*this, run).WillByDefault(Return(true));
     ON_CALL(*this, isRunning).WillByDefault(Return(true));
-    ON_CALL(*this, runningApps)
-        .WillByDefault(Return(
-            "Apps(app-01) Service(test-factory 7ca42b1567ca068dfd6a5392432a5a36700a4aa3e321922e91d974f832a2f243"));
+    ON_CALL(*this, getRunningAppsInfo)
+        .WillByDefault(
+            Return(Utils::parseJSON("{\"app-07\": {\"services\": {\"test-factory\": {\"hash\": "
+                                    "\"7ca42b1567ca068dfd6a5392432a5a36700a4aa3e321922e91d974f832a2f243\"}}}}")));
   }
 
  public:
@@ -51,7 +52,7 @@ class MockAppEngine : public AppEngine {
   MOCK_METHOD(bool, run, (const App& app), (override));
   MOCK_METHOD(void, remove, (const App& app), (override));
   MOCK_METHOD(bool, isRunning, (const App& app), (const, override));
-  MOCK_METHOD(std::string, runningApps, (), (const, override));
+  MOCK_METHOD(Json::Value, getRunningAppsInfo, (), (const, override));
 };
 
 class LiteClientHSMTest : public fixtures::ClientHSMTest {

--- a/tests/liteclient_test.cc
+++ b/tests/liteclient_test.cc
@@ -40,9 +40,10 @@ class MockAppEngine : public AppEngine {
     ON_CALL(*this, install).WillByDefault(Return(true));
     ON_CALL(*this, run).WillByDefault(Return(true));
     ON_CALL(*this, isRunning).WillByDefault(Return(true));
-    ON_CALL(*this, runningApps)
+    ON_CALL(*this, getRunningAppsInfo)
         .WillByDefault(
-            Return("Apps(app-07) Service(nginx-07 16e36b4ab48cb19c7100a22686f85ffcbdce5694c936bda03cb12a2cce88efcf"));
+            Return(Utils::parseJSON("{\"app-07\": {\"services\": {\"nginx-07\": {\"hash\": "
+                                    "\"16e36b4ab48cb19c7100a22686f85ffcbdce5694c936bda03cb12a2cce88efcf\"}}}}")));
   }
 
  public:
@@ -51,7 +52,7 @@ class MockAppEngine : public AppEngine {
   MOCK_METHOD(bool, run, (const App& app), (override));
   MOCK_METHOD(void, remove, (const App& app), (override));
   MOCK_METHOD(bool, isRunning, (const App& app), (const, override));
-  MOCK_METHOD(std::string, runningApps, (), (const, override));
+  MOCK_METHOD(Json::Value, getRunningAppsInfo, (), (const, override));
 };
 
 class LiteClientTest : public fixtures::ClientTest {


### PR DESCRIPTION
Track App update state and make use of it, so
* network usage is optimized, aklite doesn't re-fetch what has been already fetched;
* simplify debugging and troubleshooting;
* extend the context of report events with App state info.

Signed-off-by: Mike Sul <mike.sul@foundries.io>