### PR TITLE
Add new aktualizr-lite API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ if(BUILD_AKLITE)
   add_dependencies(aklite aktualizr-lite)
 
   add_custom_target(aklite-tests)
-  add_dependencies(aklite-tests aklite t_lite-helpers uptane-generator t_compose-apps t_ostree t_liteclient t_yaml2json t_composeappengine t_aklite t_liteclientHSM)
+  add_dependencies(aklite-tests aklite t_lite-helpers uptane-generator t_compose-apps t_ostree t_liteclient t_yaml2json t_composeappengine t_aklite t_liteclientHSM t_apiclient)
   set(CMAKE_MODULE_PATH "${AKTUALIZR_DIR}/cmake-modules;${CMAKE_MODULE_PATH}")
 
   find_package(OSTree REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,8 @@ if(BUILD_AKLITE)
   include(CTest)
   add_subdirectory(tests EXCLUDE_FROM_ALL)
 
+  add_subdirectory(examples)
+
 endif(BUILD_AKLITE)
 
 # Use `-LH` options (cmake <args> -LH) to output all variables

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required (VERSION 3.5)
+
+add_executable(custom-client custom-client.cc)
+target_compile_definitions(custom-client PRIVATE BOOST_LOG_DYN_LINK)
+target_include_directories(custom-client PRIVATE ${AKLITE_DIR}/include ${AKTUALIZR_DIR}/third_party/jsoncpp/include ${AKTUALIZR_DIR}/src/libaktualizr/logging)
+target_link_libraries(custom-client boost_log pthread aktualizr_lib aktualizr_lite)
+install(TARGETS custom-client RUNTIME DESTINATION bin)

--- a/examples/custom-client.cc
+++ b/examples/custom-client.cc
@@ -1,0 +1,89 @@
+#include <thread>
+
+#include "aktualizr-lite/api.h"
+#include "logging.h"
+
+static void reboot(const std::string &reboot_cmd) {
+  LOG_INFO << "Device is going to reboot with " << reboot_cmd;
+  if (setuid(0) != 0) {
+    LOG_ERROR << "Failed to set/verify a root user so cannot reboot system programmatically";
+  } else {
+    sync();
+    if (std::system(reboot_cmd.c_str()) == 0) {
+      exit(0);
+    }
+    LOG_ERROR << "Failed to execute the reboot command";
+  }
+  exit(1);
+}
+
+static std::string get_reboot_cmd(const AkliteClient &client) {
+  auto reboot_cmd = client.GetConfig().get("bootloader.reboot_command", "");
+  // boost property_tree will include surrounding quotes which we need to
+  // strip:
+  if (reboot_cmd.front() == '"') {
+    reboot_cmd.erase(0, 1);
+  }
+  if (reboot_cmd.back() == '"') {
+    reboot_cmd.erase(reboot_cmd.size()-1);
+  }
+
+  return reboot_cmd;
+}
+
+int main(int argc, char **argv) {
+  //std::vector<boost::filesystem::path> cfg = {"/var/code/og/aktualizr-dev/aktualizr-lite/local-root/sota"};
+  //AkliteClient client(cfg);
+  AkliteClient client(AkliteClient::CONFIG_DIRS);
+  auto interval = client.GetConfig().get("uptane.polling_sec", 600);
+  auto reboot_cmd = get_reboot_cmd(client);
+
+  if (access(reboot_cmd.c_str(), X_OK) != 0) {
+    LOG_ERROR << "Reboot command: " << reboot_cmd << " is not executable";
+    return EXIT_FAILURE;
+  }
+
+  LOG_INFO << "Starting aklite client with " << interval << " second interval";
+
+  auto current = client.GetCurrent();
+  while (true) {
+    LOG_INFO << "Active Target: " << current.Name() << ", sha256: " << current.Sha256Hash();
+    LOG_INFO << "Checking for a new Target...";
+
+    try {
+      auto res = client.CheckIn();
+      if (res.status != CheckInResult::Status::Ok && res.status != CheckInResult::Status::OkCached) {
+        LOG_WARNING << "Unable to update latest metadata, going to sleep for " << interval
+                    << " seconds before starting a new update cycle";
+        std::this_thread::sleep_for(std::chrono::seconds(interval));
+        continue;  // There's no point trying to look for an update
+      }
+
+      auto latest = res.GetLatest();
+      LOG_INFO << "Found Latest Target: " << latest.Name();
+      if (latest.Name() != current.Name() && !client.IsRollback(latest)) {
+        std::string reason = "Updating from " + current.Name() + " to " + latest.Name();
+        auto dres = client.Download(latest, reason);
+        if (dres.status != DownloadResult::Status::Ok) {
+          LOG_ERROR << "Unable to download target: " << dres;
+          continue;
+        }
+        auto ires = dres.Install();
+        if (ires.status == InstallResult::Status::Ok) {
+          current = latest;
+          continue;
+        } else if (ires.status == InstallResult::Status::NeedsCompletion) {
+          reboot(reboot_cmd);
+          break;
+        } else {
+          LOG_ERROR << "Unable to install target: " << ires;
+        }
+      }
+    } catch (const std::exception& exc) {
+      LOG_ERROR << "Failed to find or update Target: " << exc.what();
+      continue;
+    }
+
+    std::this_thread::sleep_for(std::chrono::seconds(interval));
+  }
+}

--- a/include/aktualizr-lite/api.h
+++ b/include/aktualizr-lite/api.h
@@ -11,6 +11,41 @@
 class LiteClient;
 
 /**
+ * A high-level representation of a TUF Target in terms applicable to a
+ * FoundriesFactory.
+ */
+class TufTarget {
+ public:
+  TufTarget(std::string name, std::string sha256, int version, Json::Value custom)
+      : name_(std::move(name)), sha256_(std::move(sha256)), version_(version), custom_(std::move(custom)) {}
+
+  /**
+   * Return the TUF Target name. This is the key in the targets.json key/value
+   * singed.metadata dictionary.
+   */
+  const std::string &Name() const { return name_; }
+  /**
+   * Return the sha256 OStree hash of the Target.
+   */
+  const std::string &Sha256Hash() const { return sha256_; }
+  /**
+   * Return the FoundriesFactory CI build number or in TUF, custom.version.
+   */
+  int Version() const { return version_; }
+
+  /**
+   * Return TUF custom data for a Target.
+   */
+  const Json::Value &Custom() const { return custom_; }
+
+ private:
+  std::string name_;
+  std::string sha256_;
+  int version_;
+  Json::Value custom_;
+};
+
+/**
  * AkliteClient provides an easy-to-use API for users wanting to customize
  * the behavior of aktualizr-lite.
  */
@@ -34,6 +69,11 @@ class AkliteClient {
    * Return the active aktualizr-lite configuration.
    */
   boost::property_tree::ptree GetConfig() const;
+
+  /**
+   * Return the Target currently running on the system.
+   */
+  TufTarget GetCurrent() const;
 
   /**
    * Default files/paths to search for sota toml when configuration client.

--- a/include/aktualizr-lite/api.h
+++ b/include/aktualizr-lite/api.h
@@ -65,6 +65,20 @@ class CheckInResult {
 };
 
 /**
+ * The response from an AkliteClient call to Install
+ */
+class InstallResult {
+ public:
+  enum class Status {
+    Ok = 0,
+    NeedsCompletion,
+    Failed,
+  };
+  Status status;
+  std::string description;
+};
+
+/**
  * The response from an AkliteClient call to Download()
  */
 class DownloadResult {
@@ -76,8 +90,10 @@ class DownloadResult {
   };
   Status status;
   std::string description;
+  std::function<InstallResult()> Install;
 };
 
+std::ostream &operator<<(std::ostream &os, const InstallResult &res);
 std::ostream &operator<<(std::ostream &os, const DownloadResult &res);
 
 /**
@@ -125,6 +141,11 @@ class AkliteClient {
    * Download and verify the content of the given target.
    */
   DownloadResult Download(const TufTarget &t, std::string reason = "");
+
+  /**
+   * Install the Target
+   */
+  InstallResult Install(const TufTarget &t);
 
   /**
    * Check if the Target has been installed but failed to boot. This would

--- a/include/aktualizr-lite/api.h
+++ b/include/aktualizr-lite/api.h
@@ -1,0 +1,45 @@
+// Copyright (c) 2021 Foundries.io
+// SPDX-License-Identifier: Apache-2.0
+
+#include <string>
+
+#include <boost/filesystem.hpp>
+#include <boost/property_tree/ptree.hpp>
+
+#include "json/json.h"
+
+class LiteClient;
+
+/**
+ * AkliteClient provides an easy-to-use API for users wanting to customize
+ * the behavior of aktualizr-lite.
+ */
+class AkliteClient {
+ public:
+  /**
+   * Construct a client instance pulling in config files from the given
+   * locations. ex:
+   *
+   *   AkliteClient c(AkliteClient::CONFIG_DIRS)
+   *
+   * @param config_dirs The list of files/directories to parse sota toml from.
+   */
+  AkliteClient(const std::vector<boost::filesystem::path> &config_dirs);
+  /**
+   * Used for unit-testing purposes.
+   */
+  AkliteClient(std::shared_ptr<LiteClient> client) : client_(client) {}
+
+  /**
+   * Return the active aktualizr-lite configuration.
+   */
+  boost::property_tree::ptree GetConfig() const;
+
+  /**
+   * Default files/paths to search for sota toml when configuration client.
+   */
+  static std::vector<boost::filesystem::path> CONFIG_DIRS;
+
+ private:
+  std::shared_ptr<LiteClient> client_;
+};

--- a/include/aktualizr-lite/api.h
+++ b/include/aktualizr-lite/api.h
@@ -106,6 +106,13 @@ class AkliteClient {
   TufTarget GetCurrent() const;
 
   /**
+   * Check if the Target has been installed but failed to boot. This would
+   * make this be considered a "rollback target" and one we shouldn't consider
+   * installing.
+   */
+  bool IsRollback(const TufTarget &t) const;
+
+  /**
    * Default files/paths to search for sota toml when configuration client.
    */
   static std::vector<boost::filesystem::path> CONFIG_DIRS;

--- a/include/aktualizr-lite/api.h
+++ b/include/aktualizr-lite/api.h
@@ -65,6 +65,22 @@ class CheckInResult {
 };
 
 /**
+ * The response from an AkliteClient call to Download()
+ */
+class DownloadResult {
+ public:
+  enum class Status {
+    Ok = 0,
+    DownloadFailed,
+    VerificationFailed,
+  };
+  Status status;
+  std::string description;
+};
+
+std::ostream &operator<<(std::ostream &os, const DownloadResult &res);
+
+/**
  * AkliteClient provides an easy-to-use API for users wanting to customize
  * the behavior of aktualizr-lite.
  */
@@ -104,6 +120,11 @@ class AkliteClient {
    * Return the Target currently running on the system.
    */
   TufTarget GetCurrent() const;
+
+  /**
+   * Download and verify the content of the given target.
+   */
+  DownloadResult Download(const TufTarget &t, std::string reason = "");
 
   /**
    * Check if the Target has been installed but failed to boot. This would

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(TARGET_EXE aktualizr-lite)
+set(TARGET_LIB aktualizr_lite)
 set(TARGET ${MAIN_TARGET_LIB})
 
 set(SRC helpers.cc
@@ -41,6 +42,7 @@ set(HEADERS helpers.h
 
 add_executable(${TARGET_EXE} main.cc)
 add_library(${TARGET} OBJECT ${SRC})
+add_library(${TARGET_LIB} SHARED ${SRC} api.cc)
 
 if(ALLOW_MANUAL_ROLLBACK)
   add_definitions(-DALLOW_MANUAL_ROLLBACK)
@@ -62,14 +64,16 @@ set(INCS
 
 target_include_directories(${TARGET} PRIVATE ${INCS})
 target_include_directories(${TARGET_EXE} PRIVATE ${INCS})
+target_include_directories(${TARGET_LIB} PRIVATE ${AKLITE_DIR}/include ${INCS})
 
 target_link_libraries(${TARGET} aktualizr_lib)
+target_link_libraries(${TARGET_LIB} aktualizr_lib)
 target_link_libraries(${TARGET_EXE} ${TARGET})
-
 
 # TODO: consider cleaning up the overall "install" elements as it includes
 # redundant targets (e.g aktualizr-secondary, aktualizr-cert-provider, etc)
 install(TARGETS ${TARGET_EXE} RUNTIME DESTINATION bin COMPONENT ${TARGET_EXE})
+install(TARGETS ${TARGET_LIB} LIBRARY DESTINATION lib COMPONENT ${TARGET_LIB})
 
 # enable creating clang-tidy targets for each source file (see aktualizr/CMakeLists.txt for details)
-aktualizr_source_file_checks(main.cc ${SRC} ${HEADERS})
+aktualizr_source_file_checks(main.cc api.cc ../include/aktualizr-lite/api.h ${SRC} ${HEADERS})

--- a/src/api.cc
+++ b/src/api.cc
@@ -22,3 +22,14 @@ boost::property_tree::ptree AkliteClient::GetConfig() const {
   boost::property_tree::ini_parser::read_ini(ss, pt);
   return pt;
 }
+
+TufTarget AkliteClient::GetCurrent() const {
+  auto current = client_->getCurrent();
+  int ver = -1;
+  try {
+    ver = std::stoi(current.custom_version(), nullptr, 0);
+  } catch (const std::invalid_argument& exc) {
+    LOG_ERROR << "Invalid version number format: " << current.custom_version();
+  }
+  return TufTarget(current.filename(), current.sha256Hash(), ver, current.custom_data());
+}

--- a/src/api.cc
+++ b/src/api.cc
@@ -81,3 +81,16 @@ TufTarget AkliteClient::GetCurrent() const {
   }
   return TufTarget(current.filename(), current.sha256Hash(), ver, current.custom_data());
 }
+
+bool AkliteClient::IsRollback(const TufTarget& t) const {
+  std::vector<Uptane::Target> known_but_not_installed_versions;
+  get_known_but_not_installed_versions(*client_, known_but_not_installed_versions);
+
+  Json::Value target_json;
+  target_json["hashes"]["sha256"] = t.Sha256Hash();
+  target_json["custom"]["targetFormat"] = "OSTREE";
+  target_json["length"] = 0;
+  Uptane::Target target(t.Name(), target_json);
+
+  return known_local_target(*client_, target, known_but_not_installed_versions);
+}

--- a/src/api.cc
+++ b/src/api.cc
@@ -1,0 +1,24 @@
+#include "aktualizr-lite/api.h"
+
+#include "helpers.h"
+#include "libaktualizr/config.h"
+#include "liteclient.h"
+
+std::vector<boost::filesystem::path> AkliteClient::CONFIG_DIRS = {"/usr/lib/sota/conf.d", "/var/sota/sota.toml",
+                                                                  "/etc/sota/conf.d/"};
+
+AkliteClient::AkliteClient(const std::vector<boost::filesystem::path>& config_dirs) {
+  Config config(config_dirs);
+  config.telemetry.report_network = !config.tls.server.empty();
+  config.telemetry.report_config = !config.tls.server.empty();
+  client_ = std::make_unique<LiteClient>(config, nullptr);
+}
+
+boost::property_tree::ptree AkliteClient::GetConfig() const {
+  std::stringstream ss;
+  ss << client_->config;
+
+  boost::property_tree::ptree pt;
+  boost::property_tree::ini_parser::read_ini(ss, pt);
+  return pt;
+}

--- a/src/liteclient.cc
+++ b/src/liteclient.cc
@@ -405,15 +405,17 @@ void LiteClient::reportHwInfo() {
     LOG_DEBUG << "Not reporting hwinfo information because telemetry is disabled";
     return;
   }
+
+  if (hwinfo_reported_) {
+    return;
+  }
   Json::Value hw_info = Utils::getHardwareInfo();
   if (!hw_info.empty()) {
-    if (hw_info != last_hw_info_reported_) {
-      const HttpResponse response = http_client->put(config.tls.server + "/system_info", hw_info);
-      if (response.isOk()) {
-        last_hw_info_reported_ = hw_info;
-      } else {
-        LOG_DEBUG << "Unable to report hwinfo information: " << response.getStatusStr();
-      }
+    const HttpResponse response = http_client->put(config.tls.server + "/system_info", hw_info);
+    if (response.isOk()) {
+      hwinfo_reported_ = true;
+    } else {
+      LOG_DEBUG << "Unable to report hwinfo information: " << response.getStatusStr();
     }
   } else {
     LOG_WARNING << "Unable to fetch hardware information from host system.";

--- a/src/liteclient.h
+++ b/src/liteclient.h
@@ -79,7 +79,7 @@ class LiteClient {
   std::shared_ptr<Uptane::Fetcher> uptane_fetcher_;
 
   Json::Value last_network_info_reported_;
-  Json::Value last_hw_info_reported_;
+  bool hwinfo_reported_{false};
   bool is_reboot_required_{false};
   bool booted_sysroot{true};
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -133,3 +133,18 @@ add_dependencies(t_aklite make_ostree_sysroot)
 set_tests_properties(test_aklite PROPERTIES LABELS "aklite:aklite")
 
 aktualizr_source_file_checks(aklite_test.cc)
+
+add_aktualizr_test(NAME apiclient
+  SOURCES $<TARGET_OBJECTS:${MAIN_TARGET_LIB}> apiclient_test.cc
+  PROJECT_WORKING_DIRECTORY
+  ARGS
+  ${PROJECT_SOURCE_DIR}/tests/device-gateway_fake.py
+  ${PROJECT_SOURCE_DIR}/tests/make_sys_rootfs.sh
+)
+aktualizr_source_file_checks(apiclient_test.cc)
+target_compile_definitions(t_apiclient PRIVATE ${TEST_DEFS})
+target_include_directories(t_apiclient PRIVATE ${TEST_INCS} ${AKLITE_DIR}/include ${AKTUALIZR_DIR}/tests/ ${AKTUALIZR_DIR}/src/)
+target_link_libraries(t_apiclient aktualizr_lite ${TEST_LIBS} uptane_generator_lib testutilities)
+add_dependencies(t_apiclient make_ostree_sysroot)
+set_tests_properties(test_apiclient PROPERTIES LABELS "aklite:apiclient")
+

--- a/tests/apiclient_test.cc
+++ b/tests/apiclient_test.cc
@@ -1,0 +1,88 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <boost/filesystem.hpp>
+#include <boost/process.hpp>
+#include <boost/process/env.hpp>
+
+#include "libaktualizr/types.h"
+#include "logging/logging.h"
+#include "test_utils.h"
+#include "uptane_generator/image_repo.h"
+#include "utilities/utils.h"
+
+#include "aktualizr-lite/api.h"
+#include "composeappmanager.h"
+#include "liteclient.h"
+
+#include "docker/composeappengine.h"
+#include "helpers.h"
+#include "ostree/repo.h"
+#include "target.h"
+
+#include "fixtures/liteclienttest.cc"
+
+using ::testing::NiceMock;
+using ::testing::Return;
+
+/**
+ * Class MockAppEngine
+ *
+ */
+class MockAppEngine : public AppEngine {
+ public:
+  MockAppEngine(bool default_behaviour = true) {
+    if (!default_behaviour) return;
+
+    ON_CALL(*this, fetch).WillByDefault(Return(true));
+    ON_CALL(*this, install).WillByDefault(Return(true));
+    ON_CALL(*this, run).WillByDefault(Return(true));
+    ON_CALL(*this, isRunning).WillByDefault(Return(true));
+    ON_CALL(*this, getRunningAppsInfo)
+        .WillByDefault(
+            Return(Utils::parseJSON("{\"app-07\": {\"services\": {\"nginx-07\": {\"hash\": "
+                                    "\"16e36b4ab48cb19c7100a22686f85ffcbdce5694c936bda03cb12a2cce88efcf\"}}}}")));
+  }
+
+ public:
+  MOCK_METHOD(bool, fetch, (const App& app), (override));
+  MOCK_METHOD(bool, install, (const App& app), (override));
+  MOCK_METHOD(bool, run, (const App& app), (override));
+  MOCK_METHOD(void, remove, (const App& app), (override));
+  MOCK_METHOD(bool, isRunning, (const App& app), (const, override));
+  MOCK_METHOD(Json::Value, getRunningAppsInfo, (), (const, override));
+};
+
+class ApiClientTest : public fixtures::ClientTest {
+ protected:
+  std::shared_ptr<LiteClient> createLiteClient(InitialVersion initial_version = InitialVersion::kOn,
+                                               boost::optional<std::vector<std::string>> apps = boost::none) override {
+    app_engine_mock_ = std::make_shared<NiceMock<MockAppEngine>>();
+    return ClientTest::createLiteClient(app_engine_mock_, initial_version, apps);
+  }
+
+  std::shared_ptr<NiceMock<MockAppEngine>>& getAppEngine() { return app_engine_mock_; }
+
+ private:
+  std::shared_ptr<NiceMock<MockAppEngine>> app_engine_mock_;
+};
+
+TEST_F(ApiClientTest, GetConfig) {
+  AkliteClient client(createLiteClient(InitialVersion::kOff));
+  ASSERT_EQ("\"ostree+compose_apps\"", client.GetConfig().get("pacman.type", ""));
+}
+
+int main(int argc, char** argv) {
+  if (argc != 3) {
+    std::cerr << argv[0] << " invalid arguments\n";
+    return EXIT_FAILURE;
+  }
+
+  ::testing::InitGoogleTest(&argc, argv);
+  logger_init();
+
+  // options passed as args in CMakeLists.txt
+  fixtures::DeviceGatewayMock::RunCmd = argv[1];
+  fixtures::SysRootFS::CreateCmd = argv[2];
+  return RUN_ALL_TESTS();
+}

--- a/tests/apiclient_test.cc
+++ b/tests/apiclient_test.cc
@@ -72,6 +72,12 @@ TEST_F(ApiClientTest, GetConfig) {
   ASSERT_EQ("\"ostree+compose_apps\"", client.GetConfig().get("pacman.type", ""));
 }
 
+TEST_F(ApiClientTest, GetCurrent) {
+  auto cur = AkliteClient(createLiteClient(InitialVersion::kOff)).GetCurrent();
+  ASSERT_EQ("unknown", cur.Name());
+  ASSERT_EQ(-1, cur.Version());
+}
+
 int main(int argc, char** argv) {
   if (argc != 3) {
     std::cerr << argv[0] << " invalid arguments\n";

--- a/tests/apiclient_test.cc
+++ b/tests/apiclient_test.cc
@@ -140,6 +140,9 @@ TEST_F(ApiClientTest, Install) {
 
   auto dresult = client.Download(latest);
   ASSERT_EQ(DownloadResult::Status::Ok, dresult.status);
+
+  auto iresult = dresult.Install();
+  ASSERT_EQ(InstallResult::Status::NeedsCompletion, iresult.status);
 }
 
 int main(int argc, char** argv) {

--- a/tests/apiclient_test.cc
+++ b/tests/apiclient_test.cc
@@ -125,6 +125,23 @@ TEST_F(ApiClientTest, Rollback) {
   ASSERT_TRUE(client.IsRollback(result.GetLatest()));
 }
 
+TEST_F(ApiClientTest, Install) {
+  auto liteclient = createLiteClient();
+  ASSERT_TRUE(targetsMatch(liteclient->getCurrent(), getInitialTarget()));
+
+  // Create a new Target: update rootfs and commit it into Treehub's repo
+  auto new_target = createTarget();
+
+  AkliteClient client(liteclient);
+  auto result = client.CheckIn();
+  ASSERT_EQ(CheckInResult::Status::Ok, result.status);
+
+  auto latest = result.GetLatest();
+
+  auto dresult = client.Download(latest);
+  ASSERT_EQ(DownloadResult::Status::Ok, dresult.status);
+}
+
 int main(int argc, char** argv) {
   if (argc != 3) {
     std::cerr << argv[0] << " invalid arguments\n";

--- a/tests/fixtures/liteclient/devicegatewaymock.cc
+++ b/tests/fixtures/liteclient/devicegatewaymock.cc
@@ -10,8 +10,9 @@ class DeviceGatewayMock {
         url_{certDir.empty() ? "http://localhost:" + port_ : "https://localhost:" + port_},
         req_headers_file_{tuf_.getPath() + "/headers.json"},
         events_file_{tuf_.getPath() + "/events.json"},
+        sota_toml_file_{tuf_.getPath() + "/sota.toml"},
         process_{RunCmd,           "--port",         port_, "--ostree", ostree_.getPath(), "--tuf-repo", tuf_.getPath(),
-    "--headers-file", req_headers_file_, "--events-file", events_file_,"--mtls", certDir}
+    "--headers-file", req_headers_file_, "--events-file", events_file_,"--mtls", certDir, "--sota-toml", sota_toml_file_}
   {
     if (certDir.empty()) {
       TestUtils::waitForServer(url_ + "/");
@@ -34,7 +35,9 @@ class DeviceGatewayMock {
   const std::string& getPort() const { return port_; }
   Json::Value getReqHeaders() const { return Utils::parseJSONFile(req_headers_file_); }
   Json::Value getEvents() const { return Utils::parseJSONFile(events_file_); }
-  Json::Value resetEvents() const { return boost::filesystem::remove(events_file_); }
+  bool resetEvents() const { return boost::filesystem::remove(events_file_); }
+  std::string readSotaToml() const { return Utils::readFile(sota_toml_file_); }
+  bool resetSotaToml() const { return boost::filesystem::remove(sota_toml_file_); }
 
  private:
   const OSTreeRepoMock& ostree_;
@@ -43,6 +46,7 @@ class DeviceGatewayMock {
   const std::string url_;
   const std::string req_headers_file_;
   const std::string events_file_;
+  const std::string sota_toml_file_;
   boost::process::child process_;
 };
 


### PR DESCRIPTION
This patchset introduces an easy-to-use API into aktualizr-lite to allow users to produce their own custom daemons with specialized logic for controlling how updates are processed.

The API is currently missing support for ComposeApps as well as support for managing secondary ECUs. These will come in future changes once this initial API is agreed on.