### PR TITLE
cmake: include HSM specific test conditionally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,8 @@ if(BUILD_AKLITE)
   add_dependencies(aklite aktualizr-lite)
 
   add_custom_target(aklite-tests)
-  add_dependencies(aklite-tests aklite t_lite-helpers uptane-generator t_compose-apps t_ostree t_liteclient t_yaml2json t_composeappengine t_restorableappengine t_aklite t_liteclientHSM t_apiclient)
+  add_dependencies(aklite-tests aklite t_lite-helpers uptane-generator t_compose-apps t_ostree t_liteclient t_yaml2json t_composeappengine t_restorableappengine t_aklite t_apiclient)
+
   set(CMAKE_MODULE_PATH "${AKTUALIZR_DIR}/cmake-modules;${CMAKE_MODULE_PATH}")
 
   find_package(OSTree REQUIRED)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -89,6 +89,9 @@ target_link_libraries(t_liteclient ${TEST_LIBS} uptane_generator_lib testutiliti
 add_dependencies(t_liteclient make_ostree_sysroot)
 set_tests_properties(test_liteclient PROPERTIES LABELS "aklite:liteclient")
 
+aktualizr_source_file_checks(liteclient_test.cc)
+
+if(BUILD_P11)
 add_aktualizr_test(NAME liteclientHSM
   SOURCES $<TARGET_OBJECTS:${MAIN_TARGET_LIB}> liteclientHSM_test.cc
   PROJECT_WORKING_DIRECTORY
@@ -102,8 +105,9 @@ target_include_directories(t_liteclientHSM PRIVATE ${TEST_INCS} ${AKTUALIZR_DIR}
 target_link_libraries(t_liteclientHSM ${TEST_LIBS} uptane_generator_lib testutilities)
 add_dependencies(t_liteclientHSM make_ostree_sysroot)
 set_tests_properties(test_liteclientHSM PROPERTIES LABELS "aklite:liteclientHSM")
+add_dependencies(aklite-tests t_liteclientHSM)
+endif(BUILD_P11)
 
-aktualizr_source_file_checks(liteclient_test.cc)
 aktualizr_source_file_checks(liteclientHSM_test.cc)
 
 add_aktualizr_test(NAME composeappengine


### PR DESCRIPTION
Add the HSM specific test suite of aklite conditionally, only if BUILD_P11 is turned ON.

Signed-off-by: Mike Sul <mike.sul@foundries.io>