### PR TITLE
ostree pull from GCS with fallback to DG/ostreeproxy

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@ set(TARGET ${MAIN_TARGET_LIB})
 
 set(SRC helpers.cc
         composeappmanager.cc
+        rootfstreemanager.cc
         docker/composeappengine.cc
         docker/composeapptree.cc
         docker/composeinfo.cc

--- a/src/composeappmanager.cc
+++ b/src/composeappmanager.cc
@@ -53,9 +53,8 @@ ComposeAppManager::ComposeAppManager(const PackageConfig& pconfig, const Bootloa
                                      const std::shared_ptr<INvStorage>& storage,
                                      const std::shared_ptr<HttpInterface>& http,
                                      std::shared_ptr<OSTree::Sysroot> sysroot, AppEngine::Ptr app_engine)
-    : OstreeManager(pconfig, bconfig, storage, http, new BootloaderLite(bconfig, *storage)),
+    : RootfsTreeManager(pconfig, bconfig, storage, http, std::move(sysroot)),
       cfg_{pconfig},
-      sysroot_{std::move(sysroot)},
       app_engine_{std::move(app_engine)} {
   if (!app_engine_) {
     app_engine_ = std::make_shared<Docker::ComposeAppEngine>(
@@ -156,7 +155,7 @@ bool ComposeAppManager::checkForAppsToUpdate(const Uptane::Target& target) {
 
 bool ComposeAppManager::fetchTarget(const Uptane::Target& target, Uptane::Fetcher& fetcher, const KeyManager& keys,
                                     const FetcherProgressCb& progress_cb, const api::FlowControlToken* token) {
-  if (!OstreeManager::fetchTarget(target, fetcher, keys, progress_cb, token)) {
+  if (!RootfsTreeManager::fetchTarget(target, fetcher, keys, progress_cb, token)) {
     return false;
   }
 
@@ -328,7 +327,6 @@ void ComposeAppManager::handleRemovedApps(const Uptane::Target& target) const {
   }
 }
 
-std::string ComposeAppManager::getCurrentHash() const { return sysroot_->getCurDeploymentHash(); }
 Json::Value ComposeAppManager::getRunningAppsInfo() const { return app_engine_->getRunningAppsInfo(); }
 std::string ComposeAppManager::getRunningAppsInfoForReport() const {
   std::string result;

--- a/src/composeappmanager.h
+++ b/src/composeappmanager.h
@@ -9,9 +9,9 @@
 #include "docker/composeapptree.h"
 #include "docker/docker.h"
 #include "ostree/sysroot.h"
-#include "package_manager/ostreemanager.h"
+#include "rootfstreemanager.h"
 
-class ComposeAppManager : public OstreeManager {
+class ComposeAppManager : public RootfsTreeManager {
  public:
   static constexpr const char* const Name{"ostree+compose_apps"};
 
@@ -53,13 +53,11 @@ class ComposeAppManager : public OstreeManager {
   void handleRemovedApps(const Uptane::Target& target) const;
 
  private:
-  std::string getCurrentHash() const override;
   Json::Value getRunningAppsInfo() const;
   std::string getRunningAppsInfoForReport() const;
 
  private:
   Config cfg_;
-  std::shared_ptr<OSTree::Sysroot> sysroot_;
   mutable AppsContainer cur_apps_to_fetch_and_update_;
   bool are_apps_checked_{false};
   AppEngine::Ptr app_engine_;

--- a/src/ostree/repo.cc
+++ b/src/ostree/repo.cc
@@ -52,12 +52,15 @@ void Repo::addRemote(const std::string& name, const std::string& url, const std:
 
   {
     g_variant_builder_add(&var_builder, "{s@v}", "gpg-verify", g_variant_new_variant(g_variant_new_boolean(FALSE)));
-    g_variant_builder_add(&var_builder, "{s@v}", "tls-ca-path",
-                          g_variant_new_variant(g_variant_new_string(ca.c_str())));
-    g_variant_builder_add(&var_builder, "{s@v}", "tls-client-cert-path",
-                          g_variant_new_variant(g_variant_new_string(cert.c_str())));
-    g_variant_builder_add(&var_builder, "{s@v}", "tls-client-key-path",
-                          g_variant_new_variant(g_variant_new_string(key.c_str())));
+
+    if (!ca.empty()) {
+      g_variant_builder_add(&var_builder, "{s@v}", "tls-ca-path",
+                            g_variant_new_variant(g_variant_new_string(ca.c_str())));
+      g_variant_builder_add(&var_builder, "{s@v}", "tls-client-cert-path",
+                            g_variant_new_variant(g_variant_new_string(cert.c_str())));
+      g_variant_builder_add(&var_builder, "{s@v}", "tls-client-key-path",
+                            g_variant_new_variant(g_variant_new_string(key.c_str())));
+    }
   }
 
   remote_options = g_variant_builder_end(&var_builder);

--- a/src/rootfstreemanager.cc
+++ b/src/rootfstreemanager.cc
@@ -1,0 +1,60 @@
+#include "rootfstreemanager.h"
+#include "ostree/repo.h"
+
+bool RootfsTreeManager::fetchTarget(const Uptane::Target &target, Uptane::Fetcher &fetcher, const KeyManager &keys,
+                                    const FetcherProgressCb &progress_cb, const api::FlowControlToken *token) {
+  (void)fetcher;
+
+  std::vector<Remote> remotes = {{remote, config.ostree_server, {{"X-Correlation-ID", target.filename()}}, true}};
+
+  getAdditionalRemotes(remotes, target.filename());
+
+  data::InstallationResult pull_err{data::ResultCode::Numeric::kUnknown, ""};
+  for (const auto &remote : remotes) {
+    LOG_INFO << "Fetchig ostree commit " + target.sha256Hash() + " from " + remote.baseUrl;
+    if (!remote.isRemoteSet) {
+      setRemote(remote.name, remote.baseUrl);
+    }
+    pull_err = OstreeManager::pull(config.sysroot, remote.baseUrl, keys, target, token, progress_cb,
+                                   remote.isRemoteSet ? nullptr : remote.name.c_str(), remote.headers);
+    if (pull_err.isSuccess()) {
+      break;
+    }
+    LOG_INFO << "Failed to fetch from " + remote.baseUrl + ", err: " + pull_err.description;
+  }
+
+  if (!pull_err.isSuccess()) {
+    LOG_ERROR << "Failed to fetch ostree commit " + target.sha256Hash() + ", err: " + pull_err.description;
+  }
+
+  return pull_err.isSuccess();
+}
+
+void RootfsTreeManager::getAdditionalRemotes(std::vector<Remote> &remotes, const std::string &target_name) {
+  const auto resp = http_client_->post(gateway_url_ + "/download-urls", Json::Value::null);
+
+  if (!resp.isOk()) {
+    LOG_WARNING << "Failed to obtain download URLs from Gateway, fallback to dowload via gateway/proxy server: "
+                << resp.getStatusStr();
+    return;
+  }
+
+  const auto respJson = resp.getJson();
+  for (Json::ValueConstIterator it = respJson.begin(); it != respJson.end(); it++) {
+    remotes.emplace(
+        remotes.begin(), Remote{"gcs",
+                                (*it)["download_url"].asString(),
+                                {
+                                    {"X-Correlation-ID", target_name},
+                                    {"Authorization", std::string("Bearer ") + (*it)["access_token"].asString()},
+                                }}
+
+    );
+  }
+}
+
+void RootfsTreeManager::setRemote(const std::string &name, const std::string &url) {
+  OSTree::Repo repo{sysroot_->path() + "/ostree/repo"};
+
+  repo.addRemote(name, url, "", "", "");
+}

--- a/src/rootfstreemanager.h
+++ b/src/rootfstreemanager.h
@@ -2,23 +2,42 @@
 #define AKTUALIZR_LITE_ROOTFS_TREE_MANAGER_H_
 
 #include "bootloader/bootloaderlite.h"
+#include "ostree/sysroot.h"
 #include "package_manager/ostreemanager.h"
 
 class RootfsTreeManager : public OstreeManager {
  public:
   static constexpr const char *const Name{"ostree"};
+  using RequestHeaders = std::unordered_map<std::string, std::string>;
+  struct Remote {
+    std::string name;
+    std::string baseUrl;
+    RequestHeaders headers;
+    bool isRemoteSet{false};
+  };
 
   RootfsTreeManager(const PackageConfig &pconfig, const BootloaderConfig &bconfig,
                     const std::shared_ptr<INvStorage> &storage, const std::shared_ptr<HttpInterface> &http,
                     std::shared_ptr<OSTree::Sysroot> sysroot)
       : OstreeManager(pconfig, bconfig, storage, http, new BootloaderLite(bconfig, *storage)),
-        sysroot_{std::move(sysroot)} {}
+        sysroot_{std::move(sysroot)},
+        http_client_{http},
+        gateway_url_{pconfig.ostree_server} {}
+
+ public:
+  bool fetchTarget(const Uptane::Target &target, Uptane::Fetcher &fetcher, const KeyManager &keys,
+                   const FetcherProgressCb &progress_cb, const api::FlowControlToken *token) override;
 
  private:
   std::string getCurrentHash() const { return sysroot_->getCurDeploymentHash(); }
+  void getAdditionalRemotes(std::vector<Remote> &remotes, const std::string &target_name);
+
+  void setRemote(const std::string &name, const std::string &url);
 
  private:
   std::shared_ptr<OSTree::Sysroot> sysroot_;
+  std::shared_ptr<HttpInterface> http_client_;
+  const std::string gateway_url_;
 };
 
 #endif  // AKTUALIZR_LITE_ROOTFS_TREE_MANAGER_H_


### PR DESCRIPTION
Pull ostree commit objects from directly from the GCS bucket(s). If remotes that points to the buckets are not available or pull from GCS fails then fallback to fetching via Device Gateway or OSTreeproxy, depending on the device/aklite configuration.