### PR TITLE
apps: check downloaded App contains a compose file

### DIFF
--- a/src/docker/composeappengine.h
+++ b/src/docker/composeappengine.h
@@ -114,6 +114,7 @@ class ComposeAppEngine : public AppEngine {
   bool start(const App& app);
 
   static bool checkAvailableStorageSpace(const boost::filesystem::path& app_root, uint64_t& out_available_size);
+  void verifyAppArchive(const App& app, const std::string& archive_file_name);
   void extractAppArchive(const App& app, const std::string& archive_file_name, bool delete_after_extraction = true);
   boost::filesystem::path appRoot(const App& app) const { return root_ / app.name; }
 

--- a/tests/aklite_test.cc
+++ b/tests/aklite_test.cc
@@ -69,6 +69,30 @@ TEST_F(AkliteTest, AppUpdate) {
   ASSERT_TRUE(app_engine->isRunning(app01_updated));
 }
 
+TEST_F(AkliteTest, AppInvalidUpdate) {
+  auto app01 = registry.addApp(fixtures::ComposeApp::create("app-01"));
+
+  auto client = createLiteClient();
+  ASSERT_TRUE(targetsMatch(client->getCurrent(), getInitialTarget()));
+  ASSERT_FALSE(app_engine->isRunning(app01));
+
+  auto target01 = createAppTarget({app01});
+
+  updateApps(*client, getInitialTarget(), target01);
+  ASSERT_TRUE(targetsMatch(client->getCurrent(), target01));
+  ASSERT_TRUE(app_engine->isRunning(app01));
+
+  // update app
+  auto app01_updated =
+      registry.addApp(fixtures::ComposeApp::create("app-01", "service-01", "image-02", "incorrect-compose-file.yml"));
+  auto target02 = createAppTarget({app01_updated});
+  updateApps(*client, target01, target02, data::ResultCode::Numeric::kDownloadFailed);
+  ASSERT_FALSE(targetsMatch(client->getCurrent(), target02));
+
+  ASSERT_TRUE(targetsMatch(client->getCurrent(), target01));
+  ASSERT_TRUE(app_engine->isRunning(app01));
+}
+
 TEST_F(AkliteTest, OstreeAndAppUpdate) {
   auto app01 = registry.addApp(fixtures::ComposeApp::create("app-01"));
 

--- a/tests/fixtures/composeapp.cc
+++ b/tests/fixtures/composeapp.cc
@@ -19,8 +19,8 @@ class ComposeApp {
 
  public:
   static Ptr create(const std::string& name,
-                    const std::string& service = "service-01", const std::string& image = "image-01") {
-    Ptr app{new ComposeApp(name)};
+                    const std::string& service = "service-01", const std::string& image = "image-01", const std::string& compose_file = Docker::ComposeAppEngine::ComposeFile) {
+    Ptr app{new ComposeApp(name, compose_file)};
     app->updateService(service, image);
     return app;
   }
@@ -41,13 +41,13 @@ class ComposeApp {
 
 
  private:
-  ComposeApp(const std::string& name):name_{name} {}
+  ComposeApp(const std::string& name, const std::string& compose_file):name_{name}, compose_file_{compose_file} {}
 
   const std::string& update() {
     TemporaryDirectory app_dir;
     TemporaryFile arch_file{"arch.tgz"};
 
-    Utils::writeFile(app_dir.Path() / Docker::ComposeAppEngine::ComposeFile, std::string(content_));
+    Utils::writeFile(app_dir.Path() / compose_file_, std::string(content_));
     boost::process::system("tar -czf " + arch_file.Path().string() + " .",  boost::process::start_dir = app_dir.Path());
     arch_ = Utils::readFile(arch_file.Path());
     arch_hash_ = boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha256digest(arch_)));
@@ -62,6 +62,7 @@ class ComposeApp {
   }
 
  private:
+  const std::string compose_file_;
   const std::string name_;
   char content_[4096];
 


### PR DESCRIPTION
Make sure that a new Target App, that akite downloads, includes a compose file (docker-compose.yml).

Signed-off-by: Mike Sul <mike.sul@foundries.io>