### PR TITLE
Remove the download/update lock

### DIFF
--- a/src/liteclient.h
+++ b/src/liteclient.h
@@ -35,8 +35,6 @@ class LiteClient {
 
   std::pair<Uptane::EcuSerial, Uptane::HardwareIdentifier> primary_ecu;
   std::shared_ptr<HttpClient> http_client;
-  boost::filesystem::path download_lockfile;
-  boost::filesystem::path update_lockfile;
 
   bool checkForUpdatesBegin();
   void checkForUpdatesEnd(const Uptane::Target& target);

--- a/src/main.cc
+++ b/src/main.cc
@@ -253,13 +253,6 @@ static int daemon_main(LiteClient& client, const bpo::variables_map& variables_m
   client.finalizeInstall();
 
   Uptane::HardwareIdentifier hwid(client.config.provision.primary_ecu_hardware_id);
-  if (variables_map.count("update-lockfile") > 0) {
-    client.update_lockfile = variables_map["update-lockfile"].as<boost::filesystem::path>();
-  }
-  if (variables_map.count("download-lockfile") > 0) {
-    client.download_lockfile = variables_map["download-lockfile"].as<boost::filesystem::path>();
-  }
-
   auto current = client.getCurrent();
 
   uint64_t interval = client.config.uptane.polling_sec;
@@ -383,8 +376,6 @@ bpo::variables_map parse_options(int argc, char** argv) {
       ("clear-installed-versions", "DANGER - clear the history of installed updates before applying the given update. This is handy when doing test/debug and you need to rollback to an old version manually.")
 #endif
       ("interval", bpo::value<uint64_t>(), "Override uptane.polling_secs interval to poll for update when in daemon mode.")
-      ("update-lockfile", bpo::value<boost::filesystem::path>(), "If provided, an flock(2) is applied to this file before performing an update in daemon mode")
-      ("download-lockfile", bpo::value<boost::filesystem::path>(), "If provided, an flock(2) is applied to this file before downloading an update in daemon mode")
       ("command", bpo::value<std::string>(), subs.c_str());
   // clang-format on
 


### PR DESCRIPTION
The current download and update locks are not used.
Since we added the aklite system-wide lock that prevents from running two simultaneous update sessions they become obsolete/redundant.