### PR TITLE
Fix app manifest storing and verification

### DIFF
--- a/src/docker/docker.cc
+++ b/src/docker/docker.cc
@@ -71,7 +71,7 @@ RegistryClient::RegistryClient(std::shared_ptr<HttpInterface> ota_lite_client, s
       ota_lite_client_{std::move(ota_lite_client)},
       http_client_factory_{std::move(http_client_factory)} {}
 
-Json::Value RegistryClient::getAppManifest(const Uri& uri, const std::string& format) const {
+std::string RegistryClient::getAppManifest(const Uri& uri, const std::string& format) const {
   const std::string manifest_url{composeManifestUrl(uri)};
   LOG_DEBUG << "Downloading App manifest: " << manifest_url;
 
@@ -99,7 +99,7 @@ Json::Value RegistryClient::getAppManifest(const Uri& uri, const std::string& fo
   }
 
   LOG_TRACE << "Received App manifest: \n" << manifest_resp.getJson();
-  return manifest_resp.getJson();
+  return manifest_resp.body;
 }
 
 struct DownloadCtx {

--- a/src/docker/docker.cc
+++ b/src/docker/docker.cc
@@ -20,7 +20,6 @@ Uri Uri::parseUri(const std::string& uri) {
 
   auto app = uri.substr(app_name_pos + 1, split_pos - app_name_pos - 1);
   auto digest = uri.substr(split_pos + 1);
-  LOG_DEBUG << app << ": App digest: " << digest;
 
   auto factory_name_pos = uri.rfind('/', app_name_pos - 1);
   if (factory_name_pos == std::string::npos) {
@@ -28,13 +27,8 @@ Uri Uri::parseUri(const std::string& uri) {
   }
 
   auto factory = uri.substr(factory_name_pos + 1, app_name_pos - factory_name_pos - 1);
-  LOG_DEBUG << app << ": Factory: " << factory;
-
   auto repo = uri.substr(factory_name_pos + 1, split_pos - factory_name_pos - 1);
-  LOG_DEBUG << app << ": App Repo: " << repo;
-
   auto registry_hostname = uri.substr(0, factory_name_pos);
-  LOG_DEBUG << app << ": App Registry hostname: " << registry_hostname;
 
   return Uri{HashedDigest{digest}, app, factory, repo, registry_hostname};
 }

--- a/src/docker/docker.h
+++ b/src/docker/docker.h
@@ -40,6 +40,7 @@ struct Manifest : Json::Value {
   static constexpr const char* const ArchiveExt{".tgz"};
   static constexpr const char* const Filename{"manifest.json"};
 
+  explicit Manifest(const std::string& json_str) : Manifest(Utils::parseJSON(json_str)) {}
   explicit Manifest(const Json::Value& value = Json::Value()) : Json::Value(value) {
     auto manifest_version{(*this)["annotations"]["compose-app"].asString()};
     if (manifest_version.empty()) {
@@ -90,7 +91,7 @@ class RegistryClient {
   RegistryClient(std::shared_ptr<HttpInterface> ota_lite_client, std::string auth_creds_endpoint = DefAuthCredsEndpoint,
                  HttpClientFactory http_client_factory = RegistryClient::DefaultHttpClientFactory);
 
-  Json::Value getAppManifest(const Uri& uri, const std::string& format) const;
+  std::string getAppManifest(const Uri& uri, const std::string& format) const;
   void downloadBlob(const Uri& uri, const boost::filesystem::path& filepath, size_t expected_size) const;
 
  private:

--- a/src/docker/restorableappengine.cc
+++ b/src/docker/restorableappengine.cc
@@ -39,8 +39,10 @@ bool RestorableAppEngine::fetch(const App& app) {
     const auto app_compose_file{app_dir / ComposeFile};
 
     if (!isAppFetched(app)) {
-      LOG_DEBUG << app.name << ": downloading App from Registry: " << app.uri << " --> " << app_dir;
+      LOG_INFO << app.name << ": downloading App from Registry: " << app.uri << " --> " << app_dir;
       pullApp(uri, app_dir);
+    } else {
+      LOG_INFO << app.name << ": App already fetched: " << app_dir;
     }
 
     // Invoke download of App images unconditionally because `skopeo` is supposed
@@ -283,7 +285,7 @@ void RestorableAppEngine::pullAppImages(const boost::filesystem::path& app_compo
     const Uri uri{Uri::parseUri(image_uri)};
     const auto image_dir{dst_dir / uri.registryHostname / uri.repo / uri.digest.hash()};
 
-    LOG_DEBUG << uri.app << ": downloading image from Registry: " << image_uri << " --> " << dst_dir;
+    LOG_INFO << uri.app << ": downloading image from Registry if missing: " << image_uri << " --> " << dst_dir;
     pullImage(client_, image_uri, image_dir, blobs_root_);
   }
 }

--- a/tests/fixtures/composeapp.cc
+++ b/tests/fixtures/composeapp.cc
@@ -103,7 +103,9 @@ class ComposeApp {
     manifest["annotations"]["compose-app"] = "v1";
     manifest["layers"][0]["digest"] = "sha256:" + arch_hash_;
     manifest["layers"][0]["size"] = arch_.size();
-    manifest_ = Utils::jsonToCanonicalStr(manifest);
+    // emulate compose-publish work, i.e. calculate hash on a manifest json as it is,
+    // no need to normalize it to a canonical representation
+    manifest_ = Utils::jsonToStr(manifest);
     hash_ = boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha256digest(manifest_)));
     return hash_;
   }


### PR DESCRIPTION
- store a received App manifest as it is, don't apply any modification/canonization;
- calculate a manifest hash by using actual unmodified/non-canonized  representation of an App manifest json;
- minor logging improvement.