### PR TITLE
aklite: invoke the post check callback in any case

### DIFF
--- a/src/liteclient.cc
+++ b/src/liteclient.cc
@@ -200,6 +200,9 @@ bool LiteClient::checkForUpdatesBegin() {
 }
 
 void LiteClient::checkForUpdatesEnd(const Uptane::Target& target) { callback("check-for-update-post", target, "OK"); }
+void LiteClient::checkForUpdatesEndWithFailure(const std::string& err) {
+  callback("check-for-update-post", Uptane::Target::Unknown(), "FAILED: " + err);
+}
 
 void LiteClient::notify(const Uptane::Target& t, std::unique_ptr<ReportEvent> event) const {
   if (!config.tls.server.empty()) {

--- a/src/liteclient.h
+++ b/src/liteclient.h
@@ -33,6 +33,7 @@ class LiteClient {
 
   bool checkForUpdatesBegin();
   void checkForUpdatesEnd(const Uptane::Target& target);
+  void checkForUpdatesEndWithFailure(const std::string& err);
   bool finalizeInstall();
   data::ResultCode::Numeric download(const Uptane::Target& target, const std::string& reason);
   data::ResultCode::Numeric install(const Uptane::Target& target);


### PR DESCRIPTION
- Invoke `check-for-update-post` callback in any case, including the case when an exception occurs.

- If a target is not found for a given device (hw ID and tags) while the metadata update is successful then do not treat it as an exceptional situation.

- Improve logging for the use-cases related to updating of metadata and finding the latest target for a device.

Signed-off-by: Mike Sul <mike.sul@foundries.io>