### PR TITLE
apps: check expected size of a layer manifest

### DIFF
--- a/src/docker/docker.h
+++ b/src/docker/docker.h
@@ -4,6 +4,8 @@
 #include <limits>
 #include <string>
 
+#include <boost/optional.hpp>
+
 #include <http/httpinterface.h>
 
 namespace Docker {
@@ -95,7 +97,7 @@ class RegistryClient {
  public:
   static constexpr const char* const DefAuthCredsEndpoint{"https://ota-lite.foundries.io:8443/hub-creds/"};
   static const int AuthMaterialMaxSize{1024};
-  static const int ManifestMaxSize{16384};
+  static const int DefManifestMaxSize{16384};
   static const size_t MaxBlobSize{std::numeric_limits<int>::max()};
 
   static const std::string ManifestEndpoint;
@@ -110,7 +112,8 @@ class RegistryClient {
                           std::string auth_creds_endpoint = DefAuthCredsEndpoint,
                           HttpClientFactory http_client_factory = RegistryClient::DefaultHttpClientFactory);
 
-  std::string getAppManifest(const Uri& uri, const std::string& format) const;
+  std::string getAppManifest(const Uri& uri, const std::string& format,
+                             boost::optional<std::int64_t> manifest_size = boost::none) const;
   void downloadBlob(const Uri& uri, const boost::filesystem::path& filepath, size_t expected_size) const;
 
  private:

--- a/src/docker/restorableappengine.cc
+++ b/src/docker/restorableappengine.cc
@@ -333,8 +333,19 @@ void RestorableAppEngine::checkAppUpdateSize(const Uri& uri, const boost::filesy
     return;
   }
 
+  if (!(layers_manifest.isMember("digest") && layers_manifest["digest"].isString())) {
+    throw std::invalid_argument("Got invalid layers manifest, missing or incorrect `digest` field");
+  }
+
+  if (!(layers_manifest.isMember("size") && layers_manifest["size"].isInt64())) {
+    throw std::invalid_argument("Got invalid layers manifest, missing or incorrect `size` field");
+  }
+
   const Docker::Uri layers_manifest_uri{uri.createUri(HashedDigest(layers_manifest["digest"].asString()))};
-  const std::string man_str{registry_client_->getAppManifest(layers_manifest_uri, Manifest::IndexFormat)};
+  const std::int64_t layers_manifest_size{layers_manifest["size"].asInt64()};
+
+  const std::string man_str{
+      registry_client_->getAppManifest(layers_manifest_uri, Manifest::IndexFormat, layers_manifest_size)};
   const auto man{Utils::parseJSON(man_str)};
 
   std::unordered_set<std::string> store_blobs;

--- a/tests/composeapp_test.cc
+++ b/tests/composeapp_test.cc
@@ -451,7 +451,7 @@ TEST(ComposeApp, fetchNegative) {
   // Manifest size exceeds maximum allowed size (RegistryClient::ManifestMaxSize)
   target_json["custom"]["docker_compose_apps"]["app2"]["uri"] = registry.addApp("test_repo", "app2",
                                         [](Json::Value& manifest, std::string&) {
-                                          manifest["layers"][1]["some_value"] = std::string(Docker::RegistryClient::ManifestMaxSize + 1, 'f');
+                                          manifest["layers"][1]["some_value"] = std::string(Docker::RegistryClient::DefManifestMaxSize + 1, 'f');
                                         });
   target = Uptane::Target("pull", target_json);
   result = client.pacman->fetchTarget(target, *(client.fetcher), *(client.keys), progress_cb, nullptr);

--- a/tests/restorableappengine_test.cc
+++ b/tests/restorableappengine_test.cc
@@ -121,6 +121,19 @@ TEST_F(RestorableAppEngineTest, FetchAndCheckSizeOverflowLayerSize) {
   ASSERT_FALSE(app_engine->isRunning(app));
 }
 
+TEST_F(RestorableAppEngineTest, FetchAndCheckSizeInvalidLayersManifestSize) {
+  Json::Value layers;
+  layers["layers"][0]["digest"] =
+      "sha256:" + boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha256digest(Utils::randomUuid())));
+  layers["layers"][0]["size"] = 1024;
+
+  auto app = registry.addApp(fixtures::ComposeApp::createAppWithCustomeLayers(
+      "app-01", layers, (Utils::jsonToCanonicalStr(layers).size() - 1)));
+  ASSERT_FALSE(app_engine->fetch(app));
+  ASSERT_FALSE(app_engine->isFetched(app));
+  ASSERT_FALSE(app_engine->isRunning(app));
+}
+
 TEST_F(RestorableAppEngineTest, FetchAndCheckSizeInvalidLayerSize) {
   {
     // layer sizes must be int64, we set it to uint64::max to check how the given negative case is handled


### PR DESCRIPTION
We do not know in advance a size of an App's index/root manifest,
hence we just assume that it shouldn't be bigger than certain predefined value (16KB).
But, we know a layer manifest size since it is defined in the root level manifest (Merkle tree).
Therefore, we must ensure that a downloaded layer manifest's size matches the size specified in the root manifest.
Also, we must sure that data being downloaded don't exceed the given manifest's size,
libcurl does that we just pass a corresponding param down to it via the http client.

Signed-off-by: Mike Sul <mike.sul@foundries.io>