### PR TITLE
bootloader: update fw if bootfirmware_version is not set

### DIFF
--- a/src/bootloader/rollbacks/fiovb.h
+++ b/src/bootloader/rollbacks/fiovb.h
@@ -39,7 +39,7 @@ class FiovbRollback : public Rollback {
     std::string sink;
     if (Utils::shell("fiovb_printenv bootfirmware_version", &sink) != 0) {
       LOG_WARNING << "Failed to read bootfirmware_version";
-      return;
+      sink = std::string();
     }
     LOG_INFO << "Current firmware version: " << sink;
     if (sink.compare(version) != 0) {


### PR DESCRIPTION
On a closed board, if the bootfirmware_version is not set
it means that an upgrade is need to properly set the version.

Signed-off-by: Tim Anderson <tim.anderson@foundries.io>