### PR TITLE
apps: check if the state files exist before use

### DIFF
--- a/src/docker/composeappengine.cc
+++ b/src/docker/composeappengine.cc
@@ -200,7 +200,7 @@ Json::Value ComposeAppEngine::getRunningAppsInfo() const {
         continue;
       }
 
-      if (!apps.isMember(app_name)) {
+      if (!apps.isMember(app_name) && AppState::exists(root_ / app_name)) {
         App app{app_name, ""};
         AppState state(app, appRoot(app));
         app.uri = state.version();
@@ -398,6 +398,11 @@ ComposeAppEngine::AppState::AppState(const App& app, const boost::filesystem::pa
 }
 catch (const std::exception& exc) {
   LOG_ERROR << "Failed to read version or state file: " << exc.what();
+}
+
+bool ComposeAppEngine::AppState::exists(const boost::filesystem::path& root) {
+  return boost::filesystem::exists(root / MetaDir / VersionFile) &&
+         boost::filesystem::exists(root / MetaDir / StateFile);
 }
 
 void ComposeAppEngine::AppState::setState(const State& state) {

--- a/src/docker/composeappengine.h
+++ b/src/docker/composeappengine.h
@@ -74,6 +74,8 @@ class ComposeAppEngine : public AppEngine {
     AppState(const AppState&) = delete;
     AppState& operator=(const AppState&) = delete;
 
+    static bool exists(const boost::filesystem::path& root);
+
     void setState(const State& state);
     const State& operator()() const { return state_; }
     const std::string& version() const { return version_; }


### PR DESCRIPTION
Make sure that the state files exist before trying to fetch info from
them during gathering info about currently running apps and their
containers/services.

Signed-off-by: Mike Sul <mike.sul@foundries.io>