### PR TITLE
Add support for secondary ecus via custom api

### DIFF
--- a/examples/custom-client.cc
+++ b/examples/custom-client.cc
@@ -63,12 +63,13 @@ int main(int argc, char **argv) {
       LOG_INFO << "Found Latest Target: " << latest.Name();
       if (latest.Name() != current.Name() && !client.IsRollback(latest)) {
         std::string reason = "Updating from " + current.Name() + " to " + latest.Name();
-        auto dres = client.Download(latest, reason);
+        auto installer = client.Installer(latest, reason);
+        auto dres = installer->Download();
         if (dres.status != DownloadResult::Status::Ok) {
           LOG_ERROR << "Unable to download target: " << dres;
           continue;
         }
-        auto ires = dres.Install();
+        auto ires = installer->Install();
         if (ires.status == InstallResult::Status::Ok) {
           current = latest;
           continue;

--- a/include/aktualizr-lite/api.h
+++ b/include/aktualizr-lite/api.h
@@ -99,11 +99,17 @@ class DownloadResult {
   };
   Status status;
   std::string description;
-  std::function<InstallResult()> Install;
 };
 
 std::ostream &operator<<(std::ostream &os, const InstallResult &res);
 std::ostream &operator<<(std::ostream &os, const DownloadResult &res);
+
+class InstallContext {
+ public:
+  virtual ~InstallContext() = default;
+  virtual DownloadResult Download() = 0;
+  virtual InstallResult Install() = 0;
+};
 
 struct SecondaryEcu {
   SecondaryEcu(std::string serial, std::string hwid, std::string target_name)
@@ -155,9 +161,9 @@ class AkliteClient {
   TufTarget GetCurrent() const;
 
   /**
-   * Download and verify the content of the given target.
+   * Create an InstallContext object to help drive an update.
    */
-  DownloadResult Download(const TufTarget &t, std::string reason = "");
+  std::unique_ptr<InstallContext> Installer(const TufTarget &t, std::string reason = "") const;
 
   /**
    * Check if the Target has been installed but failed to boot. This would

--- a/include/aktualizr-lite/api.h
+++ b/include/aktualizr-lite/api.h
@@ -99,6 +99,14 @@ class DownloadResult {
 std::ostream &operator<<(std::ostream &os, const InstallResult &res);
 std::ostream &operator<<(std::ostream &os, const DownloadResult &res);
 
+struct SecondaryEcu {
+  SecondaryEcu(std::string serial, std::string hwid, std::string target_name)
+      : serial(std::move(serial)), hwid(std::move(hwid)), target_name(std::move(target_name)) {}
+  std::string serial;
+  std::string hwid;
+  std::string target_name;
+};
+
 /**
  * AkliteClient provides an easy-to-use API for users wanting to customize
  * the behavior of aktualizr-lite.
@@ -158,12 +166,20 @@ class AkliteClient {
   bool IsRollback(const TufTarget &t) const;
 
   /**
+   * Set the secondary ECUs managed by this device. Will update the status of
+   * the ECUs on the device-gateway and instruct the CheckIn method to also
+   * look for targets with the given hardware ids.
+   */
+  InstallResult SetSecondaries(const std::vector<SecondaryEcu> &ecus);
+
+  /**
    * Default files/paths to search for sota toml when configuration client.
    */
   static std::vector<boost::filesystem::path> CONFIG_DIRS;
 
  private:
   std::shared_ptr<LiteClient> client_;
+  std::vector<std::string> secondary_hwids_;
   mutable bool configUploaded_{false};
 };
 

--- a/include/aktualizr-lite/api.h
+++ b/include/aktualizr-lite/api.h
@@ -58,12 +58,18 @@ class CheckInResult {
     OkCached,  // check-in failed, but locally cached meta-data is still valid
     Failed,    // check-in failed and there's no valid local meta-data
   };
-  CheckInResult(Status status, std::vector<TufTarget> targets) : status(status), targets_(std::move(targets)) {}
+  CheckInResult(Status status, std::string primary_hwid, std::vector<TufTarget> targets)
+      : status(status), primary_hwid_(std::move(primary_hwid)), targets_(std::move(targets)) {}
   Status status;
   const std::vector<TufTarget> &Targets() const { return targets_; }
-  TufTarget GetLatest() const { return targets_.back(); }
+  /**
+   * If no hwid is specified, this method will return the latest target for
+   * the primary.
+   */
+  TufTarget GetLatest(std::string hwid = "") const;
 
  private:
+  std::string primary_hwid_;
   std::vector<TufTarget> targets_;
 };
 

--- a/include/aktualizr-lite/api.h
+++ b/include/aktualizr-lite/api.h
@@ -160,11 +160,6 @@ class AkliteClient {
   DownloadResult Download(const TufTarget &t, std::string reason = "");
 
   /**
-   * Install the Target
-   */
-  InstallResult Install(const TufTarget &t);
-
-  /**
    * Check if the Target has been installed but failed to boot. This would
    * make this be considered a "rollback target" and one we shouldn't consider
    * installing.

--- a/include/aktualizr-lite/api.h
+++ b/include/aktualizr-lite/api.h
@@ -109,6 +109,19 @@ class InstallContext {
   virtual ~InstallContext() = default;
   virtual DownloadResult Download() = 0;
   virtual InstallResult Install() = 0;
+
+  enum class SecondaryEvent {
+    DownloadStarted,
+    DownloadFailed,
+    DownloadCompleted,
+
+    InstallStarted,
+    InstallNeedsCompletion,
+    InstallCompleted,
+    InstallFailed,
+  };
+
+  virtual void QueueEvent(std::string ecu_serial, SecondaryEvent event, std::string details = "") = 0;
 };
 
 struct SecondaryEcu {

--- a/src/api.cc
+++ b/src/api.cc
@@ -173,3 +173,20 @@ bool AkliteClient::IsRollback(const TufTarget& t) const {
 
   return known_local_target(*client_, target, known_but_not_installed_versions);
 }
+
+InstallResult AkliteClient::SetSecondaries(const std::vector<SecondaryEcu>& ecus) {
+  std::vector<std::string> hwids;
+  Json::Value data;
+  for (const auto& ecu : ecus) {
+    Json::Value entry;
+    entry["target"] = ecu.target_name;
+    data[ecu.serial] = entry;
+    hwids.emplace_back(ecu.hwid);
+  }
+  const HttpResponse response = client_->http_client->put(client_->config.tls.server + "/ecus", data);
+  if (!response.isOk()) {
+    return InstallResult{InstallResult::Status::Failed, response.getStatusStr()};
+  }
+  secondary_hwids_ = std::move(hwids);
+  return InstallResult{InstallResult::Status::Ok, ""};
+}

--- a/src/liteclient.cc
+++ b/src/liteclient.cc
@@ -196,7 +196,7 @@ bool LiteClient::checkForUpdatesBegin() {
 
 void LiteClient::checkForUpdatesEnd(const Uptane::Target& target) { callback("check-for-update-post", target, "OK"); }
 
-void LiteClient::notify(const Uptane::Target& t, std::unique_ptr<ReportEvent> event) {
+void LiteClient::notify(const Uptane::Target& t, std::unique_ptr<ReportEvent> event) const {
   if (!config.tls.server.empty()) {
     event->custom["targetName"] = t.filename();
     event->custom["version"] = t.custom_version();

--- a/src/liteclient.h
+++ b/src/liteclient.h
@@ -49,6 +49,7 @@ class LiteClient {
   static void update_request_headers(std::shared_ptr<HttpClient>& http_client, const Uptane::Target& target,
                                      PackageConfig& config);
   void logTarget(const std::string& prefix, const Uptane::Target& target) const;
+  std::unique_ptr<ReportQueue> report_queue;
 
  private:
   FRIEND_TEST(helpers, locking);
@@ -73,7 +74,6 @@ class LiteClient {
   boost::filesystem::path callback_program;
   std::unique_ptr<KeyManager> key_manager_;
   std::shared_ptr<PackageManagerInterface> package_manager_;
-  std::unique_ptr<ReportQueue> report_queue;
 
   Uptane::ImageRepository image_repo_;
   std::shared_ptr<Uptane::Fetcher> uptane_fetcher_;

--- a/src/liteclient.h
+++ b/src/liteclient.h
@@ -57,7 +57,7 @@ class LiteClient {
 
   void callback(const char* msg, const Uptane::Target& install_target, const std::string& result = "");
 
-  void notify(const Uptane::Target& t, std::unique_ptr<ReportEvent> event);
+  void notify(const Uptane::Target& t, std::unique_ptr<ReportEvent> event) const;
   void notifyDownloadStarted(const Uptane::Target& t, const std::string& reason);
   void notifyDownloadFinished(const Uptane::Target& t, bool success);
   void notifyInstallStarted(const Uptane::Target& t);

--- a/tests/apiclient_test.cc
+++ b/tests/apiclient_test.cc
@@ -145,6 +145,17 @@ TEST_F(ApiClientTest, Install) {
   ASSERT_EQ(InstallResult::Status::NeedsCompletion, iresult.status);
 }
 
+TEST_F(ApiClientTest, Secondaries) {
+  AkliteClient client(createLiteClient(InitialVersion::kOff));
+  std::vector<SecondaryEcu> ecus;
+  ecus.emplace_back("123", "riscv", "target12");
+  auto res = client.SetSecondaries(ecus);
+  ASSERT_EQ(InstallResult::Status::Ok, res.status);
+  auto events = getDeviceGateway().getEvents();
+  ASSERT_EQ(1, events.size());
+  ASSERT_EQ("target12", events[0]["123"]["target"].asString());
+}
+
 int main(int argc, char** argv) {
   if (argc != 3) {
     std::cerr << argv[0] << " invalid arguments\n";

--- a/tests/apiclient_test.cc
+++ b/tests/apiclient_test.cc
@@ -154,6 +154,15 @@ TEST_F(ApiClientTest, Secondaries) {
   auto events = getDeviceGateway().getEvents();
   ASSERT_EQ(1, events.size());
   ASSERT_EQ("target12", events[0]["123"]["target"].asString());
+
+  auto new_target = createTarget();
+  auto secondary_target = createTarget(nullptr, "riscv");
+  auto result = client.CheckIn();
+  ASSERT_EQ(CheckInResult::Status::Ok, result.status);
+
+  ASSERT_EQ(2, result.Targets().size());
+  ASSERT_EQ(new_target.filename(), result.GetLatest().Name());
+  ASSERT_EQ(secondary_target.filename(), result.GetLatest("riscv").Name());
 }
 
 int main(int argc, char** argv) {

--- a/tests/apiclient_test.cc
+++ b/tests/apiclient_test.cc
@@ -138,10 +138,12 @@ TEST_F(ApiClientTest, Install) {
 
   auto latest = result.GetLatest();
 
-  auto dresult = client.Download(latest);
+  auto installer = client.Installer(latest);
+  ASSERT_NE(nullptr, installer);
+  auto dresult = installer->Download();
   ASSERT_EQ(DownloadResult::Status::Ok, dresult.status);
 
-  auto iresult = dresult.Install();
+  auto iresult = installer->Install();
   ASSERT_EQ(InstallResult::Status::NeedsCompletion, iresult.status);
 }
 

--- a/tests/device-gateway_fake.py
+++ b/tests/device-gateway_fake.py
@@ -22,7 +22,7 @@ class Handler(SimpleHTTPRequestHandler):
     SysInfoPrefix = "/system_info"
 
     def do_PUT(self):
-        if not self.path.startswith(self.SysInfoPrefix):
+        if not self.path.startswith(self.SysInfoPrefix) and not self.path.startswith("/ecus"):
             self.send_response(404)
             self.end_headers()
             return

--- a/tests/fixtures/liteclienttest.cc
+++ b/tests/fixtures/liteclienttest.cc
@@ -136,7 +136,7 @@ class ClientTest :virtual public ::testing::Test {
   /**
    * method createTarget
    */
-  Uptane::Target createTarget(const std::vector<AppEngine::App>* apps = nullptr) {
+  Uptane::Target createTarget(const std::vector<AppEngine::App>* apps = nullptr, std::string hwid="") {
     const auto& latest_target{getTufRepo().getLatest()};
     std::string version;
     try {
@@ -159,9 +159,13 @@ class ClientTest :virtual public ::testing::Test {
       }
     }
 
+    if (hwid.empty()) {
+      hwid = hw_id;
+    }
+
     // add new target to TUF repo
-    const std::string name = hw_id + "-" + os + "-" + version;
-    return getTufRepo().addTarget(name, hash, hw_id, version, apps_json);
+    const std::string name = hwid + "-" + os + "-" + version;
+    return getTufRepo().addTarget(name, hash, hwid, version, apps_json);
   }
 
   /**


### PR DESCRIPTION
This patchset allows custom clients to define and manage secondary ecus in the way that works best for them. The API doesn't specify mechanism, it simply provides APIs to inform the Foundries device-gateway the status of secondary ecus.