### PR TITLE
Restorable apps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ if(BUILD_AKLITE)
   add_dependencies(aklite aktualizr-lite)
 
   add_custom_target(aklite-tests)
-  add_dependencies(aklite-tests aklite t_lite-helpers uptane-generator t_compose-apps t_ostree t_liteclient t_yaml2json t_composeappengine t_aklite t_liteclientHSM t_apiclient)
+  add_dependencies(aklite-tests aklite t_lite-helpers uptane-generator t_compose-apps t_ostree t_liteclient t_yaml2json t_composeappengine t_restorableappengine t_aklite t_liteclientHSM t_apiclient)
   set(CMAKE_MODULE_PATH "${AKTUALIZR_DIR}/cmake-modules;${CMAKE_MODULE_PATH}")
 
   find_package(OSTree REQUIRED)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -105,7 +105,7 @@ RUN chmod +x /usr/local/bin/wrapdocker
 # Install skopeo
 RUN echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_20.04/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list && \
     wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_20.04/Release.key -O- | apt-key add -
-RUN apt-get update && apt-get -y install skopeo
+RUN apt-get update && apt-get -y install skopeo && ln -s /usr/bin/skopeo /sbin/skopeo
 
 RUN useradd testuser
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -102,6 +102,11 @@ RUN curl -sSL https://get.docker.com/ | sh
 ADD ./docker/wrapdocker /usr/local/bin/wrapdocker
 RUN chmod +x /usr/local/bin/wrapdocker
 
+# Install skopeo
+RUN echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_20.04/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list && \
+    wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_20.04/Release.key -O- | apt-key add -
+RUN apt-get update && apt-get -y install skopeo
+
 RUN useradd testuser
 
 WORKDIR /

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,7 @@ set(TARGET ${MAIN_TARGET_LIB})
 set(SRC helpers.cc
         composeappmanager.cc
         rootfstreemanager.cc
+        docker/restorableappengine.cc
         docker/composeappengine.cc
         docker/composeapptree.cc
         docker/composeinfo.cc
@@ -21,6 +22,7 @@ set(SRC helpers.cc
 set(HEADERS helpers.h
         composeappmanager.h
         rootfstreemanager.h
+        docker/restorableappengine.h
         docker/composeappengine.h
         docker/composeapptree.h
         docker/composeinfo.h

--- a/src/appengine.h
+++ b/src/appengine.h
@@ -19,6 +19,7 @@ class AppEngine {
   virtual bool install(const App& app) = 0;
   virtual bool run(const App& app) = 0;
   virtual void remove(const App& app) = 0;
+  virtual bool isFetched(const App& app) const = 0;
   virtual bool isRunning(const App& app) const = 0;
   virtual Json::Value getRunningAppsInfo() const = 0;
 

--- a/src/appengine.h
+++ b/src/appengine.h
@@ -2,7 +2,9 @@
 #define AKTUALIZR_LITE_APP_ENGINE_H_
 
 #include <memory>
+#include <set>
 #include <string>
+
 #include "json/json.h"
 
 class AppEngine {
@@ -12,6 +14,7 @@ class AppEngine {
     std::string uri;
   };
 
+  using Apps = std::vector<App>;
   using Ptr = std::shared_ptr<AppEngine>;
 
  public:
@@ -22,6 +25,7 @@ class AppEngine {
   virtual bool isFetched(const App& app) const = 0;
   virtual bool isRunning(const App& app) const = 0;
   virtual Json::Value getRunningAppsInfo() const = 0;
+  virtual void prune(const Apps& app_shortlist) = 0;
 
  public:
   virtual ~AppEngine() = default;

--- a/src/composeappmanager.cc
+++ b/src/composeappmanager.cc
@@ -49,6 +49,9 @@ ComposeAppManager::Config::Config(const PackageConfig& pconfig) {
   if (raw.count("docker_compose_bin") == 1) {
     compose_bin = raw.at("docker_compose_bin");
   }
+  if (raw.count("skopeo_bin") == 1) {
+    skopeo_bin = raw.at("skopeo_bin");
+  }
 
   if (raw.count("docker_prune") == 1) {
     std::string val = raw.at("docker_prune");
@@ -76,7 +79,7 @@ ComposeAppManager::ComposeAppManager(const PackageConfig& pconfig, const Bootloa
     auto docker_client{std::make_shared<Docker::DockerClient>()};
     auto registry_client{std::make_shared<Docker::RegistryClient>(http, cfg_.hub_auth_creds_endpoint)};
     const auto compose_cmd{boost::filesystem::canonical(cfg_.compose_bin).string() + " "};
-    const std::string skopeo_cmd{"skopeo"};
+    const std::string skopeo_cmd{boost::filesystem::canonical(cfg_.skopeo_bin).string()};
     const std::string docker_host{"unix:///var/run/docker.sock"};
 
     if (!!cfg_.reset_apps) {

--- a/src/composeappmanager.h
+++ b/src/composeappmanager.h
@@ -58,7 +58,7 @@ class ComposeAppManager : public RootfsTreeManager {
   Json::Value getRunningAppsInfo() const;
   std::string getRunningAppsInfoForReport() const;
 
-  AppsContainer getAppsToFetch(const Uptane::Target& t) const;
+  AppsContainer getAppsToFetch(const Uptane::Target& target, bool check_store = true) const;
 
  private:
   Config cfg_;

--- a/src/composeappmanager.h
+++ b/src/composeappmanager.h
@@ -24,6 +24,7 @@ class ComposeAppManager : public RootfsTreeManager {
     boost::filesystem::path apps_root{"/var/sota/compose-apps"};
     boost::filesystem::path reset_apps_root{"/var/sota/reset-apps"};
     boost::filesystem::path compose_bin{"/usr/bin/docker-compose"};
+    boost::filesystem::path skopeo_bin{"/sbin/skopeo"};
     bool docker_prune{true};
     bool force_update{false};
     boost::filesystem::path apps_tree{"/var/sota/compose-apps-tree"};

--- a/src/composeappmanager.h
+++ b/src/composeappmanager.h
@@ -20,7 +20,9 @@ class ComposeAppManager : public RootfsTreeManager {
     Config(const PackageConfig& pconfig);
 
     boost::optional<std::vector<std::string>> apps;
+    boost::optional<std::vector<std::string>> reset_apps;
     boost::filesystem::path apps_root{"/var/sota/compose-apps"};
+    boost::filesystem::path reset_apps_root{"/var/sota/reset-apps"};
     boost::filesystem::path compose_bin{"/usr/bin/docker-compose"};
     bool docker_prune{true};
     bool force_update{false};
@@ -56,9 +58,12 @@ class ComposeAppManager : public RootfsTreeManager {
   Json::Value getRunningAppsInfo() const;
   std::string getRunningAppsInfoForReport() const;
 
+  AppsContainer getAppsToFetch(const Uptane::Target& t) const;
+
  private:
   Config cfg_;
   mutable AppsContainer cur_apps_to_fetch_and_update_;
+  mutable AppsContainer cur_apps_to_fetch_;
   bool are_apps_checked_{false};
   AppEngine::Ptr app_engine_;
   std::unique_ptr<ComposeAppTree> app_tree_;

--- a/src/composeappmanager.h
+++ b/src/composeappmanager.h
@@ -59,6 +59,7 @@ class ComposeAppManager : public RootfsTreeManager {
   std::string getRunningAppsInfoForReport() const;
 
   AppsContainer getAppsToFetch(const Uptane::Target& target, bool check_store = true) const;
+  void removeDisabledComposeApps(const Uptane::Target& target) const;
 
  private:
   Config cfg_;

--- a/src/docker/composeappengine.cc
+++ b/src/docker/composeappengine.cc
@@ -135,6 +135,20 @@ void ComposeAppEngine::remove(const App& app) {
   }
 }
 
+bool ComposeAppEngine::isFetched(const App& app) const {
+  if (!boost::filesystem::exists(appRoot(app))) {
+    return false;
+  }
+  bool res{false};
+  try {
+    AppState state(app, appRoot(app));
+    res = state() == AppState::State::kPulled;
+  } catch (const std::exception& exc) {
+    LOG_WARNING << "Failed to get/set App state: " << exc.what();
+  }
+  return res;
+}
+
 bool ComposeAppEngine::isRunning(const App& app) const {
   if (!boost::filesystem::exists(appRoot(app))) {
     return false;

--- a/src/docker/composeappengine.cc
+++ b/src/docker/composeappengine.cc
@@ -358,6 +358,15 @@ void ComposeAppEngine::extractAppArchive(const App& app, const std::string& arch
   }
 }
 
+void ComposeAppEngine::pruneDockerStore() {
+  LOG_INFO << "Pruning unused docker images";
+  // Utils::shell which isn't interactive, we'll use std::system so that
+  // stdout/stderr is streamed while docker sets things up.
+  if (std::system("docker image prune -a -f --filter=\"label!=aktualizr-no-prune\"") != 0) {
+    LOG_WARNING << "Unable to prune unused docker images";
+  }
+}
+
 ComposeAppEngine::AppState::AppState(const App& app, const boost::filesystem::path& root, bool set_version) try
     : version_file_ {
   (root / MetaDir / VersionFile).string()

--- a/src/docker/composeappengine.cc
+++ b/src/docker/composeappengine.cc
@@ -229,41 +229,6 @@ Json::Value ComposeAppEngine::getRunningAppsInfo() const {
 
 // Private implementation
 
-struct Manifest : Json::Value {
-  static constexpr const char* const Format{"application/vnd.oci.image.manifest.v1+json"};
-  static constexpr const char* const Version{"v1"};
-
-  explicit Manifest(const Json::Value& value = Json::Value()) : Json::Value(value) {
-    auto manifest_version{(*this)["annotations"]["compose-app"].asString()};
-    if (manifest_version.empty()) {
-      throw std::runtime_error("Got invalid App manifest, missing a manifest version: " +
-                               Utils::jsonToCanonicalStr(value));
-    }
-    if (Version != manifest_version) {
-      throw std::runtime_error("Got unsupported App manifest version: " + Utils::jsonToCanonicalStr(value));
-    }
-  }
-
-  std::string archiveDigest() const {
-    auto digest{(*this)["layers"][0]["digest"].asString()};
-    if (digest.empty()) {
-      throw std::runtime_error("Got invalid App manifest, failed to extract App Archive digest from App manifest: " +
-                               Utils::jsonToCanonicalStr(*this));
-    }
-    return digest;
-  }
-
-  size_t archiveSize() const {
-    uint64_t arch_size{(*this)["layers"][0]["size"].asUInt64()};
-    if (0 == arch_size || arch_size > std::numeric_limits<size_t>::max()) {
-      throw std::runtime_error("Invalid size of App Archive is specified in App manifest: " +
-                               Utils::jsonToCanonicalStr(*this));
-    }
-
-    return arch_size;
-  }
-};
-
 // Utils::shell isn't interactive. The compose commands can take a few
 // seconds to run, so we use boost::process:system to stream it to stdout/sterr
 bool ComposeAppEngine::cmd_streaming(const std::string& cmd, const App& app) {

--- a/src/docker/composeappengine.h
+++ b/src/docker/composeappengine.h
@@ -27,6 +27,13 @@ class ComposeAppEngine : public AppEngine {
   bool isFetched(const App& app) const override;
   bool isRunning(const App& app) const override;
   Json::Value getRunningAppsInfo() const override;
+  void prune(const Apps& app_shortlist) override {
+    (void)app_shortlist;
+    pruneDockerStore();
+  }
+
+ public:
+  static void pruneDockerStore();
 
  private:
   static constexpr const char* const MetaDir{".meta"};

--- a/src/docker/composeappengine.h
+++ b/src/docker/composeappengine.h
@@ -24,6 +24,7 @@ class ComposeAppEngine : public AppEngine {
   bool install(const App& app) override;
   bool run(const App& app) override;
   void remove(const App& app) override;
+  bool isFetched(const App& app) const override;
   bool isRunning(const App& app) const override;
   Json::Value getRunningAppsInfo() const override;
 

--- a/src/docker/composeinfo.cc
+++ b/src/docker/composeinfo.cc
@@ -7,7 +7,7 @@ namespace Docker {
 
 ComposeInfo::ComposeInfo(const std::string& yaml) : json_(yaml) {}
 
-std::vector<Json::Value> ComposeInfo::getServices() {
+std::vector<Json::Value> ComposeInfo::getServices() const {
   Json::Value p = json_.root_["services"];
   std::vector<Json::Value> services;
   for (Json::ValueIterator ii = p.begin(); ii != p.end(); ++ii) {
@@ -16,11 +16,11 @@ std::vector<Json::Value> ComposeInfo::getServices() {
   return services;
 }
 
-std::string ComposeInfo::getImage(const Json::Value& service) {
+std::string ComposeInfo::getImage(const Json::Value& service) const {
   return json_.root_["services"][service.asString()]["image"].asString();
 }
 
-std::string ComposeInfo::getHash(const Json::Value& service) {
+std::string ComposeInfo::getHash(const Json::Value& service) const {
   return json_.root_["services"][service.asString()]["labels"]["io.compose-spec.config-hash"].asString();
 }
 

--- a/src/docker/composeinfo.h
+++ b/src/docker/composeinfo.h
@@ -11,9 +11,9 @@ namespace Docker {
 class ComposeInfo {
  public:
   ComposeInfo(const std::string& yaml);
-  std::vector<Json::Value> getServices();
-  std::string getImage(const Json::Value& service);
-  std::string getHash(const Json::Value& service);
+  std::vector<Json::Value> getServices() const;
+  std::string getImage(const Json::Value& service) const;
+  std::string getHash(const Json::Value& service) const;
 
  private:
   Yaml2Json json_;

--- a/src/docker/docker.cc
+++ b/src/docker/docker.cc
@@ -39,7 +39,7 @@ Uri Uri::parseUri(const std::string& uri) {
   return Uri{HashedDigest{digest}, app, factory, repo, registry_hostname};
 }
 
-Uri Uri::createUri(const HashedDigest& digest_in) {
+Uri Uri::createUri(const HashedDigest& digest_in) const {
   return Uri{HashedDigest{digest_in}, app, factory, repo, registryHostname};
 }
 

--- a/src/docker/restorableappengine.cc
+++ b/src/docker/restorableappengine.cc
@@ -1,0 +1,19 @@
+#include "restorableappengine.h"
+
+namespace Docker {
+
+RestorableAppEngine::RestorableAppEngine() {}
+
+bool RestorableAppEngine::fetch(const App& app) {}
+
+bool RestorableAppEngine::install(const App& app) {}
+
+bool RestorableAppEngine::run(const App& app) {}
+
+void RestorableAppEngine::remove(const App& app) {}
+
+bool RestorableAppEngine::isRunning(const App& app) const {}
+
+Json::Value RestorableAppEngine::getRunningAppsInfo() const {}
+
+}  // namespace Docker

--- a/src/docker/restorableappengine.cc
+++ b/src/docker/restorableappengine.cc
@@ -1,11 +1,36 @@
 #include "restorableappengine.h"
 
+#include <boost/format.hpp>
+#include <boost/process.hpp>
+
+#include "docker/composeinfo.h"
+
 namespace Docker {
 
-RestorableAppEngine::RestorableAppEngine() {}
+const std::string RestorableAppEngine::ComposeFile{"docker-compose.yml"};
+
+RestorableAppEngine::RestorableAppEngine(boost::filesystem::path store_root,
+                                         Docker::RegistryClient::Ptr registry_client, const std::string& client)
+    : store_root_{std::move(store_root)}, client_{std::move(client)}, registry_client_{std::move(registry_client)} {
+  boost::filesystem::create_directories(apps_root_);
+  boost::filesystem::create_directories(blobs_root_);
+}
 
 bool RestorableAppEngine::fetch(const App& app) {
   bool res{true};
+  try {
+    const Uri uri{Uri::parseUri(app.uri)};
+    const auto app_dir{apps_root_ / uri.app / uri.digest.hash()};
+    LOG_DEBUG << app.name << ": downloading App from Registry: " << app.uri << " --> " << app_dir;
+    const auto app_compose_file{pullApp(uri, app_dir)};
+
+    const auto images_dir{app_dir / "images"};
+    LOG_DEBUG << app.name << ": downloading App images from Registry(ies): " << app.uri << " --> " << images_dir;
+    pullAppImages(app_compose_file, images_dir);
+  } catch (const std::exception& exc) {
+    LOG_ERROR << "failed to fetch App; app: " + app.name + "; uri: " + app.uri + "; err: " + exc.what();
+  }
+
   return res;
 }
 
@@ -27,5 +52,57 @@ bool RestorableAppEngine::isRunning(const App& app) const {
 }
 
 Json::Value RestorableAppEngine::getRunningAppsInfo() const { return Json::Value(); }
+
+// protected & private implementation
+
+boost::filesystem::path RestorableAppEngine::pullApp(const Uri& uri, const boost::filesystem::path& app_dir) {
+  boost::filesystem::create_directories(app_dir);
+
+  const Manifest manifest{registry_client_->getAppManifest(uri, Manifest::Format)};
+  Docker::Uri archive_uri{uri.createUri(manifest.archiveDigest())};
+  const auto archive_full_path{app_dir / (HashedDigest(manifest.archiveDigest()).hash() + Manifest::ArchiveExt)};
+
+  registry_client_->downloadBlob(archive_uri, archive_full_path, manifest.archiveSize());
+  // TODO: verify archive
+
+  Utils::writeFile(app_dir / Manifest::Filename, manifest);
+  // extract docker-compose.yml, temporal hack, we don't need to extract it
+  auto cmd = boost::str(boost::format("tar -xzf %s %s") % archive_full_path % ComposeFile);
+  if (0 != boost::process::system(cmd, boost::this_process::environment(), boost::process::start_dir = app_dir)) {
+    throw std::runtime_error("failed to extract the compose app archive: " + archive_full_path.string());
+  }
+
+  return app_dir / ComposeFile;
+}
+
+void RestorableAppEngine::pullAppImages(const boost::filesystem::path& app_compose_file,
+                                        const boost::filesystem::path& dst_dir) {
+  boost::filesystem::create_directories(dst_dir);
+
+  const auto compose{ComposeInfo(app_compose_file.string())};
+  for (const auto& service : compose.getServices()) {
+    const auto image_uri = compose.getImage(service);
+    LOG_ERROR << image_uri;
+
+    const Uri uri{Uri::parseUri(image_uri)};
+    const auto image_dir{dst_dir / uri.registryHostname / uri.repo / uri.digest.hash()};
+
+    LOG_DEBUG << uri.app << ": downloading image from Registry: " << image_uri << " --> " << dst_dir;
+    pullImage(client_, image_uri, image_dir, blobs_root_);
+  }
+}
+
+void RestorableAppEngine::pullImage(const std::string& client, const std::string& uri,
+                                    const boost::filesystem::path& dst_dir,
+                                    const boost::filesystem::path& shared_blob_dir, const std::string& format) {
+  boost::filesystem::create_directories(dst_dir);
+
+  boost::format cmd_fmt{"%s copy -f %s --dest-shared-blob-dir %s docker://%s oci:%s"};
+  const auto cmd{boost::str(cmd_fmt % client % format % shared_blob_dir.string() % uri % dst_dir.string())};
+
+  if (0 != boost::process::system(cmd, boost::this_process::environment())) {
+    throw std::runtime_error("failed to pull image " + uri);
+  }
+}
 
 }  // namespace Docker

--- a/src/docker/restorableappengine.cc
+++ b/src/docker/restorableappengine.cc
@@ -9,9 +9,14 @@ namespace Docker {
 
 const std::string RestorableAppEngine::ComposeFile{"docker-compose.yml"};
 
-RestorableAppEngine::RestorableAppEngine(boost::filesystem::path store_root,
-                                         Docker::RegistryClient::Ptr registry_client, const std::string& client)
-    : store_root_{std::move(store_root)}, client_{std::move(client)}, registry_client_{std::move(registry_client)} {
+RestorableAppEngine::RestorableAppEngine(boost::filesystem::path store_root, boost::filesystem::path install_root,
+                                         Docker::RegistryClient::Ptr registry_client, const std::string& client,
+                                         const std::string& docker_host)
+    : store_root_{std::move(store_root)},
+      install_root_{std::move(install_root)},
+      client_{std::move(client)},
+      docker_host_{std::move(docker_host)},
+      registry_client_{std::move(registry_client)} {
   boost::filesystem::create_directories(apps_root_);
   boost::filesystem::create_directories(blobs_root_);
 }
@@ -36,6 +41,17 @@ bool RestorableAppEngine::fetch(const App& app) {
 
 bool RestorableAppEngine::install(const App& app) {
   bool res{true};
+  try {
+    const Uri uri{Uri::parseUri(app.uri)};
+    const auto app_dir{apps_root_ / uri.app / uri.digest.hash()};
+    const auto app_install_dir{install_root_ / app.name};
+    LOG_DEBUG << app.name << ": installing App: " << app_dir << " --> " << app_install_dir;
+    installApp(app_dir, app_install_dir);
+    LOG_DEBUG << app.name << ": installing App images: " << app_dir << " --> docker://";
+    installAppImages(app_dir);
+  } catch (const std::exception& exc) {
+    LOG_ERROR << "failed to fetch App; app: " + app.name + "; uri: " + app.uri + "; err: " + exc.what();
+  }
   return res;
 }
 
@@ -92,6 +108,32 @@ void RestorableAppEngine::pullAppImages(const boost::filesystem::path& app_compo
   }
 }
 
+void RestorableAppEngine::installApp(const boost::filesystem::path& app_dir, const boost::filesystem::path& dst_dir) {
+  const Manifest manifest{Utils::parseJSONFile(app_dir / Manifest::Filename)};
+  const auto archive_full_path{app_dir / (HashedDigest(manifest.archiveDigest()).hash() + Manifest::ArchiveExt)};
+
+  boost::filesystem::create_directories(dst_dir);
+  auto cmd = boost::str(boost::format("tar --overwrite -xzf %s") % archive_full_path.string());
+  if (0 != boost::process::system(cmd, boost::process::start_dir = dst_dir)) {
+    throw std::runtime_error("failed to install Compose App: " + app_dir.string());
+  }
+}
+
+void RestorableAppEngine::installAppImages(const boost::filesystem::path& app_dir) {
+  const auto compose{ComposeInfo((app_dir / ComposeFile).string())};
+  for (const auto& service : compose.getServices()) {
+    const auto image_uri = compose.getImage(service);
+    LOG_ERROR << image_uri;
+
+    const Uri uri{Uri::parseUri(image_uri)};
+    const std::string tag{uri.registryHostname + '/' + uri.repo + ':' + uri.digest.shortHash()};
+    const auto image_dir{app_dir / "images" / uri.registryHostname / uri.repo / uri.digest.hash()};
+    installImage(client_, image_dir, blobs_root_, docker_host_, tag);
+  }
+}
+
+// static methods to manage image data
+
 void RestorableAppEngine::pullImage(const std::string& client, const std::string& uri,
                                     const boost::filesystem::path& dst_dir,
                                     const boost::filesystem::path& shared_blob_dir, const std::string& format) {
@@ -101,7 +143,19 @@ void RestorableAppEngine::pullImage(const std::string& client, const std::string
   const auto cmd{boost::str(cmd_fmt % client % format % shared_blob_dir.string() % uri % dst_dir.string())};
 
   if (0 != boost::process::system(cmd, boost::this_process::environment())) {
-    throw std::runtime_error("failed to pull image " + uri);
+    throw std::runtime_error("failed to install image " + uri);
+  }
+}
+
+void RestorableAppEngine::installImage(const std::string& client, const boost::filesystem::path& image_dir,
+                                       const boost::filesystem::path& shared_blob_dir, const std::string& docker_host,
+                                       const std::string& tag, const std::string& format) {
+  boost::format cmd_fmt{"%s copy -f %s --dest-daemon-host %s --src-shared-blob-dir %s oci:%s docker-daemon:%s"};
+  LOG_ERROR << image_dir;
+  std::string cmd{
+      boost::str(cmd_fmt % client % format % docker_host % shared_blob_dir.string() % image_dir.string() % tag)};
+  if (0 != boost::process::system(cmd, boost::this_process::environment())) {
+    throw std::runtime_error("failed to install image ");
   }
 }
 

--- a/src/docker/restorableappengine.cc
+++ b/src/docker/restorableappengine.cc
@@ -3,6 +3,7 @@
 #include <boost/format.hpp>
 #include <boost/process.hpp>
 
+#include "crypto/crypto.h"
 #include "docker/composeinfo.h"
 
 namespace Docker {
@@ -10,14 +11,16 @@ namespace Docker {
 const std::string RestorableAppEngine::ComposeFile{"docker-compose.yml"};
 
 RestorableAppEngine::RestorableAppEngine(boost::filesystem::path store_root, boost::filesystem::path install_root,
-                                         Docker::RegistryClient::Ptr registry_client, const std::string& client,
+                                         Docker::RegistryClient::Ptr registry_client,
+                                         Docker::DockerClient::Ptr docker_client, const std::string& client,
                                          const std::string& docker_host, const std::string& compose_cmd)
     : store_root_{std::move(store_root)},
       install_root_{std::move(install_root)},
       client_{std::move(client)},
       docker_host_{std::move(docker_host)},
       compose_cmd_{std::move(compose_cmd)},
-      registry_client_{std::move(registry_client)} {
+      registry_client_{std::move(registry_client)},
+      docker_client_{std::move(docker_client)} {
   boost::filesystem::create_directories(apps_root_);
   boost::filesystem::create_directories(blobs_root_);
 }
@@ -68,11 +71,49 @@ bool RestorableAppEngine::run(const App& app) {
 void RestorableAppEngine::remove(const App& app) {}
 
 bool RestorableAppEngine::isRunning(const App& app) const {
-  bool res{true};
+  bool res{false};
+
+  try {
+    res = isAppInstalled(app) && isRunning(app, (install_root_ / app.name / ComposeFile).string(), docker_client_);
+  } catch (const std::exception& exc) {
+    LOG_WARNING << "App: " << app.name << ", cant check whether App is running: " << exc.what();
+  }
+
   return res;
 }
 
-Json::Value RestorableAppEngine::getRunningAppsInfo() const { return Json::Value(); }
+Json::Value RestorableAppEngine::getRunningAppsInfo() const {
+  Json::Value apps;
+  try {
+    Json::Value containers;
+    docker_client_->getContainers(containers);
+
+    for (Json::ValueIterator ii = containers.begin(); ii != containers.end(); ++ii) {
+      Json::Value val = *ii;
+
+      std::string app_name = val["Labels"]["com.docker.compose.project"].asString();
+      if (app_name.empty()) {
+        continue;
+      }
+
+      std::string service = val["Labels"]["com.docker.compose.service"].asString();
+      std::string hash = val["Labels"]["io.compose-spec.config-hash"].asString();
+      std::string image = val["Image"].asString();
+      std::string state = val["State"].asString();
+      std::string status = val["Status"].asString();
+
+      apps[app_name]["services"][service]["hash"] = hash;
+      apps[app_name]["services"][service]["image"] = image;
+      apps[app_name]["services"][service]["state"] = state;
+      apps[app_name]["services"][service]["status"] = status;
+    }
+
+  } catch (const std::exception& exc) {
+    LOG_WARNING << "Failed to get an info about running containers: " << exc.what();
+  }
+
+  return apps;
+}
 
 // protected & private implementation
 
@@ -146,6 +187,95 @@ void RestorableAppEngine::installAppImages(const boost::filesystem::path& app_di
     const auto image_dir{app_dir / "images" / uri.registryHostname / uri.repo / uri.digest.hash()};
     installImage(client_, image_dir, blobs_root_, docker_host_, tag);
   }
+}
+
+bool RestorableAppEngine::isAppInstalled(const App& app) const {
+  bool res{false};
+  const Uri uri{Uri::parseUri(app.uri)};
+  const auto app_dir{apps_root_ / uri.app / uri.digest.hash()};
+  const auto app_install_dir{install_root_ / app.name};
+
+  do {
+    if (!boost::filesystem::exists(app_dir)) {
+      LOG_DEBUG << app.name << ": missing App dir: " << app_dir;
+      break;
+    }
+
+    const auto manifest_file{app_dir / Manifest::Filename};
+    if (!boost::filesystem::exists(manifest_file)) {
+      LOG_DEBUG << app.name << ": missing App manifest: " << manifest_file;
+      break;
+    }
+
+    const Manifest manifest{Utils::parseJSONFile(manifest_file)};
+    const auto archive_manifest_hash{HashedDigest(manifest.archiveDigest()).hash()};
+    const auto archive_full_path{app_dir / (archive_manifest_hash + Manifest::ArchiveExt)};
+    if (!boost::filesystem::exists(archive_full_path)) {
+      LOG_DEBUG << app.name << ": missing App archive: " << archive_full_path;
+      break;
+    }
+
+    // we assume that a compose App blob is relatively small so we can just read it all into RAM
+    const auto app_arch_str = Utils::readFile(archive_full_path);
+    const auto app_arch_hash =
+        boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha256digest(app_arch_str)));
+    if (app_arch_hash != archive_manifest_hash) {
+      LOG_DEBUG << app.name << ": App archive hash mismatch; actual: " << app_arch_str
+                << "; defined in manifest: " << archive_manifest_hash;
+      break;
+    }
+
+    auto cmd = boost::str(boost::format("tar -xzf %s %s") % archive_full_path % ComposeFile);
+    if (0 != boost::process::system(cmd, boost::this_process::environment(), boost::process::start_dir = app_dir)) {
+      LOG_DEBUG << app.name
+                << ": failed to extract a compose file from the compose app archive: " + archive_full_path.string();
+      break;
+    }
+
+    const auto compose_file_str = Utils::readFile(app_dir / ComposeFile);
+    const auto compose_file_hash =
+        boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha256digest(compose_file_str)));
+    const auto installed_compose_file_str = Utils::readFile(app_install_dir / ComposeFile);
+    const auto installed_compose_file_hash =
+        boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha256digest(installed_compose_file_str)));
+
+    if (compose_file_hash != installed_compose_file_hash) {
+      LOG_DEBUG << app.name << "; a compose file hash mismatch; installed: " << installed_compose_file_hash
+                << "fetched: " << compose_file_hash;
+      break;
+    }
+    // TODO: check if App images are installed, require a function to generate sha256 hash while reading data from a
+    // file.
+    res = true;
+  } while (0);
+
+  return res;
+}
+
+bool RestorableAppEngine::isRunning(const App& app, const std::string& compose_file,
+                                    const Docker::DockerClient::Ptr& docker_client) {
+  ComposeInfo compose{compose_file};
+  std::vector<Json::Value> services = compose.getServices();
+
+  if (services.empty()) {
+    LOG_WARNING << "App: " << app.name << ", no services in App's compose file: " << compose_file;
+    return false;
+  }
+
+  Json::Value containers;
+  docker_client->getContainers(containers);
+
+  for (std::size_t i = 0; i < services.size(); i++) {
+    std::string service = services[i].asString();
+    std::string hash = compose.getHash(services[i]);
+    if (docker_client->isRunning(containers, app.name, service, hash)) {
+      continue;
+    }
+    LOG_WARNING << "App: " << app.name << ", service: " << service << ", hash: " << hash << ", not running!";
+    return false;
+  }
+
+  return true;
 }
 
 // static methods to manage image data and Compose App

--- a/src/docker/restorableappengine.cc
+++ b/src/docker/restorableappengine.cc
@@ -4,16 +4,28 @@ namespace Docker {
 
 RestorableAppEngine::RestorableAppEngine() {}
 
-bool RestorableAppEngine::fetch(const App& app) {}
+bool RestorableAppEngine::fetch(const App& app) {
+  bool res{true};
+  return res;
+}
 
-bool RestorableAppEngine::install(const App& app) {}
+bool RestorableAppEngine::install(const App& app) {
+  bool res{true};
+  return res;
+}
 
-bool RestorableAppEngine::run(const App& app) {}
+bool RestorableAppEngine::run(const App& app) {
+  bool res{true};
+  return res;
+}
 
 void RestorableAppEngine::remove(const App& app) {}
 
-bool RestorableAppEngine::isRunning(const App& app) const {}
+bool RestorableAppEngine::isRunning(const App& app) const {
+  bool res{true};
+  return res;
+}
 
-Json::Value RestorableAppEngine::getRunningAppsInfo() const {}
+Json::Value RestorableAppEngine::getRunningAppsInfo() const { return Json::Value(); }
 
 }  // namespace Docker

--- a/src/docker/restorableappengine.cc
+++ b/src/docker/restorableappengine.cc
@@ -15,8 +15,8 @@ const std::string RestorableAppEngine::ComposeFile{"docker-compose.yml"};
 
 RestorableAppEngine::RestorableAppEngine(boost::filesystem::path store_root, boost::filesystem::path install_root,
                                          Docker::RegistryClient::Ptr registry_client,
-                                         Docker::DockerClient::Ptr docker_client, const std::string& client,
-                                         const std::string& docker_host, const std::string& compose_cmd)
+                                         Docker::DockerClient::Ptr docker_client, std::string client,
+                                         std::string docker_host, std::string compose_cmd)
     : store_root_{std::move(store_root)},
       install_root_{std::move(install_root)},
       client_{std::move(client)},
@@ -277,7 +277,7 @@ void RestorableAppEngine::pullAppImages(const boost::filesystem::path& app_compo
 boost::filesystem::path RestorableAppEngine::installAppAndImages(const App& app) {
   const Uri uri{Uri::parseUri(app.uri)};
   const auto app_dir{apps_root_ / uri.app / uri.digest.hash()};
-  const auto app_install_dir{install_root_ / app.name};
+  auto app_install_dir{install_root_ / app.name};
   LOG_DEBUG << app.name << ": installing App: " << app_dir << " --> " << app_install_dir;
   installApp(app_dir, app_install_dir);
   LOG_DEBUG << app.name << ": installing App images: " << app_dir << " --> docker://";
@@ -346,7 +346,7 @@ bool RestorableAppEngine::isAppFetched(const App& app) const {
     // TODO: check if App images are installed, require a function to generate sha256 hash while reading data from a
     // file.
     res = true;
-  } while (0);
+  } while (false);
 
   return res;
 }
@@ -385,7 +385,7 @@ bool RestorableAppEngine::isAppInstalled(const App& app) const {
     // TODO: check whether docker store has all App images
 
     res = true;
-  } while (0);
+  } while (false);
 
   return res;
 }

--- a/src/docker/restorableappengine.h
+++ b/src/docker/restorableappengine.h
@@ -57,6 +57,8 @@ class RestorableAppEngine : public AppEngine {
   static void startComposeApp(const std::string& compose_cmd, const boost::filesystem::path& app_dir,
                               const std::string& flags = "up --remove-orphans -d");
 
+  static void stopComposeApp(const std::string& compose_cmd, const boost::filesystem::path& app_dir);
+
  private:
   const boost::filesystem::path store_root_;
   const boost::filesystem::path install_root_;

--- a/src/docker/restorableappengine.h
+++ b/src/docker/restorableappengine.h
@@ -24,6 +24,7 @@ class RestorableAppEngine : public AppEngine {
   bool install(const App& app) override;
   bool run(const App& app) override;
   void remove(const App& app) override;
+  bool isFetched(const App& app) const override;
   bool isRunning(const App& app) const override;
   Json::Value getRunningAppsInfo() const override;
 
@@ -37,6 +38,7 @@ class RestorableAppEngine : public AppEngine {
   void installApp(const boost::filesystem::path& app_dir, const boost::filesystem::path& dst_dir);
   void installAppImages(const boost::filesystem::path& app_dir);
 
+  bool isAppFetched(const App& app) const;
   bool isAppInstalled(const App& app) const;
 
   // check if App&Images are running

--- a/src/docker/restorableappengine.h
+++ b/src/docker/restorableappengine.h
@@ -15,9 +15,8 @@ class RestorableAppEngine : public AppEngine {
  public:
   RestorableAppEngine(boost::filesystem::path store_root, boost::filesystem::path install_root,
                       Docker::RegistryClient::Ptr registry_client, Docker::DockerClient::Ptr docker_client,
-                      const std::string& client = "skopeo",
-                      const std::string& docker_host = "unix:///var/run/docker.sock",
-                      const std::string& compose_cmd = "/usr/bin/docker-compose");
+                      std::string client = "skopeo", std::string docker_host = "unix:///var/run/docker.sock",
+                      std::string compose_cmd = "/usr/bin/docker-compose");
 
  public:
   bool fetch(const App& app) override;
@@ -36,7 +35,7 @@ class RestorableAppEngine : public AppEngine {
 
   // install App&Images
   boost::filesystem::path installAppAndImages(const App& app);
-  void installApp(const boost::filesystem::path& app_dir, const boost::filesystem::path& dst_dir);
+  static void installApp(const boost::filesystem::path& app_dir, const boost::filesystem::path& dst_dir);
   void installAppImages(const boost::filesystem::path& app_dir);
 
   bool isAppFetched(const App& app) const;

--- a/src/docker/restorableappengine.h
+++ b/src/docker/restorableappengine.h
@@ -27,6 +27,7 @@ class RestorableAppEngine : public AppEngine {
   bool isFetched(const App& app) const override;
   bool isRunning(const App& app) const override;
   Json::Value getRunningAppsInfo() const override;
+  void prune(const Apps& app_shortlist) override;
 
  private:
   // pull App&Images

--- a/src/docker/restorableappengine.h
+++ b/src/docker/restorableappengine.h
@@ -15,7 +15,7 @@ class RestorableAppEngine : public AppEngine {
  public:
   RestorableAppEngine(boost::filesystem::path store_root, boost::filesystem::path install_root,
                       Docker::RegistryClient::Ptr registry_client, Docker::DockerClient::Ptr docker_client,
-                      std::string client = "skopeo", std::string docker_host = "unix:///var/run/docker.sock",
+                      std::string client = "/sbin/skopeo", std::string docker_host = "unix:///var/run/docker.sock",
                       std::string compose_cmd = "/usr/bin/docker-compose");
 
  public:

--- a/src/docker/restorableappengine.h
+++ b/src/docker/restorableappengine.h
@@ -1,0 +1,23 @@
+#ifndef AKTUALIZR_LITE_RESTORABLE_APP_ENGINE_H_
+#define AKTUALIZR_LITE_RESTORABLE_APP_ENGINE_H_
+
+#include "appengine.h"
+
+namespace Docker {
+
+class RestorableAppEngine : public AppEngine {
+ public:
+  RestorableAppEngine();
+
+ public:
+  bool fetch(const App& app) override;
+  bool install(const App& app) override;
+  bool run(const App& app) override;
+  void remove(const App& app) override;
+  bool isRunning(const App& app) const override;
+  Json::Value getRunningAppsInfo() const override;
+};
+
+}  // namespace Docker
+
+#endif  // AKTUALIZR_LITE_RESTORABLE_APP_ENGINE_H_

--- a/src/docker/restorableappengine.h
+++ b/src/docker/restorableappengine.h
@@ -3,11 +3,17 @@
 
 #include "appengine.h"
 
+#include "docker/docker.h"
+
 namespace Docker {
 
 class RestorableAppEngine : public AppEngine {
  public:
-  RestorableAppEngine();
+  static const std::string ComposeFile;
+
+ public:
+  RestorableAppEngine(boost::filesystem::path store_root, Docker::RegistryClient::Ptr registry_client,
+                      const std::string& client = "skopeo");
 
  public:
   bool fetch(const App& app) override;
@@ -16,6 +22,21 @@ class RestorableAppEngine : public AppEngine {
   void remove(const App& app) override;
   bool isRunning(const App& app) const override;
   Json::Value getRunningAppsInfo() const override;
+
+ private:
+  boost::filesystem::path pullApp(const Uri& uri, const boost::filesystem::path& app_dir);
+  void pullAppImages(const boost::filesystem::path& app_compose_file, const boost::filesystem::path& dst_dir);
+
+  // image tranfer utility specific functions
+  static void pullImage(const std::string& client, const std::string& uri, const boost::filesystem::path& dst_dir,
+                        const boost::filesystem::path& shared_blob_dir, const std::string& format = "v2s2");
+
+ private:
+  const boost::filesystem::path store_root_;
+  const std::string client_;
+  const boost::filesystem::path apps_root_{store_root_ / "apps"};
+  const boost::filesystem::path blobs_root_{store_root_ / "blobs"};
+  Docker::RegistryClient::Ptr registry_client_;
 };
 
 }  // namespace Docker

--- a/src/docker/restorableappengine.h
+++ b/src/docker/restorableappengine.h
@@ -14,7 +14,8 @@ class RestorableAppEngine : public AppEngine {
  public:
   RestorableAppEngine(boost::filesystem::path store_root, boost::filesystem::path install_root,
                       Docker::RegistryClient::Ptr registry_client, const std::string& client = "skopeo",
-                      const std::string& docker_host = "unix:///var/run/docker.sock");
+                      const std::string& docker_host = "unix:///var/run/docker.sock",
+                      const std::string& compose_cmd = "/usr/bin/docker-compose");
 
  public:
   bool fetch(const App& app) override;
@@ -28,6 +29,7 @@ class RestorableAppEngine : public AppEngine {
   boost::filesystem::path pullApp(const Uri& uri, const boost::filesystem::path& app_dir);
   void pullAppImages(const boost::filesystem::path& app_compose_file, const boost::filesystem::path& dst_dir);
 
+  boost::filesystem::path installAppAndImages(const App& app);
   void installApp(const boost::filesystem::path& app_dir, const boost::filesystem::path& dst_dir);
   void installAppImages(const boost::filesystem::path& app_dir);
 
@@ -39,11 +41,15 @@ class RestorableAppEngine : public AppEngine {
                            const boost::filesystem::path& shared_blob_dir, const std::string& docker_host,
                            const std::string& tag, const std::string& format = "v2s2");
 
+  static void startComposeApp(const std::string& compose_cmd, const boost::filesystem::path& app_dir,
+                              const std::string& flags = "up --remove-orphans -d");
+
  private:
   const boost::filesystem::path store_root_;
   const boost::filesystem::path install_root_;
   const std::string client_;
   const std::string docker_host_;
+  const std::string compose_cmd_;
   const boost::filesystem::path apps_root_{store_root_ / "apps"};
   const boost::filesystem::path blobs_root_{store_root_ / "blobs"};
   Docker::RegistryClient::Ptr registry_client_;

--- a/src/docker/restorableappengine.h
+++ b/src/docker/restorableappengine.h
@@ -12,8 +12,9 @@ class RestorableAppEngine : public AppEngine {
   static const std::string ComposeFile;
 
  public:
-  RestorableAppEngine(boost::filesystem::path store_root, Docker::RegistryClient::Ptr registry_client,
-                      const std::string& client = "skopeo");
+  RestorableAppEngine(boost::filesystem::path store_root, boost::filesystem::path install_root,
+                      Docker::RegistryClient::Ptr registry_client, const std::string& client = "skopeo",
+                      const std::string& docker_host = "unix:///var/run/docker.sock");
 
  public:
   bool fetch(const App& app) override;
@@ -27,13 +28,22 @@ class RestorableAppEngine : public AppEngine {
   boost::filesystem::path pullApp(const Uri& uri, const boost::filesystem::path& app_dir);
   void pullAppImages(const boost::filesystem::path& app_compose_file, const boost::filesystem::path& dst_dir);
 
-  // image tranfer utility specific functions
+  void installApp(const boost::filesystem::path& app_dir, const boost::filesystem::path& dst_dir);
+  void installAppImages(const boost::filesystem::path& app_dir);
+
+  // functions specific to an image tranfer utility
   static void pullImage(const std::string& client, const std::string& uri, const boost::filesystem::path& dst_dir,
                         const boost::filesystem::path& shared_blob_dir, const std::string& format = "v2s2");
 
+  static void installImage(const std::string& client, const boost::filesystem::path& image_dir,
+                           const boost::filesystem::path& shared_blob_dir, const std::string& docker_host,
+                           const std::string& tag, const std::string& format = "v2s2");
+
  private:
   const boost::filesystem::path store_root_;
+  const boost::filesystem::path install_root_;
   const std::string client_;
+  const std::string docker_host_;
   const boost::filesystem::path apps_root_{store_root_ / "apps"};
   const boost::filesystem::path blobs_root_{store_root_ / "blobs"};
   Docker::RegistryClient::Ptr registry_client_;

--- a/src/target.h
+++ b/src/target.h
@@ -69,6 +69,8 @@ class Target {
 
     Iterator begin() const { return target_apps_json_.begin(); }
     Iterator end() const { return target_apps_json_.end(); }
+    bool isPresent(const std::string& app_name) const { return target_apps_json_.isMember(app_name); }
+    AppDesc operator[](const std::string& app_name) const { return AppDesc(app_name, target_apps_json_[app_name]); }
 
    private:
     Json::Value target_apps_json_;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -113,6 +113,7 @@ add_aktualizr_test(NAME composeappengine
 
 target_compile_definitions(t_composeappengine PRIVATE ${TEST_DEFS})
 target_include_directories(t_composeappengine PRIVATE ${TEST_INCS} ${AKTUALIZR_DIR}/tests/ ${AKTUALIZR_DIR}/src/)
+target_link_libraries(t_composeappengine ${TEST_LIBS} testutilities)
 set_tests_properties(test_composeappengine PROPERTIES LABELS "aklite:appengine")
 
 aktualizr_source_file_checks(composeappengine_test.cc)
@@ -124,6 +125,7 @@ add_aktualizr_test(NAME restorableappengine
 
 target_compile_definitions(t_restorableappengine PRIVATE ${TEST_DEFS})
 target_include_directories(t_restorableappengine PRIVATE ${TEST_INCS} ${AKTUALIZR_DIR}/tests/ ${AKTUALIZR_DIR}/src/)
+target_link_libraries(t_restorableappengine ${TEST_LIBS} testutilities)
 set_tests_properties(test_restorableappengine PROPERTIES LABELS "aklite:restorableappengine")
 
 aktualizr_source_file_checks(restorableappengine_test.cc)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -117,6 +117,16 @@ set_tests_properties(test_composeappengine PROPERTIES LABELS "aklite:appengine")
 
 aktualizr_source_file_checks(composeappengine_test.cc)
 
+add_aktualizr_test(NAME restorableappengine
+  SOURCES $<TARGET_OBJECTS:${MAIN_TARGET_LIB}> restorableappengine_test.cc
+  PROJECT_WORKING_DIRECTORY
+)
+
+target_compile_definitions(t_restorableappengine PRIVATE ${TEST_DEFS})
+target_include_directories(t_restorableappengine PRIVATE ${TEST_INCS} ${AKTUALIZR_DIR}/tests/ ${AKTUALIZR_DIR}/src/)
+set_tests_properties(test_restorableappengine PROPERTIES LABELS "aklite:restorableappengine")
+
+aktualizr_source_file_checks(restorableappengine_test.cc)
 
 add_aktualizr_test(NAME aklite
   SOURCES $<TARGET_OBJECTS:${MAIN_TARGET_LIB}> aklite_test.cc

--- a/tests/apiclient_test.cc
+++ b/tests/apiclient_test.cc
@@ -37,6 +37,7 @@ class MockAppEngine : public AppEngine {
     ON_CALL(*this, fetch).WillByDefault(Return(true));
     ON_CALL(*this, install).WillByDefault(Return(true));
     ON_CALL(*this, run).WillByDefault(Return(true));
+    ON_CALL(*this, isFetched).WillByDefault(Return(true));
     ON_CALL(*this, isRunning).WillByDefault(Return(true));
     ON_CALL(*this, getRunningAppsInfo)
         .WillByDefault(
@@ -49,6 +50,7 @@ class MockAppEngine : public AppEngine {
   MOCK_METHOD(bool, install, (const App& app), (override));
   MOCK_METHOD(bool, run, (const App& app), (override));
   MOCK_METHOD(void, remove, (const App& app), (override));
+  MOCK_METHOD(bool, isFetched, (const App& app), (const, override));
   MOCK_METHOD(bool, isRunning, (const App& app), (const, override));
   MOCK_METHOD(Json::Value, getRunningAppsInfo, (), (const, override));
 };

--- a/tests/apiclient_test.cc
+++ b/tests/apiclient_test.cc
@@ -53,6 +53,7 @@ class MockAppEngine : public AppEngine {
   MOCK_METHOD(bool, isFetched, (const App& app), (const, override));
   MOCK_METHOD(bool, isRunning, (const App& app), (const, override));
   MOCK_METHOD(Json::Value, getRunningAppsInfo, (), (const, override));
+  MOCK_METHOD(void, prune, (const Apps& app), (override));
 };
 
 class ApiClientTest : public fixtures::ClientTest {

--- a/tests/composeappengine_test.cc
+++ b/tests/composeappengine_test.cc
@@ -7,6 +7,7 @@
 #include <boost/process.hpp>
 
 #include "crypto/crypto.h"
+#include "test_utils.h"
 
 #include "docker/composeappengine.h"
 #include "logging/logging.h"
@@ -62,7 +63,8 @@ TEST_F(ComposeAppEngineTest, FetchRunAndUpdate) {
 }
 
 TEST_F(ComposeAppEngineTest, FetchRunCompare) {
-  auto updated_app = registry.addApp(fixtures::ComposeApp::create("app-02", "service-02", "image-02"));
+  const auto app{fixtures::ComposeApp::create("app-02", "service-02", "image-02")};
+  auto updated_app = registry.addApp(app);
 
   // the format is defined by DockerClient.cc
   boost::format format("App(%s) Service(%s ");
@@ -79,7 +81,7 @@ TEST_F(ComposeAppEngineTest, FetchRunCompare) {
   Json::Value apps_info = app_engine->getRunningAppsInfo();
   ASSERT_TRUE(apps_info.isMember("app-02"));
   ASSERT_TRUE(apps_info["app-02"]["services"].isMember("service-02"));
-  ASSERT_EQ(apps_info["app-02"]["services"]["service-02"]["image"].asString(), "image-02");
+  ASSERT_EQ(apps_info["app-02"]["services"]["service-02"]["image"].asString(), app->image().uri());
 }
 
 int main(int argc, char** argv) {

--- a/tests/composeappengine_test.cc
+++ b/tests/composeappengine_test.cc
@@ -14,7 +14,14 @@
 
 #include "fixtures/composeappenginetest.cc"
 
-class ComposeAppEngineTest : public fixtures::AppEngineTest {};
+class ComposeAppEngineTest : public fixtures::AppEngineTest {
+ protected:
+  void SetUp() override {
+    fixtures::AppEngineTest::SetUp();
+    app_engine =
+        std::make_shared<Docker::ComposeAppEngine>(apps_root_dir, compose_cmd, docker_client_, registry_client_);
+  }
+};
 
 TEST_F(ComposeAppEngineTest, Fetch) {
   auto app = registry.addApp(fixtures::ComposeApp::create("app-01"));

--- a/tests/docker-daemon_fake.py
+++ b/tests/docker-daemon_fake.py
@@ -1,0 +1,61 @@
+#!/usr/bin/python3
+
+import os
+import sys
+import argparse
+import json
+import logging
+import ssl
+
+from http.server import SimpleHTTPRequestHandler, HTTPServer
+
+logger = logging.getLogger("Fake Docker Daemon")
+
+
+class Handler(SimpleHTTPRequestHandler):
+    def do_GET(self):
+        logger.info(">>> GET  %s" % self.path)
+
+        self.send_response(200)
+        self.end_headers()
+
+    def do_POST(self):
+        logger.info(">>> POST  %s" % self.path)
+
+        while True:
+            line = self.rfile.readline().strip()
+            chunk_length = int(line, 16)
+            if chunk_length == 0:
+                break
+
+            self.rfile.read(chunk_length)
+            self.rfile.readline()
+
+        self.send_response(200)
+        self.end_headers()
+
+
+class FakeDockerRegistry(HTTPServer):
+    def __init__(self, addr, root_dir):
+        super(HTTPServer, self).__init__(server_address=addr, RequestHandlerClass=Handler)
+        self.root_dir = root_dir
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Run a fake Docker Daemon')
+    parser.add_argument('-p', '--port', type=int, help='server port')
+    parser.add_argument('-d', '--dir', type=str, help='docker daemon root dir')
+
+    args = parser.parse_args()
+
+    try:
+        httpd = FakeDockerRegistry(('', args.port), args.dir)
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        httpd.server_close()
+
+
+if __name__ == "__main__":
+    logger.addHandler(logging.StreamHandler(sys.stderr))
+    logger.setLevel(logging.INFO)
+    sys.exit(main())

--- a/tests/docker-registry_fake.py
+++ b/tests/docker-registry_fake.py
@@ -1,0 +1,85 @@
+#!/usr/bin/python3
+
+import os
+import sys
+import argparse
+import json
+import logging
+import ssl
+
+from http.server import SimpleHTTPRequestHandler, HTTPServer
+
+logger = logging.getLogger("Fake Docker Registry")
+
+
+class Handler(SimpleHTTPRequestHandler):
+    def do_GET(self):
+        logger.info(">>> GET  %s" % self.path)
+
+        if not self.path.startswith('/v2'):
+            self.send_response(404)
+            self.end_headers()
+            return
+
+        # ping call from a client
+        if self.path == '/v2/':
+            self.send_response(200)
+            self.end_headers()
+            return
+
+        path_elements = self.path.split('/')
+
+        factory = path_elements[2]
+        image = path_elements[3]
+        artifact_type = path_elements[4]
+        digest = path_elements[5]
+        logger.info(">>> Factory: {}; Image: {}; Element: {}; Digest: {}".format(factory, image, artifact_type, digest))
+
+        if not digest.startswith('sha256:'):
+            self.send_response(400)
+            self.send_header('Content-type', 'application/json')
+            self.end_headers()
+            self.wfile.write(json.dumps({'err': 'Invalid resource hash: ' + digest}).encode())
+            return
+
+        hash = digest[len('sha256:'):]
+        full_path = os.path.join(self.server.root_dir, factory, image, artifact_type, hash)
+        if not os.path.exists(full_path):
+            self.send_response(404)
+            self.end_headers()
+
+        self.send_response(200)
+        self.send_header('Content-type', 'application/vnd.docker.distribution.manifest.v2+json')
+        self.end_headers()
+        with open(full_path, 'rb') as f:
+            while True:
+                data = f.read(1024)
+                if not data:
+                    break
+                self.wfile.write(data)
+
+
+class FakeDockerRegistry(HTTPServer):
+    def __init__(self, addr, root_dir):
+        super(HTTPServer, self).__init__(server_address=addr, RequestHandlerClass=Handler)
+        self.root_dir = root_dir
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Run a fake Docker Registry')
+    parser.add_argument('-p', '--port', type=int, help='server port')
+    parser.add_argument('-d', '--dir', type=str, help='registry root dir')
+
+    args = parser.parse_args()
+
+    try:
+        httpd = FakeDockerRegistry(('', args.port), args.dir)
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        httpd.server_close()
+
+
+if __name__ == "__main__":
+    logger.addHandler(logging.StreamHandler(sys.stderr))
+    logger.setLevel(logging.INFO)
+    sys.exit(main())

--- a/tests/fixtures/composeapp.cc
+++ b/tests/fixtures/composeapp.cc
@@ -92,7 +92,10 @@ class ComposeApp {
     TemporaryFile arch_file{"arch.tgz"};
 
     Utils::writeFile(app_dir.Path() / compose_file_, std::string(content_));
-    boost::process::system("tar -czf " + arch_file.Path().string() + " .",  boost::process::start_dir = app_dir.Path());
+    auto cmd = std::string("tar -czf ") + arch_file.Path().string() + " " + compose_file_;
+    if (0 != boost::process::system(cmd, boost::process::start_dir = app_dir.Path())) {
+      throw std::runtime_error("failed to create App archive: " + name());
+    }
     arch_ = Utils::readFile(arch_file.Path());
     arch_hash_ = boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha256digest(arch_)));
 

--- a/tests/fixtures/composeapp.cc
+++ b/tests/fixtures/composeapp.cc
@@ -1,5 +1,48 @@
 namespace fixtures {
 
+class Image {
+  public:
+   struct HashedData {
+     HashedData(const std::string& d):data{d},
+                                      hash{boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha256digest(d)))},
+                                      size{data.size()} {}
+
+     std::string data;
+     std::string hash;
+     std::size_t size;
+   };
+
+   Image(const std::string& name):name_{name}, layer_blob_{Utils::randomUuid()}, manifest_str_{"undefined"} {
+     manifest_["mediaType"] = "application/vnd.docker.distribution.manifest.v2+json";
+     manifest_["schemaVersion"] = 2;
+
+     manifest_["config"]["mediaType"] = "application/vnd.docker.container.image.v1+json";
+     manifest_["config"]["size"] = image_config_.size;
+     manifest_["config"]["digest"] = "sha256:" + image_config_.hash;
+
+     manifest_["layers"][0]["mediaType"] = "application/vnd.docker.image.rootfs.diff.tar.gzip";
+     manifest_["layers"][0]["size"] = layer_blob_.size;
+     manifest_["layers"][0]["digest"] = "sha256:" + layer_blob_.hash;
+     manifest_str_ = HashedData{Utils::jsonToCanonicalStr(manifest_)};
+     uri_ = name_ + "@sha256:" + manifest_str_.hash;
+   }
+
+   const std::string& name() const { return name_; }
+   const HashedData& layerBlob() const { return layer_blob_; }
+   const HashedData& config() const { return image_config_; }
+   const HashedData& manifest() const { return manifest_str_; }
+   std::string uri(const std::string host = "localhost") const { return host + "/" + uri_; }
+
+  private:
+   const std::string name_;
+   const HashedData layer_blob_;
+   const HashedData image_config_{"{}"};
+
+   Json::Value manifest_;
+   HashedData manifest_str_;
+   std::string uri_;
+};
+
 class ComposeApp {
  public:
   using Ptr = std::shared_ptr<ComposeApp>;
@@ -20,16 +63,16 @@ class ComposeApp {
  public:
   static Ptr create(const std::string& name,
                     const std::string& service = "service-01", const std::string& image = "image-01", const std::string& compose_file = Docker::ComposeAppEngine::ComposeFile) {
-    Ptr app{new ComposeApp(name, compose_file)};
-    app->updateService(service, image);
+    Ptr app{new ComposeApp(name, compose_file, "factory/" + image)};
+    app->updateService(service);
     return app;
   }
 
-  const std::string& updateService(const std::string& service, const std::string& image) {
+  const std::string& updateService(const std::string& service) {
     char service_content[1024];
-    sprintf(service_content, ServiceTemplate.c_str(), service.c_str(), image.c_str());
+    sprintf(service_content, ServiceTemplate.c_str(), service.c_str(), image_.uri().c_str());
     auto service_hash = boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha256digest(service_content)));
-    sprintf(content_, DefaultTemplate.c_str(), service.c_str(), image.c_str(), service_hash.c_str());
+    sprintf(content_, DefaultTemplate.c_str(), service.c_str(), image_.uri().c_str(), service_hash.c_str());
     return update();
   }
 
@@ -38,10 +81,11 @@ class ComposeApp {
   const std::string& archHash() const { return arch_hash_; }
   const std::string& archive() const { return arch_; }
   const std::string& manifest() const { return manifest_; }
+  const Image& image() const { return image_; }
 
 
  private:
-  ComposeApp(const std::string& name, const std::string& compose_file):name_{name}, compose_file_{compose_file} {}
+  ComposeApp(const std::string& name, const std::string& compose_file, const std::string& image_name):compose_file_{compose_file}, name_{name}, image_{image_name} {}
 
   const std::string& update() {
     TemporaryDirectory app_dir;
@@ -64,6 +108,7 @@ class ComposeApp {
  private:
   const std::string compose_file_;
   const std::string name_;
+  const Image image_;
   char content_[4096];
 
   std::string arch_;

--- a/tests/fixtures/composeappenginetest.cc
+++ b/tests/fixtures/composeappenginetest.cc
@@ -12,7 +12,7 @@ class AppEngineTest : virtual public ::testing::Test {
   AppEngineTest() : registry{test_dir_.Path() / "registry"}, daemon_{test_dir_.Path() / "daemon"} {}
 
   void SetUp() override {
-    auto compose_cmd =
+    compose_cmd =
         boost::filesystem::canonical("tests/docker-compose_fake.py").string() + " " + daemon_.dir().string() + " ";
 
     apps_root_dir = test_dir_.Path() / "compose-apps";
@@ -26,6 +26,7 @@ class AppEngineTest : virtual public ::testing::Test {
   fixtures::DockerDaemon daemon_;
   Docker::RegistryClient::Ptr registry_client_;
 
+  std::string compose_cmd;
   boost::filesystem::path apps_root_dir;
   std::shared_ptr<AppEngine> app_engine;
 

--- a/tests/fixtures/composeappenginetest.cc
+++ b/tests/fixtures/composeappenginetest.cc
@@ -18,7 +18,6 @@ class AppEngineTest : virtual public ::testing::Test {
     apps_root_dir = test_dir_.Path() / "compose-apps";
     registry_client_ = std::make_shared<Docker::RegistryClient>(registry.getClient(), registry.authURL(), registry.getClientFactory());
     docker_client_ = std::make_shared<Docker::DockerClient>(daemon_.getClient());
-    app_engine = std::make_shared<Docker::ComposeAppEngine>(apps_root_dir, compose_cmd, docker_client_, registry_client_);
   }
 
  protected:

--- a/tests/fixtures/composeappenginetest.cc
+++ b/tests/fixtures/composeappenginetest.cc
@@ -17,7 +17,8 @@ class AppEngineTest : virtual public ::testing::Test {
 
     apps_root_dir = test_dir_.Path() / "compose-apps";
     registry_client_ = std::make_shared<Docker::RegistryClient>(registry.getClient(), registry.authURL(), registry.getClientFactory());
-    app_engine = std::make_shared<Docker::ComposeAppEngine>(apps_root_dir, compose_cmd, std::make_shared<Docker::DockerClient>(daemon_.getClient()), registry_client_);
+    docker_client_ = std::make_shared<Docker::DockerClient>(daemon_.getClient());
+    app_engine = std::make_shared<Docker::ComposeAppEngine>(apps_root_dir, compose_cmd, docker_client_, registry_client_);
   }
 
  protected:
@@ -25,6 +26,7 @@ class AppEngineTest : virtual public ::testing::Test {
   fixtures::DockerRegistry registry;
   fixtures::DockerDaemon daemon_;
   Docker::RegistryClient::Ptr registry_client_;
+  Docker::DockerClient::Ptr docker_client_;
 
   std::string compose_cmd;
   boost::filesystem::path apps_root_dir;

--- a/tests/fixtures/composeappenginetest.cc
+++ b/tests/fixtures/composeappenginetest.cc
@@ -3,6 +3,7 @@
 #include "fixtures/dockerdaemon.cc"
 #include "fixtures/dockerregistry.cc"
 
+
 namespace fixtures {
 
 
@@ -15,14 +16,15 @@ class AppEngineTest : virtual public ::testing::Test {
         boost::filesystem::canonical("tests/docker-compose_fake.py").string() + " " + daemon_.dir().string() + " ";
 
     apps_root_dir = test_dir_.Path() / "compose-apps";
-    app_engine = std::make_shared<Docker::ComposeAppEngine>(apps_root_dir, compose_cmd, std::make_shared<Docker::DockerClient>(daemon_.getClient()),
-                                                            std::make_shared<Docker::RegistryClient>(registry.getClient(), registry.authURL(), registry.getClientFactory()));
+    registry_client_ = std::make_shared<Docker::RegistryClient>(registry.getClient(), registry.authURL(), registry.getClientFactory());
+    app_engine = std::make_shared<Docker::ComposeAppEngine>(apps_root_dir, compose_cmd, std::make_shared<Docker::DockerClient>(daemon_.getClient()), registry_client_);
   }
 
  protected:
   TemporaryDirectory test_dir_;
   fixtures::DockerRegistry registry;
   fixtures::DockerDaemon daemon_;
+  Docker::RegistryClient::Ptr registry_client_;
 
   boost::filesystem::path apps_root_dir;
   std::shared_ptr<AppEngine> app_engine;

--- a/tests/liteclientHSM_test.cc
+++ b/tests/liteclientHSM_test.cc
@@ -39,6 +39,7 @@ class MockAppEngine : public AppEngine {
     ON_CALL(*this, fetch).WillByDefault(Return(true));
     ON_CALL(*this, install).WillByDefault(Return(true));
     ON_CALL(*this, run).WillByDefault(Return(true));
+    ON_CALL(*this, isFetched).WillByDefault(Return(true));
     ON_CALL(*this, isRunning).WillByDefault(Return(true));
     ON_CALL(*this, getRunningAppsInfo)
         .WillByDefault(
@@ -51,6 +52,7 @@ class MockAppEngine : public AppEngine {
   MOCK_METHOD(bool, install, (const App& app), (override));
   MOCK_METHOD(bool, run, (const App& app), (override));
   MOCK_METHOD(void, remove, (const App& app), (override));
+  MOCK_METHOD(bool, isFetched, (const App& app), (const, override));
   MOCK_METHOD(bool, isRunning, (const App& app), (const, override));
   MOCK_METHOD(Json::Value, getRunningAppsInfo, (), (const, override));
 };

--- a/tests/liteclientHSM_test.cc
+++ b/tests/liteclientHSM_test.cc
@@ -55,6 +55,7 @@ class MockAppEngine : public AppEngine {
   MOCK_METHOD(bool, isFetched, (const App& app), (const, override));
   MOCK_METHOD(bool, isRunning, (const App& app), (const, override));
   MOCK_METHOD(Json::Value, getRunningAppsInfo, (), (const, override));
+  MOCK_METHOD(void, prune, (const Apps& app), (override));
 };
 
 class LiteClientHSMTest : public fixtures::ClientHSMTest {

--- a/tests/liteclient_test.cc
+++ b/tests/liteclient_test.cc
@@ -39,6 +39,7 @@ class MockAppEngine : public AppEngine {
     ON_CALL(*this, fetch).WillByDefault(Return(true));
     ON_CALL(*this, install).WillByDefault(Return(true));
     ON_CALL(*this, run).WillByDefault(Return(true));
+    ON_CALL(*this, isFetched).WillByDefault(Return(true));
     ON_CALL(*this, isRunning).WillByDefault(Return(true));
     ON_CALL(*this, getRunningAppsInfo)
         .WillByDefault(
@@ -51,6 +52,7 @@ class MockAppEngine : public AppEngine {
   MOCK_METHOD(bool, install, (const App& app), (override));
   MOCK_METHOD(bool, run, (const App& app), (override));
   MOCK_METHOD(void, remove, (const App& app), (override));
+  MOCK_METHOD(bool, isFetched, (const App& app), (const, override));
   MOCK_METHOD(bool, isRunning, (const App& app), (const, override));
   MOCK_METHOD(Json::Value, getRunningAppsInfo, (), (const, override));
 };

--- a/tests/liteclient_test.cc
+++ b/tests/liteclient_test.cc
@@ -55,6 +55,7 @@ class MockAppEngine : public AppEngine {
   MOCK_METHOD(bool, isFetched, (const App& app), (const, override));
   MOCK_METHOD(bool, isRunning, (const App& app), (const, override));
   MOCK_METHOD(Json::Value, getRunningAppsInfo, (), (const, override));
+  MOCK_METHOD(void, prune, (const Apps& app), (override));
 };
 
 class LiteClientTest : public fixtures::ClientTest {

--- a/tests/restorableappengine_test.cc
+++ b/tests/restorableappengine_test.cc
@@ -1,0 +1,30 @@
+#include <gtest/gtest.h>
+
+#include <boost/filesystem.hpp>
+#include <boost/format.hpp>
+#include <boost/process.hpp>
+
+#include "crypto/crypto.h"
+#include "logging/logging.h"
+
+#include "docker/composeappengine.h"
+#include "docker/restorableappengine.h"
+
+#include "fixtures/composeappenginetest.cc"
+
+class RestorableAppEngineTest : public fixtures::AppEngineTest {
+ protected:
+  void SetUp() override {
+    fixtures::AppEngineTest::SetUp();
+    app_engine = std::make_shared<Docker::RestorableAppEngine>();
+  }
+};
+
+TEST_F(RestorableAppEngineTest, InitDeinit) {}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  logger_init();
+
+  return RUN_ALL_TESTS();
+}

--- a/tests/restorableappengine_test.cc
+++ b/tests/restorableappengine_test.cc
@@ -15,17 +15,13 @@
 
 class RestorableAppEngineTest : public fixtures::AppEngineTest {
  protected:
-  RestorableAppEngineTest() : fixtures::AppEngineTest(), apps_store_root_dir_{test_dir_.Path() / "apps-store"} {}
   void SetUp() override {
     fixtures::AppEngineTest::SetUp();
 
-    app_engine = std::make_shared<Docker::RestorableAppEngine>(apps_store_root_dir_, apps_root_dir, registry_client_,
-                                                               docker_client_, registry.getSkopeoClient(),
-                                                               daemon_.getUrl(), compose_cmd);
+    app_engine = std::make_shared<Docker::RestorableAppEngine>(
+        test_dir_.Path() / "apps-store", apps_root_dir, registry_client_, docker_client_, registry.getSkopeoClient(),
+        daemon_.getUrl(), compose_cmd);
   }
-
- protected:
-  boost::filesystem::path apps_store_root_dir_;
 };
 
 TEST_F(RestorableAppEngineTest, InitDeinit) {}

--- a/tests/restorableappengine_test.cc
+++ b/tests/restorableappengine_test.cc
@@ -6,6 +6,7 @@
 
 #include "crypto/crypto.h"
 #include "logging/logging.h"
+#include "test_utils.h"
 
 #include "docker/composeappengine.h"
 #include "docker/restorableappengine.h"
@@ -21,6 +22,11 @@ class RestorableAppEngineTest : public fixtures::AppEngineTest {
 };
 
 TEST_F(RestorableAppEngineTest, InitDeinit) {}
+
+TEST_F(RestorableAppEngineTest, Fetch) {
+  auto app = registry.addApp(fixtures::ComposeApp::create("app-01"));
+  ASSERT_TRUE(app_engine->fetch(app));
+}
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/tests/restorableappengine_test.cc
+++ b/tests/restorableappengine_test.cc
@@ -19,8 +19,8 @@ class RestorableAppEngineTest : public fixtures::AppEngineTest {
   void SetUp() override {
     fixtures::AppEngineTest::SetUp();
 
-    app_engine = std::make_shared<Docker::RestorableAppEngine>(apps_store_root_dir_, registry_client_,
-                                                               registry.getSkopeoClient());
+    app_engine = std::make_shared<Docker::RestorableAppEngine>(apps_store_root_dir_, apps_root_dir, registry_client_,
+                                                               registry.getSkopeoClient(), daemon_.getUrl());
   }
 
  protected:
@@ -32,6 +32,14 @@ TEST_F(RestorableAppEngineTest, InitDeinit) {}
 TEST_F(RestorableAppEngineTest, Fetch) {
   auto app = registry.addApp(fixtures::ComposeApp::create("app-01"));
   ASSERT_TRUE(app_engine->fetch(app));
+}
+
+TEST_F(RestorableAppEngineTest, FetchAndInstall) {
+  auto app = registry.addApp(fixtures::ComposeApp::create("app-02"));
+  ASSERT_TRUE(app_engine->fetch(app));
+  // TODO: AppEngine API doesn't provide mean(s) to check if App is installed
+  ASSERT_TRUE(app_engine->install(app));
+  // ASSERT_FALSE(app_engine->isRunning(app));
 }
 
 int main(int argc, char** argv) {

--- a/tests/restorableappengine_test.cc
+++ b/tests/restorableappengine_test.cc
@@ -19,8 +19,9 @@ class RestorableAppEngineTest : public fixtures::AppEngineTest {
   void SetUp() override {
     fixtures::AppEngineTest::SetUp();
 
-    app_engine = std::make_shared<Docker::RestorableAppEngine>(apps_store_root_dir_, apps_root_dir, registry_client_,
-                                                               registry.getSkopeoClient(), daemon_.getUrl());
+    app_engine =
+        std::make_shared<Docker::RestorableAppEngine>(apps_store_root_dir_, apps_root_dir, registry_client_,
+                                                      registry.getSkopeoClient(), daemon_.getUrl(), compose_cmd);
   }
 
  protected:
@@ -39,6 +40,14 @@ TEST_F(RestorableAppEngineTest, FetchAndInstall) {
   ASSERT_TRUE(app_engine->fetch(app));
   // TODO: AppEngine API doesn't provide mean(s) to check if App is installed
   ASSERT_TRUE(app_engine->install(app));
+  // ASSERT_FALSE(app_engine->isRunning(app));
+}
+
+TEST_F(RestorableAppEngineTest, FetchAndRun) {
+  auto app = registry.addApp(fixtures::ComposeApp::create("app-03"));
+  ASSERT_TRUE(app_engine->fetch(app));
+  // TODO: AppEngine API doesn't provide mean(s) to check if App is installed
+  ASSERT_TRUE(app_engine->run(app));
   // ASSERT_FALSE(app_engine->isRunning(app));
 }
 

--- a/tests/restorableappengine_test.cc
+++ b/tests/restorableappengine_test.cc
@@ -15,10 +15,16 @@
 
 class RestorableAppEngineTest : public fixtures::AppEngineTest {
  protected:
+  RestorableAppEngineTest() : fixtures::AppEngineTest(), apps_store_root_dir_{test_dir_.Path() / "apps-store"} {}
   void SetUp() override {
     fixtures::AppEngineTest::SetUp();
-    app_engine = std::make_shared<Docker::RestorableAppEngine>();
+
+    app_engine = std::make_shared<Docker::RestorableAppEngine>(apps_store_root_dir_, registry_client_,
+                                                               registry.getSkopeoClient());
   }
+
+ protected:
+  boost::filesystem::path apps_store_root_dir_;
 };
 
 TEST_F(RestorableAppEngineTest, InitDeinit) {}

--- a/tests/restorableappengine_test.cc
+++ b/tests/restorableappengine_test.cc
@@ -19,9 +19,9 @@ class RestorableAppEngineTest : public fixtures::AppEngineTest {
   void SetUp() override {
     fixtures::AppEngineTest::SetUp();
 
-    app_engine =
-        std::make_shared<Docker::RestorableAppEngine>(apps_store_root_dir_, apps_root_dir, registry_client_,
-                                                      registry.getSkopeoClient(), daemon_.getUrl(), compose_cmd);
+    app_engine = std::make_shared<Docker::RestorableAppEngine>(apps_store_root_dir_, apps_root_dir, registry_client_,
+                                                               docker_client_, registry.getSkopeoClient(),
+                                                               daemon_.getUrl(), compose_cmd);
   }
 
  protected:
@@ -40,7 +40,7 @@ TEST_F(RestorableAppEngineTest, FetchAndInstall) {
   ASSERT_TRUE(app_engine->fetch(app));
   // TODO: AppEngine API doesn't provide mean(s) to check if App is installed
   ASSERT_TRUE(app_engine->install(app));
-  // ASSERT_FALSE(app_engine->isRunning(app));
+  ASSERT_FALSE(app_engine->isRunning(app));
 }
 
 TEST_F(RestorableAppEngineTest, FetchAndRun) {
@@ -48,7 +48,53 @@ TEST_F(RestorableAppEngineTest, FetchAndRun) {
   ASSERT_TRUE(app_engine->fetch(app));
   // TODO: AppEngine API doesn't provide mean(s) to check if App is installed
   ASSERT_TRUE(app_engine->run(app));
-  // ASSERT_FALSE(app_engine->isRunning(app));
+  ASSERT_TRUE(app_engine->isRunning(app));
+}
+
+TEST_F(RestorableAppEngineTest, FetchInstallAndRun) {
+  auto app = registry.addApp(fixtures::ComposeApp::create("app-04"));
+  ASSERT_TRUE(app_engine->fetch(app));
+  ASSERT_TRUE(app_engine->install(app));
+  ASSERT_TRUE(app_engine->run(app));
+  ASSERT_TRUE(app_engine->isRunning(app));
+}
+
+TEST_F(RestorableAppEngineTest, FetchRunAndUpdate) {
+  auto app = registry.addApp(fixtures::ComposeApp::create("app-05"));
+  ASSERT_TRUE(app_engine->fetch(app));
+  ASSERT_TRUE(app_engine->run(app));
+  ASSERT_TRUE(app_engine->isRunning(app));
+
+  // update App, image URL has changed
+  auto updated_app = registry.addApp(fixtures::ComposeApp::create("app-05", "service-01", "image-02"));
+  ASSERT_TRUE(app_engine->fetch(updated_app));
+  ASSERT_FALSE(app_engine->isRunning(updated_app));
+
+  // run updated App
+  ASSERT_TRUE(app_engine->run(updated_app));
+  ASSERT_TRUE(app_engine->isRunning(updated_app));
+}
+
+TEST_F(RestorableAppEngineTest, FetchRunCompare) {
+  const auto app{fixtures::ComposeApp::create("app-06", "service-02", "image-02")};
+  auto updated_app = registry.addApp(app);
+
+  // the format is defined by DockerClient.cc
+  boost::format format("App(%s) Service(%s ");
+  std::string id = boost::str(format % "app-06" % "service-02");
+
+  ASSERT_TRUE(app_engine->fetch(updated_app));
+  ASSERT_FALSE(app_engine->isRunning(updated_app));
+  ASSERT_FALSE(app_engine->getRunningAppsInfo().isMember("app-06"));
+
+  // run updated App
+  ASSERT_TRUE(app_engine->run(updated_app));
+  ASSERT_TRUE(app_engine->isRunning(updated_app));
+
+  Json::Value apps_info = app_engine->getRunningAppsInfo();
+  ASSERT_TRUE(apps_info.isMember("app-06"));
+  ASSERT_TRUE(apps_info["app-06"]["services"].isMember("service-02"));
+  ASSERT_EQ(apps_info["app-06"]["services"]["service-02"]["image"].asString(), app->image().uri());
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
- Use `skopeo` to pull images from Registry(ies);
- Store apps&images' data (manifests, blobs, etc) in dedicated folder/volume in addition to `/var/lib/docker` and `/var/sota/compose-apps`;
- Use skopeo to copy images from the restorable app store to the docker store (`/var/lib/docker');
- If `/var/lib/docker` and `/var/sota/compose-apps` are removed then Apps&images are restored from the local store.