### PR TITLE
apps: parameterized App recreation before reboot

### DIFF
--- a/src/composeappmanager.h
+++ b/src/composeappmanager.h
@@ -32,6 +32,7 @@ class ComposeAppManager : public RootfsTreeManager {
     boost::filesystem::path images_data_root{"/var/lib/docker"};
     std::string docker_images_reload_cmd{"systemctl reload docker"};
     std::string hub_auth_creds_endpoint{Docker::RegistryClient::DefAuthCredsEndpoint};
+    bool create_containers_before_reboot{true};
   };
 
   using AppsContainer = std::unordered_map<std::string, std::string>;

--- a/tests/fixtures/dockerdaemon.cc
+++ b/tests/fixtures/dockerdaemon.cc
@@ -11,7 +11,7 @@ class DockerDaemon {
  public:
   DockerDaemon(boost::filesystem::path dir): dir_{std::move(dir)}, port_{TestUtils::getFreePort()}, process_{RunCmd, "--port", port_, "--dir", dir.string()} {
     // zero containers are running in the beginning
-    Utils::writeFile(dir_ / ContainersFile, std::string("[]"), true);
+    Utils::writeFile(dir_ / ContainersFile, none_containers_, true);
     TestUtils::waitForServer("http://localhost:" + port_ + "/");
   }
 
@@ -22,6 +22,11 @@ class DockerDaemon {
   std::shared_ptr<HttpInterface> getClient() { return std::make_shared<DockerDaemon::HttpClient>(*this); }
   const boost::filesystem::path& dir() const { return dir_; }
   std::string getRunningContainers() const { return Utils::readFile(dir_ / ContainersFile); }
+  bool areContainersCreated() const {
+    const std::string cur_containers{Utils::readFile(dir_ / ContainersFile)};
+    return !(cur_containers == none_containers_);
+  }
+
 
  private:
   class HttpClient: public BaseHttpClient {
@@ -43,6 +48,7 @@ class DockerDaemon {
   };
 
  private:
+  const std::string none_containers_{"[]"};
   boost::filesystem::path dir_;
   const std::string port_;
   boost::process::child process_;

--- a/tests/fixtures/liteclienttest.cc
+++ b/tests/fixtures/liteclienttest.cc
@@ -37,7 +37,8 @@ class ClientTest :virtual public ::testing::Test {
                                                InitialVersion initial_version = InitialVersion::kOn,
                                                boost::optional<std::vector<std::string>> apps = boost::none,
                                                const std::string& compose_apps_root = "",
-                                               boost::optional<std::vector<std::string>> reset_apps = boost::none) {
+                                               boost::optional<std::vector<std::string>> reset_apps = boost::none,
+                                               bool create_containers_before_reboot = true) {
     Config conf;
     conf.tls.server = device_gateway_.getTlsUri();
     conf.uptane.repo_server = device_gateway_.getTufRepoUri();
@@ -57,6 +58,10 @@ class ClientTest :virtual public ::testing::Test {
     }
     app_shortlist_ = apps;
     conf.pacman.ostree_server = device_gateway_.getOsTreeUri();
+    if (!create_containers_before_reboot) {
+      // by default it set to "1"/true in the composeappmanager's config
+      conf.pacman.extra["create_containers_before_reboot"] = "0";
+    }
 
     conf.bootloader.reboot_command = "/bin/true";
     conf.bootloader.reboot_sentinel_dir = conf.storage.path;


### PR DESCRIPTION
- Add a config param `create_containers_before_reboot` that allows
configuring aklite behavior if both ostree and Apps are updated.
Specifically, whether to recreate App's containers or not before a system reboot.
By default, App's containers are recreated (but not restarted).
It's worth noting that App containers are recreated just after reboot if
docker-compose detects any configuration changes in any case
(e.g. a new version of ostree/LmP modifies compose App content on boot).

Signed-off-by: Mike Sul <mike.sul@foundries.io>