### PR TITLE
Make sure the metadata is loaded from storage before trying to use it.

### DIFF
--- a/src/api.cc
+++ b/src/api.cc
@@ -248,6 +248,8 @@ std::unique_ptr<InstallContext> AkliteClient::Installer(const TufTarget& t, std:
   if (read_only_) {
     throw std::runtime_error("Can't perform this operation from read-only mode");
   }
+  // Make sure the metadata is loaded from storage and valid.
+  client_->checkImageMetaOffline();
   std::unique_ptr<Uptane::Target> target;
   for (const auto& tt : client_->allTargets()) {
     if (tt.filename() == t.Name()) {


### PR DESCRIPTION
This is an issue in particular after restarting and trying to report that a Secondary has completed installation before checking for new updates. A segfault would occur in `AkliteClient::Installer()` via `LiteClient::allTargets()` when trying to fetch targets from an empty shared pointer.

Note that this fixes the bug on the client side, but the web UI shows the successful installation completed event in a separate chain of events from the rest, presumably because the correlation ID is different. I'm not quite sure how to fix that, and that's not quite as important to me yet, although it would be good to fix.