### PR TITLE
api: Include secondary hwid in backend payload

### DIFF
--- a/src/api.cc
+++ b/src/api.cc
@@ -284,6 +284,7 @@ InstallResult AkliteClient::SetSecondaries(const std::vector<SecondaryEcu>& ecus
   for (const auto& ecu : ecus) {
     Json::Value entry;
     entry["target"] = ecu.target_name;
+    entry["hwid"] = ecu.hwid;
     data[ecu.serial] = entry;
     hwids.emplace_back(ecu.hwid);
   }

--- a/tests/apiclient_test.cc
+++ b/tests/apiclient_test.cc
@@ -161,6 +161,7 @@ TEST_F(ApiClientTest, Secondaries) {
   auto events = getDeviceGateway().getEvents();
   ASSERT_EQ(1, events.size());
   ASSERT_EQ("target12", events[0]["123"]["target"].asString());
+  ASSERT_EQ("riscv", events[0]["123"]["hwid"].asString());
 
   auto new_target = createTarget();
   auto secondary_target = createTarget(nullptr, "riscv");


### PR DESCRIPTION
The backend will now track hwid's if provided.

Signed-off-by: Andy Doan <andy@foundries.io>