### PR TITLE
Check if App is really installed successfully

### DIFF
--- a/src/docker/composeappengine.h
+++ b/src/docker/composeappengine.h
@@ -122,6 +122,7 @@ class ComposeAppEngine : public AppEngine {
   bool pullImages(const App& app);
   bool installApp(const App& app);
   bool start(const App& app);
+  bool areContainersCreated(const App& app);
 
   static bool checkAvailableStorageSpace(const boost::filesystem::path& app_root, uint64_t& out_available_size);
   void verifyAppArchive(const App& app, const std::string& archive_file_name);

--- a/src/docker/dockerclient.cc
+++ b/src/docker/dockerclient.cc
@@ -35,22 +35,19 @@ void DockerClient::getContainers(Json::Value& root) {
   }
 }
 
-bool DockerClient::isRunning(const Json::Value& root, const std::string& app, const std::string& service,
-                             const std::string& hash) {
+std::tuple<bool, std::string> DockerClient::getContainerState(const Json::Value& root, const std::string& app,
+                                                              const std::string& service, const std::string& hash) {
   for (Json::ValueConstIterator ii = root.begin(); ii != root.end(); ++ii) {
     Json::Value val = *ii;
     if (val["Labels"]["com.docker.compose.project"].asString() == app) {
       if (val["Labels"]["com.docker.compose.service"].asString() == service) {
         if (val["Labels"]["io.compose-spec.config-hash"].asString() == hash) {
-          // All other states imply that a container was started
-          if (val["State"].asString() != "created") {
-            return true;
-          }
+          return {true, val["State"].asString()};
         }
       }
     }
   }
-  return false;
+  return {false, ""};
 }
 
 }  // namespace Docker

--- a/src/docker/dockerclient.h
+++ b/src/docker/dockerclient.h
@@ -18,8 +18,8 @@ class DockerClient {
   DockerClient(std::shared_ptr<HttpInterface> http_client = DefaultHttpClientFactory());
   void getContainers(Json::Value& root);
 
-  static bool isRunning(const Json::Value& root, const std::string& app, const std::string& service,
-                        const std::string& hash);
+  static std::tuple<bool, std::string> getContainerState(const Json::Value& root, const std::string& app,
+                                                         const std::string& service, const std::string& hash);
 
  private:
   std::shared_ptr<HttpInterface> http_client_;

--- a/src/docker/restorableappengine.h
+++ b/src/docker/restorableappengine.h
@@ -107,6 +107,11 @@ class RestorableAppEngine : public AppEngine {
   static bool isRunning(const App& app, const std::string& compose_file,
                         const Docker::DockerClient::Ptr& docker_client);
 
+  static bool areContainersCreated(const App& app, const std::string& compose_file,
+                                   const Docker::DockerClient::Ptr& docker_client);
+  static bool checkAppContainers(const App& app, const std::string& compose_file,
+                                 const Docker::DockerClient::Ptr& docker_client, bool check_state = true);
+
   // functions specific to an image tranfer utility
   static void pullImage(const std::string& client, const std::string& uri, const boost::filesystem::path& dst_dir,
                         const boost::filesystem::path& shared_blob_dir, const std::string& format = "v2s2");

--- a/tests/docker-compose_fake.py
+++ b/tests/docker-compose_fake.py
@@ -15,8 +15,11 @@ logger = logging.getLogger("Fake Docker Compose")
 def up(out_dir, app_name, compose, flags):
     logger.info("Up: " + flags[0] + " " + flags[1])
 
-    if not compose["x-status"]["valid"]:
+    if compose["x-fault-injection"]["failure-type"] == "compose-failure":
         exit(1)
+
+    if compose["x-fault-injection"]["failure-type"] == "container-failure":
+        exit(0)
 
     logger.info("Run services...")
     with open(os.path.join(out_dir, "containers.json"), "r") as f:

--- a/tests/fixtures/composeapp.cc
+++ b/tests/fixtures/composeapp.cc
@@ -51,8 +51,8 @@ class ComposeApp {
       %s
         labels:
           io.compose-spec.config-hash: %s
-    x-status:
-      valid: %s
+    x-fault-injection:
+      failure-type: %s
     version: "3.8"
     )";
 
@@ -65,17 +65,17 @@ class ComposeApp {
                     const std::string& service = "service-01", const std::string& image = "image-01",
                     const std::string& service_template = ServiceTemplate,
                     const std::string& compose_file = Docker::ComposeAppEngine::ComposeFile,
-                    bool valid = true) {
+                    const std::string& failure = "none") {
     Ptr app{new ComposeApp(name, compose_file, "factory/" + image)};
-    app->updateService(service, service_template, valid);
+    app->updateService(service, service_template, failure);
     return app;
   }
 
-  const std::string& updateService(const std::string& service, const std::string& service_template = ServiceTemplate, bool valid = true) {
+  const std::string& updateService(const std::string& service, const std::string& service_template = ServiceTemplate, const std::string& failure = "none") {
     char service_content[1024];
     sprintf(service_content, service_template.c_str(), service.c_str(), image_.uri().c_str());
     auto service_hash = boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha256digest(service_content)));
-    sprintf(content_, DefaultTemplate, service_content, service_hash.c_str(), valid?"true":"false");
+    sprintf(content_, DefaultTemplate, service_content, service_hash.c_str(), failure.c_str());
     return update();
   }
 


### PR DESCRIPTION
This change makes sure that we properly determine whether a new App was successfully installed or not.
From aklite (update agent) perspective an App installation is successful if:
1.  `docker-compose up` exits with 0;
2.  All App's containers are created.
    
So, the PR makes sure the second criterion is met.

App/service running inside of Compose App's container(s)  might fail of course, too. But aklite doesn't take it into account during App installation since this is App specific business logic failure and we wanna keep aklite agnostic of it.
Thus, in this case, a user will be notified that the new App version was successfully installed, but the status report will indicate that one or more of the App's containers are not running including its state and exit/failure code&reason.