### PR TITLE
api: Include jsoncpp headers with install

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,6 +75,7 @@ target_link_libraries(${TARGET_EXE} ${TARGET})
 install(TARGETS ${TARGET_EXE} RUNTIME DESTINATION bin COMPONENT ${TARGET_EXE})
 install(TARGETS ${TARGET_LIB} LIBRARY DESTINATION lib COMPONENT ${TARGET_LIB})
 install(DIRECTORY ../include/aktualizr-lite DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(DIRECTORY ../aktualizr/third_party/jsoncpp/include/json  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 # enable creating clang-tidy targets for each source file (see aktualizr/CMakeLists.txt for details)
 aktualizr_source_file_checks(main.cc api.cc ../include/aktualizr-lite/api.h ${SRC} ${HEADERS})


### PR DESCRIPTION
These are required by api.h

Signed-off-by: Andy Doan <andy@foundries.io>