### PR TITLE
Forward-declare as much as possible in liteclient.h.

### DIFF
--- a/src/api.cc
+++ b/src/api.cc
@@ -5,8 +5,10 @@
 #include <boost/uuid/uuid_io.hpp>
 
 #include "helpers.h"
+#include "http/httpclient.h"
 #include "libaktualizr/config.h"
 #include "liteclient.h"
+#include "primary/reportqueue.h"
 
 std::vector<boost::filesystem::path> AkliteClient::CONFIG_DIRS = {"/usr/lib/sota/conf.d", "/var/sota/sota.toml",
                                                                   "/etc/sota/conf.d/"};

--- a/src/helpers.cc
+++ b/src/helpers.cc
@@ -4,6 +4,7 @@
 #include <boost/uuid/uuid_io.hpp>
 
 #include "composeappmanager.h"
+#include "storage/invstorage.h"
 
 static bool appListChanged(const Json::Value& target_apps, std::vector<std::string>& cfg_apps_in,
                            const boost::filesystem::path& apps_dir) {

--- a/src/liteclient.cc
+++ b/src/liteclient.cc
@@ -9,7 +9,12 @@
 
 #include "composeappmanager.h"
 #include "crypto/keymanager.h"
+#include "crypto/p11engine.h"
+#include "http/httpclient.h"
+#include "ostree/sysroot.h"
+#include "primary/reportqueue.h"
 #include "rootfstreemanager.h"
+#include "storage/invstorage.h"
 #include "target.h"
 
 LiteClient::LiteClient(Config& config_in, const AppEngine::Ptr& app_engine, const std::shared_ptr<P11EngineGuard>& p11)
@@ -108,6 +113,8 @@ LiteClient::LiteClient(Config& config_in, const AppEngine::Ptr& app_engine, cons
     throw std::runtime_error("Unsupported package manager type: " + config.pacman.type);
   }
 }
+
+LiteClient::~LiteClient() {}  // NOLINT(modernize-use-equals-default, hicpp-use-equals-default)
 
 data::InstallationResult LiteClient::finalizePendingUpdate(boost::optional<Uptane::Target>& target) {
   data::InstallationResult ret{data::ResultCode::Numeric::kNeedCompletion, ""};

--- a/src/liteclient.h
+++ b/src/liteclient.h
@@ -1,20 +1,27 @@
 #ifndef AKTUALIZR_LITE_CLIENT_H_
 #define AKTUALIZR_LITE_CLIENT_H_
 
-#include "http/httpclient.h"
+#include "gtest/gtest_prod.h"
 #include "libaktualizr/config.h"
-#include "ostree/sysroot.h"
-#include "package_manager/packagemanagerfake.h"
-#include "primary/reportqueue.h"
-#include "storage/invstorage.h"
+#include "libaktualizr/packagemanagerinterface.h"
 #include "uptane/imagerepository.h"
 
 class AppEngine;
+class HttpClient;
+class INvStorage;
+class KeyManager;
+class P11EngineGuard;
+class ReportEvent;
+class ReportQueue;
 
 class LiteClient {
  public:
   LiteClient(Config& config_in, const std::shared_ptr<AppEngine>& app_engine = nullptr,
              const std::shared_ptr<P11EngineGuard>& p11 = nullptr);
+  // Prevent inlining to enable forward declarations.
+  ~LiteClient();
+  LiteClient(LiteClient&&) = default;
+  LiteClient& operator=(LiteClient&&) = default;
 
   Config config;
   std::vector<std::string> tags;

--- a/src/main.cc
+++ b/src/main.cc
@@ -8,8 +8,9 @@
 
 #include "crypto/keymanager.h"
 #include "helpers.h"
+#include "http/httpclient.h"
 #include "libaktualizr/config.h"
-
+#include "storage/invstorage.h"
 #include "target.h"
 #include "utilities/aktualizr_version.h"
 

--- a/tests/helpers_test.cc
+++ b/tests/helpers_test.cc
@@ -2,6 +2,8 @@
 
 #include "helpers.h"
 #include "composeappmanager.h"
+#include "primary/reportqueue.h"
+#include "storage/invstorage.h"
 #include "target.h"
 
 static boost::filesystem::path test_sysroot;


### PR DESCRIPTION
This makes it much easier to use elsewhere. Note that the destructor has
to be declared explicitly to prevent auto-inlining, which prevents
forward declaration with unique_ptr.

There were several transitive header dependencies that had to be filled
in appropriately as well.

This _might_ depend on https://github.com/uptane/aktualizr/pull/19, but I think it's just our test code that depends on both.