### PR TITLE
Revert "api: Include jsoncpp headers with install"

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,7 +75,6 @@ target_link_libraries(${TARGET_EXE} ${TARGET})
 install(TARGETS ${TARGET_EXE} RUNTIME DESTINATION bin COMPONENT ${TARGET_EXE})
 install(TARGETS ${TARGET_LIB} LIBRARY DESTINATION lib COMPONENT ${TARGET_LIB})
 install(DIRECTORY ../include/aktualizr-lite DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-install(DIRECTORY ../aktualizr/third_party/jsoncpp/include/json  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 # enable creating clang-tidy targets for each source file (see aktualizr/CMakeLists.txt for details)
 aktualizr_source_file_checks(main.cc api.cc ../include/aktualizr-lite/api.h ${SRC} ${HEADERS})


### PR DESCRIPTION
This reverts commit 87fde29d993f457fa304c4467132d698d6dac523.

Turns out the better way of handling this in OE is to depend on the
jsoncpp package:

 https://github.com/foundriesio/meta-lmp/pull/430#discussion_r714812071`

Signed-off-by: Andy Doan <andy@foundries.io>