### PR TITLE
Add Target verification step to Compose App Manager

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -73,7 +73,8 @@ RUN apt-get update && apt-get -y install --no-install-suggests --no-install-reco
   valgrind \
   wget \
   xsltproc \
-  zip
+  zip \
+  docker-compose
 
 RUN ln -s clang-10 /usr/bin/clang && \
     ln -s clang++-10 /usr/bin/clang++

--- a/src/appengine.h
+++ b/src/appengine.h
@@ -19,6 +19,7 @@ class AppEngine {
 
  public:
   virtual bool fetch(const App& app) = 0;
+  virtual bool verify(const App& app) = 0;
   virtual bool install(const App& app) = 0;
   virtual bool run(const App& app) = 0;
   virtual void remove(const App& app) = 0;

--- a/src/composeappmanager.h
+++ b/src/composeappmanager.h
@@ -44,6 +44,7 @@ class ComposeAppManager : public RootfsTreeManager {
   bool fetchTarget(const Uptane::Target& target, Uptane::Fetcher& fetcher, const KeyManager& keys,
                    const FetcherProgressCb& progress_cb, const api::FlowControlToken* token) override;
 
+  TargetStatus verifyTarget(const Uptane::Target& target) const override;
   data::InstallationResult install(const Uptane::Target& target) const override;
   data::InstallationResult finalizeInstall(const Uptane::Target& target) override;
 

--- a/src/docker/composeappengine.h
+++ b/src/docker/composeappengine.h
@@ -21,6 +21,7 @@ class ComposeAppEngine : public AppEngine {
                    Docker::RegistryClient::Ptr registry_client);
 
   bool fetch(const App& app) override;
+  bool verify(const App& app) override;
   bool install(const App& app) override;
   bool run(const App& app) override;
   void remove(const App& app) override;
@@ -118,7 +119,6 @@ class ComposeAppEngine : public AppEngine {
   static std::pair<bool, std::string> cmd(const std::string& cmd);
 
   bool download(const App& app);
-  bool verify(const App& app);
   bool pullImages(const App& app);
   bool installApp(const App& app);
   bool start(const App& app);

--- a/src/docker/restorableappengine.h
+++ b/src/docker/restorableappengine.h
@@ -81,6 +81,7 @@ class RestorableAppEngine : public AppEngine {
 
  public:
   bool fetch(const App& app) override;
+  bool verify(const App& app) override;
   bool install(const App& app) override;
   bool run(const App& app) override;
   void remove(const App& app) override;
@@ -114,6 +115,7 @@ class RestorableAppEngine : public AppEngine {
                            const boost::filesystem::path& shared_blob_dir, const std::string& docker_host,
                            const std::string& tag, const std::string& format = "v2s2");
 
+  static void verifyComposeApp(const std::string& compose_cmd, const boost::filesystem::path& app_dir);
   static void startComposeApp(const std::string& compose_cmd, const boost::filesystem::path& app_dir,
                               const std::string& flags = "up --remove-orphans -d");
 

--- a/tests/apiclient_test.cc
+++ b/tests/apiclient_test.cc
@@ -35,6 +35,7 @@ class MockAppEngine : public AppEngine {
     if (!default_behaviour) return;
 
     ON_CALL(*this, fetch).WillByDefault(Return(true));
+    ON_CALL(*this, verify).WillByDefault(Return(true));
     ON_CALL(*this, install).WillByDefault(Return(true));
     ON_CALL(*this, run).WillByDefault(Return(true));
     ON_CALL(*this, isFetched).WillByDefault(Return(true));
@@ -47,6 +48,7 @@ class MockAppEngine : public AppEngine {
 
  public:
   MOCK_METHOD(bool, fetch, (const App& app), (override));
+  MOCK_METHOD(bool, verify, (const App& app), (override));
   MOCK_METHOD(bool, install, (const App& app), (override));
   MOCK_METHOD(bool, run, (const App& app), (override));
   MOCK_METHOD(void, remove, (const App& app), (override));

--- a/tests/docker-compose_fake.py
+++ b/tests/docker-compose_fake.py
@@ -3,6 +3,7 @@
 import sys
 import logging
 import os
+import subprocess
 import yaml
 import traceback
 import json
@@ -46,6 +47,8 @@ def main():
         app_name = os.path.basename(os.getcwd())
         if cmd == "up":
             up(out_dir, app_name, compose, sys.argv[3:])
+        elif cmd == "config":
+            exit_code = subprocess.call(["docker-compose", "config"], timeout=10)
     except Exception as exc:
         logger.error("Failed to process compose file: {}\n{}".format(exc, traceback.format_exc()))
         exit_code = 1

--- a/tests/fixtures/composeapp.cc
+++ b/tests/fixtures/composeapp.cc
@@ -46,33 +46,33 @@ class Image {
 class ComposeApp {
  public:
   using Ptr = std::shared_ptr<ComposeApp>;
-  const std::string DefaultTemplate = R"(
+  static constexpr const char* const DefaultTemplate = R"(
     services:
-      %s:
-        image: %s
+      %s
         labels:
           io.compose-spec.config-hash: %s
     version: "3.2"
     )";
 
-  const std::string ServiceTemplate = R"(
-    %s:
-      image: %s
-    )";
+  static constexpr const char* const ServiceTemplate = R"(
+      %s:
+        image: %s)";
 
  public:
   static Ptr create(const std::string& name,
-                    const std::string& service = "service-01", const std::string& image = "image-01", const std::string& compose_file = Docker::ComposeAppEngine::ComposeFile) {
+                    const std::string& service = "service-01", const std::string& image = "image-01",
+                    const std::string& service_template = ServiceTemplate,
+                    const std::string& compose_file = Docker::ComposeAppEngine::ComposeFile) {
     Ptr app{new ComposeApp(name, compose_file, "factory/" + image)};
-    app->updateService(service);
+    app->updateService(service, service_template);
     return app;
   }
 
-  const std::string& updateService(const std::string& service) {
+  const std::string& updateService(const std::string& service, const std::string& service_template = ServiceTemplate) {
     char service_content[1024];
-    sprintf(service_content, ServiceTemplate.c_str(), service.c_str(), image_.uri().c_str());
+    sprintf(service_content, service_template.c_str(), service.c_str(), image_.uri().c_str());
     auto service_hash = boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha256digest(service_content)));
-    sprintf(content_, DefaultTemplate.c_str(), service.c_str(), image_.uri().c_str(), service_hash.c_str());
+    sprintf(content_, DefaultTemplate, service_content, service_hash.c_str());
     return update();
   }
 

--- a/tests/fixtures/liteclienttest.cc
+++ b/tests/fixtures/liteclienttest.cc
@@ -239,6 +239,15 @@ class ClientTest :virtual public ::testing::Test {
       return;
     }
 
+    if (client.VerifyTarget(to) != TargetStatus::kGood) {
+      ASSERT_EQ(expected_install_code, data::ResultCode::Numeric::kVerificationFailed);
+      ASSERT_EQ(client.getCurrent().sha256Hash(), from.sha256Hash());
+      ASSERT_EQ(client.getCurrent().filename(), from.filename());
+      checkHeaders(client, from);
+      checkEvents(client, from, UpdateType::kApp);
+      return;
+    }
+
     ASSERT_EQ(client.install(to), expected_install_code);
     if (expected_install_code == data::ResultCode::Numeric::kOk) {
       // make sure that the new Target has been applied

--- a/tests/liteclientHSM_test.cc
+++ b/tests/liteclientHSM_test.cc
@@ -37,6 +37,7 @@ class MockAppEngine : public AppEngine {
     if (!default_behaviour) return;
 
     ON_CALL(*this, fetch).WillByDefault(Return(true));
+    ON_CALL(*this, verify).WillByDefault(Return(true));
     ON_CALL(*this, install).WillByDefault(Return(true));
     ON_CALL(*this, run).WillByDefault(Return(true));
     ON_CALL(*this, isFetched).WillByDefault(Return(true));
@@ -49,6 +50,7 @@ class MockAppEngine : public AppEngine {
 
  public:
   MOCK_METHOD(bool, fetch, (const App& app), (override));
+  MOCK_METHOD(bool, verify, (const App& app), (override));
   MOCK_METHOD(bool, install, (const App& app), (override));
   MOCK_METHOD(bool, run, (const App& app), (override));
   MOCK_METHOD(void, remove, (const App& app), (override));

--- a/tests/liteclient_test.cc
+++ b/tests/liteclient_test.cc
@@ -37,6 +37,7 @@ class MockAppEngine : public AppEngine {
     if (!default_behaviour) return;
 
     ON_CALL(*this, fetch).WillByDefault(Return(true));
+    ON_CALL(*this, verify).WillByDefault(Return(true));
     ON_CALL(*this, install).WillByDefault(Return(true));
     ON_CALL(*this, run).WillByDefault(Return(true));
     ON_CALL(*this, isFetched).WillByDefault(Return(true));
@@ -49,6 +50,7 @@ class MockAppEngine : public AppEngine {
 
  public:
   MOCK_METHOD(bool, fetch, (const App& app), (override));
+  MOCK_METHOD(bool, verify, (const App& app), (override));
   MOCK_METHOD(bool, install, (const App& app), (override));
   MOCK_METHOD(bool, run, (const App& app), (override));
   MOCK_METHOD(void, remove, (const App& app), (override));


### PR DESCRIPTION
Make sure that App is verified (docker-compose config) just after successful download.
We used to do it for Compose Apps at the end of "fetch" phase.
Now, we want to support App update rollback, so we need to distinguish between true download and Target verification&installation  failures. In the first case, aklite can keep doing download attempts to make sure that Target Apps are fully downloaded. In the later case, there is no sense in update retrying, thus a rollback should be performed.