### PR TITLE
apps: use DEBUG level msg if no app state file

### DIFF
--- a/src/docker/composeappengine.cc
+++ b/src/docker/composeappengine.cc
@@ -145,7 +145,7 @@ bool ComposeAppEngine::isRunning(const App& app) const {
     AppState state(app, appRoot(app));
     started_state = state() == AppState::State::kStarted;
   } catch (const std::exception& exc) {
-    LOG_WARNING << "Failed to get/set App state, fallback to checking the dockerd state: " << exc.what();
+    LOG_DEBUG << "Failed to get/set App state, fallback to checking the dockerd state: " << exc.what();
     started_state = true;
   }
 


### PR DESCRIPTION
The warning message might scarry users as they appear during the transition to the latest aklite version that supports App state tracking. Specifically, if aklite is updated and one or more of the Apps are not updated then the state files won't be present on a system so isRunning() check cannot be accomplished by means of the state files. The PR just set DEBUG level for the message informing about it.

Signed-off-by: Mike Sul <mike.sul@foundries.io>