### PR TITLE
Check an available capacity of the docker store before an App update

### DIFF
--- a/src/composeappmanager.cc
+++ b/src/composeappmanager.cc
@@ -87,8 +87,9 @@ ComposeAppManager::ComposeAppManager(const PackageConfig& pconfig, const Bootloa
     const std::string docker_host{"unix:///var/run/docker.sock"};
 
     if (!!cfg_.reset_apps) {
-      app_engine_ = std::make_shared<Docker::RestorableAppEngine>(cfg_.reset_apps_root, cfg_.apps_root, registry_client,
-                                                                  docker_client, skopeo_cmd, docker_host, compose_cmd);
+      app_engine_ = std::make_shared<Docker::RestorableAppEngine>(cfg_.reset_apps_root, cfg_.apps_root,
+                                                                  cfg_.images_data_root, registry_client, docker_client,
+                                                                  skopeo_cmd, docker_host, compose_cmd);
     } else {
       app_engine_ =
           std::make_shared<Docker::ComposeAppEngine>(cfg_.apps_root, compose_cmd, docker_client, registry_client);

--- a/src/docker/restorableappengine.h
+++ b/src/docker/restorableappengine.h
@@ -79,8 +79,9 @@ class RestorableAppEngine : public AppEngine {
   static StorageSpaceFunc DefStorageSpaceFunc;
 
   RestorableAppEngine(boost::filesystem::path store_root, boost::filesystem::path install_root,
-                      Docker::RegistryClient::Ptr registry_client, Docker::DockerClient::Ptr docker_client,
-                      std::string client = "/sbin/skopeo", std::string docker_host = "unix:///var/run/docker.sock",
+                      boost::filesystem::path docker_root, Docker::RegistryClient::Ptr registry_client,
+                      Docker::DockerClient::Ptr docker_client, std::string client = "/sbin/skopeo",
+                      std::string docker_host = "unix:///var/run/docker.sock",
                       std::string compose_cmd = "/usr/bin/docker-compose",
                       StorageSpaceFunc storage_space_func = RestorableAppEngine::DefStorageSpaceFunc);
 
@@ -133,8 +134,21 @@ class RestorableAppEngine : public AppEngine {
   static void stopComposeApp(const std::string& compose_cmd, const boost::filesystem::path& app_dir);
   static std::string getContentHash(const boost::filesystem::path& path);
 
+  static uint64_t getAppUpdateSize(const Json::Value& app_layers, const boost::filesystem::path& blob_dir);
+  static uint64_t getDockerStoreSizeForAppUpdate(const uint64_t& compressed_update_size,
+                                                 uint32_t average_compression_ratio);
+
+  void checkAvailableStorageInStores(const std::string& app_name, const uint64_t& skopeo_required_storage,
+                                     const uint64_t& docker_required_storage, float watermark) const;
+
+  static bool areDockerAndSkopeoOnTheSameVolume(const boost::filesystem::path& skopeo_path,
+                                                const boost::filesystem::path& docker_path);
+  static std::tuple<uint64_t, bool> getPathVolumeID(const boost::filesystem::path& path);
+
   const boost::filesystem::path store_root_;
   const boost::filesystem::path install_root_;
+  const boost::filesystem::path docker_root_;
+  const bool docker_and_skopeo_same_volume_{true};
   const std::string client_;
   const std::string docker_host_;
   const std::string compose_cmd_;

--- a/tests/aklite_test.cc
+++ b/tests/aklite_test.cc
@@ -32,8 +32,8 @@ class AkliteTest : public fixtures::ClientTest,
     } else if (app_engine_type == "RestorableAppEngine") {
       setAvailableStorageSpace(std::numeric_limits<boost::uintmax_t>::max());
       app_engine = std::make_shared<Docker::RestorableAppEngine>(
-          fixtures::ClientTest::test_dir_.Path() / "apps-store", apps_root_dir, registry_client_, docker_client_,
-          registry.getSkopeoClient(), daemon_.getUrl(), compose_cmd,
+          fixtures::ClientTest::test_dir_.Path() / "apps-store", apps_root_dir, daemon_.dataRoot(), registry_client_,
+          docker_client_, registry.getSkopeoClient(), daemon_.getUrl(), compose_cmd,
           [this](const boost::filesystem::path& path) { return this->available_storage_space_; });
     } else {
       throw std::invalid_argument("Unsupported AppEngine type: " + app_engine_type);

--- a/tests/fixtures/dockerdaemon.cc
+++ b/tests/fixtures/dockerdaemon.cc
@@ -15,6 +15,8 @@ class DockerDaemon {
     TestUtils::waitForServer("http://localhost:" + port_ + "/");
   }
 
+  const std::string& dataRoot() const { return dir_.string(); }
+
   std::string getUrl() const {
     return "http://localhost:" + port_;
   }


### PR DESCRIPTION
Check whether there is sufficient amount of available storage in both the skopeo and docker store before an App update.
A storage size, required to accommodate a new App version, is calculated  precisely for the skopeo store (tar.gzip format) and approximately for the docker store.
The approximation is based on an average gzip compression ratio in the case of rootfs diffs/image layers.
