### PR TITLE
ostree: cancel ostree download session if hung

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -311,11 +311,14 @@ static int daemon_main(LiteClient& client, const bpo::variables_map& variables_m
       } else {
         if (!client.appsInSync()) {
           client.checkForUpdatesEnd(client.getCurrent());
-          do_app_sync(client);
+          auto rc = do_app_sync(client);
+          if (rc == data::ResultCode::Numeric::kOk) {
+            LOG_INFO << "Device is up-to-date";
+          }
         } else {
           client.checkForUpdatesEnd(Uptane::Target::Unknown());
+          LOG_INFO << "Device is up-to-date";
         }
-        LOG_INFO << "Device is up-to-date";
       }
 
     } catch (const std::exception& exc) {


### PR DESCRIPTION
Add a download watchdog to workaround the issue in libostree related to resuming of download after network goes down for a longer period of time (~ 15-20 minutes) and then goes up again.
TODO: add more details about the issue.

Signed-off-by: Mike Sul <mike.sul@foundries.io>