### PR TITLE
aklite: add ability to manage non-booted rootfs

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,7 @@ set(SRC helpers.cc
 
 set(HEADERS helpers.h
         composeappmanager.h
+        rootfstreemanager.h
         docker/composeappengine.h
         docker/composeapptree.h
         docker/composeinfo.h

--- a/src/liteclient.cc
+++ b/src/liteclient.cc
@@ -9,6 +9,7 @@
 
 #include "composeappmanager.h"
 #include "crypto/keymanager.h"
+#include "rootfstreemanager.h"
 #include "target.h"
 
 LiteClient::LiteClient(Config& config_in, const AppEngine::Ptr& app_engine, const std::shared_ptr<P11EngineGuard>& p11)
@@ -100,8 +101,9 @@ LiteClient::LiteClient(Config& config_in, const AppEngine::Ptr& app_engine, cons
   if (config.pacman.type == ComposeAppManager::Name) {
     package_manager_ = std::make_shared<ComposeAppManager>(config.pacman, config.bootloader, storage, http_client,
                                                            ostree_sysroot, app_engine);
-  } else if (config.pacman.type == PACKAGE_MANAGER_OSTREE) {
-    package_manager_ = std::make_shared<OstreeManager>(config.pacman, config.bootloader, storage, http_client);
+  } else if (config.pacman.type == RootfsTreeManager::Name) {
+    package_manager_ =
+        std::make_shared<RootfsTreeManager>(config.pacman, config.bootloader, storage, http_client, ostree_sysroot);
   } else {
     throw std::runtime_error("Unsupported package manager type: " + config.pacman.type);
   }

--- a/src/rootfstreemanager.h
+++ b/src/rootfstreemanager.h
@@ -1,0 +1,24 @@
+#ifndef AKTUALIZR_LITE_ROOTFS_TREE_MANAGER_H_
+#define AKTUALIZR_LITE_ROOTFS_TREE_MANAGER_H_
+
+#include "bootloader/bootloaderlite.h"
+#include "package_manager/ostreemanager.h"
+
+class RootfsTreeManager : public OstreeManager {
+ public:
+  static constexpr const char *const Name{"ostree"};
+
+  RootfsTreeManager(const PackageConfig &pconfig, const BootloaderConfig &bconfig,
+                    const std::shared_ptr<INvStorage> &storage, const std::shared_ptr<HttpInterface> &http,
+                    std::shared_ptr<OSTree::Sysroot> sysroot)
+      : OstreeManager(pconfig, bconfig, storage, http, new BootloaderLite(bconfig, *storage)),
+        sysroot_{std::move(sysroot)} {}
+
+ private:
+  std::string getCurrentHash() const { return sysroot_->getCurDeploymentHash(); }
+
+ private:
+  std::shared_ptr<OSTree::Sysroot> sysroot_;
+};
+
+#endif  // AKTUALIZR_LITE_ROOTFS_TREE_MANAGER_H_


### PR DESCRIPTION
- Add ability to run aklite on a local host in the case of `ostree`
package manager usage. I.e. teach the ostree manager to manage a
standalone/non-booted ostree-based rootfs.

- Also, it makes the ostree package manager use the Fio's bootloader instead of the
libaktualizr's native one. The bootloader update won't work if the
libaktualizr's bootloader implementation is used.

Signed-off-by: Mike Sul <mike.sul@foundries.io>