### PR TITLE
Rollback if Apps fail to create before reboot or start after reboot

### DIFF
--- a/src/composeappmanager.cc
+++ b/src/composeappmanager.cc
@@ -237,7 +237,12 @@ TargetStatus ComposeAppManager::verifyTarget(const Uptane::Target& target) const
 data::InstallationResult ComposeAppManager::install(const Uptane::Target& target) const {
   data::InstallationResult res;
   Uptane::Target current = OstreeManager::getCurrent();
-  if (current.sha256Hash() != target.sha256Hash()) {
+  // Do ostree install if the currently installed target's hash differs from the specified target's hash,
+  // or there is pending installation and it differs from the specified target so we undeploy it and make the new target
+  // pending
+  if ((current.sha256Hash() != target.sha256Hash()) ||
+      (!sysroot()->getDeploymentHash(OSTree::Sysroot::Deployment::kPending).empty() &&
+       sysroot()->getDeploymentHash(OSTree::Sysroot::Deployment::kPending) != target.sha256Hash())) {
     // notify the bootloader before installation happens as it is not atomic
     // and a false notification doesn't hurt with rollback support in place
     // Hacking in order to invoke non-const method from the const one !!!
@@ -249,6 +254,12 @@ data::InstallationResult ComposeAppManager::install(const Uptane::Target& target
       return res;
     }
     const_cast<ComposeAppManager*>(this)->installNotify(target);
+    if (current.sha256Hash() == target.sha256Hash() &&
+        res.result_code.num_code == data::ResultCode::Numeric::kNeedCompletion) {
+      LOG_INFO << "Successfully undeployed the pending failing Target";
+      LOG_INFO << "Target " << target.sha256Hash() << " is same as current";
+      res = data::InstallationResult(data::ResultCode::Numeric::kOk, "OSTree hash already installed, same as current");
+    }
   } else {
     LOG_INFO << "Target " << target.sha256Hash() << " is same as current";
     res = data::InstallationResult(data::ResultCode::Numeric::kOk, "OSTree hash already installed, same as current");

--- a/src/docker/composeappengine.cc
+++ b/src/docker/composeappengine.cc
@@ -142,7 +142,7 @@ bool ComposeAppEngine::isFetched(const App& app) const {
   bool res{false};
   try {
     AppState state(app, appRoot(app));
-    res = state() == AppState::State::kPulled;
+    res = ((state() == AppState::State::kPulled) || (state() >= AppState::State::kInstalled));
   } catch (const std::exception& exc) {
     LOG_WARNING << "Failed to get/set App state: " << exc.what();
   }
@@ -319,7 +319,7 @@ bool ComposeAppEngine::installApp(const App& app) {
 }
 
 bool ComposeAppEngine::start(const App& app) {
-  LOG_INFO << "Starting App";
+  LOG_INFO << "Starting App: " << app.name << " -> " << app.uri;
   const auto result = cmd_streaming(compose_ + "up --remove-orphans -d", app);
   return result;
 }

--- a/src/helpers.cc
+++ b/src/helpers.cc
@@ -80,21 +80,19 @@ bool target_has_tags(const Uptane::Target& t, const std::vector<std::string>& co
 bool known_local_target(LiteClient& client, const Uptane::Target& t,
                         std::vector<Uptane::Target>& known_but_not_installed_versions) {
   bool known_target = false;
-  auto current = client.getCurrent();
   boost::optional<Uptane::Target> pending;
   client.storage->loadPrimaryInstalledVersions(nullptr, &pending);
 
-  if (current.filename() != t.filename()) /* make sure that a specified target is not current */ {
-    std::vector<Uptane::Target>::reverse_iterator it;
-    for (it = known_but_not_installed_versions.rbegin(); it != known_but_not_installed_versions.rend(); it++) {
-      if (it->filename() == t.filename()) {
-        // Make sure installed version is not what is currently pending
-        if ((pending != boost::none) && (it->sha256Hash() == pending->sha256Hash())) {
-          continue;
-        }
-        known_target = true;
-        break;
+  // current Target can be "known"/failing Target too
+  std::vector<Uptane::Target>::reverse_iterator it;
+  for (it = known_but_not_installed_versions.rbegin(); it != known_but_not_installed_versions.rend(); it++) {
+    if (it->filename() == t.filename()) {
+      // Make sure installed version is not what is currently pending
+      if ((pending != boost::none) && (it->sha256Hash() == pending->sha256Hash())) {
+        continue;
       }
+      known_target = true;
+      break;
     }
   }
   return known_target;

--- a/src/liteclient.h
+++ b/src/liteclient.h
@@ -66,6 +66,8 @@ class LiteClient {
  private:
   FRIEND_TEST(helpers, locking);
   FRIEND_TEST(helpers, callback);
+  FRIEND_TEST(AkliteTest, RollbackIfAppsInstallFails);
+  FRIEND_TEST(AkliteTest, RollbackIfAppsInstallFailsAndPowerCut);
 
   void callback(const char* msg, const Uptane::Target& install_target, const std::string& result = "");
 

--- a/src/liteclient.h
+++ b/src/liteclient.h
@@ -4,6 +4,7 @@
 #include "gtest/gtest_prod.h"
 #include "libaktualizr/config.h"
 #include "libaktualizr/packagemanagerinterface.h"
+#include "ostree/sysroot.h"
 #include "uptane/imagerepository.h"
 
 class AppEngine;
@@ -35,6 +36,7 @@ class LiteClient {
   void checkForUpdatesEnd(const Uptane::Target& target);
   void checkForUpdatesEndWithFailure(const std::string& err);
   bool finalizeInstall();
+  Uptane::Target getRollbackTarget();
   data::ResultCode::Numeric download(const Uptane::Target& target, const std::string& reason);
   data::ResultCode::Numeric install(const Uptane::Target& target);
   void notifyInstallFinished(const Uptane::Target& t, data::InstallationResult& ir);
@@ -90,6 +92,8 @@ class LiteClient {
   Json::Value last_network_info_reported_;
   bool hwinfo_reported_{false};
   bool is_reboot_required_{false};
+
+  std::shared_ptr<OSTree::Sysroot> sysroot_;
 };
 
 #endif  // AKTUALIZR_LITE_CLIENT_H_

--- a/src/main.cc
+++ b/src/main.cc
@@ -365,8 +365,9 @@ static int daemon_main(LiteClient& client, const bpo::variables_map& variables_m
           break;
         } else if (rc == data::ResultCode::Numeric::kInstallFailed) {
           // If installation of the new Target has failed then do not wait `interval` time for the next update cycle,
-          // just do it immediately in order to sync Apps for the current Target, what effectively leads to Apps'
-          // rollback.
+          // just do it immediately in order to sync current installation with the current Target.
+          // It effectively leads to either just Apps' rollback or both sysroot and Apps' rollback depending on
+          // changes in the latest failing Target.
           client.setAppsNotChecked();
           continue;
         }

--- a/src/ostree/sysroot.cc
+++ b/src/ostree/sysroot.cc
@@ -2,29 +2,79 @@
 
 namespace OSTree {
 
-Sysroot::Sysroot(std::string sysroot_path, BootedType booted) : path_{std::move(sysroot_path)}, booted_{booted} {
+Sysroot::Sysroot(std::string sysroot_path, BootedType booted, std::string os_name)
+    : path_{std::move(sysroot_path)}, booted_{booted}, os_name_{std::move(os_name)} {
   sysroot_ = OstreeManager::LoadSysroot(path_);
 }
 
-std::string Sysroot::getCurDeploymentHash() const {
+std::string Sysroot::getDeploymentHash(Deployment deployment_type) const {
+  std::string deployment_hash;
   g_autoptr(GPtrArray) deployments = nullptr;
   OstreeDeployment* deployment = nullptr;
 
-  if (booted_ == BootedType::kBooted) {
-    deployment = ostree_sysroot_get_booted_deployment(sysroot_.get());
-  } else {
-    deployments = ostree_sysroot_get_deployments(sysroot_.get());
-    if (deployments != nullptr && deployments->len > 0) {
-      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-      deployment = static_cast<OstreeDeployment*>(deployments->pdata[0]);
-    }
+  switch (booted_) {
+    case BootedType::kBooted:
+      deployment = getDeploymentIfBooted(sysroot_.get(), os_name_.c_str(), deployment_type);
+      break;
+    case BootedType::kStaged:
+      deployment = getDeploymentIfStaged(sysroot_.get(), os_name_.c_str(), deployment_type);
+      break;
+    default:
+      throw std::runtime_error("Invalid boot type: " + std::to_string(static_cast<int>(booted_)));
   }
 
-  if (deployment == nullptr) {
-    LOG_WARNING << "Failed to get " << booted_ << " deployment in " << path();
-    return "";
+  if (deployment != nullptr) {
+    deployment_hash = ostree_deployment_get_csum(deployment);
   }
-  return ostree_deployment_get_csum(deployment);
+  return deployment_hash;
+}
+
+OstreeDeployment* Sysroot::getDeploymentIfBooted(OstreeSysroot* sysroot, const char* os_name,
+                                                 Deployment deployment_type) {
+  OstreeDeployment* deployment{nullptr};
+
+  switch (deployment_type) {
+    case Deployment::kCurrent:
+      deployment = ostree_sysroot_get_booted_deployment(sysroot);
+      break;
+    case Deployment::kRollback:
+      ostree_sysroot_query_deployments_for(sysroot, os_name, nullptr, &deployment);
+      break;
+    default:
+      throw std::runtime_error("Invalid deployment type: " + std::to_string(static_cast<int>(deployment_type)));
+  }
+
+  return deployment;
+}
+
+OstreeDeployment* Sysroot::getDeploymentIfStaged(OstreeSysroot* sysroot, const char* os_name,
+                                                 Deployment deployment_type) {
+  g_autoptr(GPtrArray) deployments{nullptr};
+  OstreeDeployment* deployment{nullptr};
+
+  switch (deployment_type) {
+    case Deployment::kCurrent:
+      ostree_sysroot_query_deployments_for(sysroot, os_name, &deployment, nullptr);
+      break;
+    case Deployment::kRollback:
+      deployments = ostree_sysroot_get_deployments(sysroot);
+      if (deployments != nullptr && deployments->len > 1) {
+        // Rollback deployment is the second deployment in the array of deployments,
+        // it goes just after the pending or current deployment if it's not booted sysroot.
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        deployment = static_cast<OstreeDeployment*>(deployments->pdata[1]);
+        if (strcmp(ostree_deployment_get_osname(deployment), os_name) != 0) {
+          LOG_WARNING << "Found rollback deployment doesn't match the given os name; found: "
+                      << ostree_deployment_get_osname(deployment) << ", expected: " << os_name;
+          deployment = nullptr;
+        }
+      }
+      break;
+    default:
+      throw std::runtime_error("Invalid deployment type: " + std::to_string(static_cast<int>(deployment_type)));
+  }
+
+  return deployment;
 }
 
 }  // namespace OSTree

--- a/src/ostree/sysroot.h
+++ b/src/ostree/sysroot.h
@@ -10,15 +10,23 @@ namespace OSTree {
 
 class Sysroot {
  public:
-  explicit Sysroot(std::string sysroot_path, BootedType booted = BootedType::kBooted);
+  enum class Deployment { kCurrent = 0, kRollback = 1 };
+
+  explicit Sysroot(std::string sysroot_path, BootedType booted = BootedType::kBooted, std::string os_name = "lmp");
 
   const std::string& path() const { return path_; }
 
-  virtual std::string getCurDeploymentHash() const;
+  virtual std::string getDeploymentHash(Deployment deployment_type) const;
 
  private:
+  static OstreeDeployment* getDeploymentIfBooted(OstreeSysroot* sysroot, const char* os_name,
+                                                 Deployment deployment_type);
+  static OstreeDeployment* getDeploymentIfStaged(OstreeSysroot* sysroot, const char* os_name,
+                                                 Deployment deployment_type);
+
   const std::string path_;
   const BootedType booted_;
+  const std::string os_name_;
 
   GObjectUniquePtr<OstreeSysroot> sysroot_;
 };

--- a/src/ostree/sysroot.h
+++ b/src/ostree/sysroot.h
@@ -10,13 +10,14 @@ namespace OSTree {
 
 class Sysroot {
  public:
-  enum class Deployment { kCurrent = 0, kRollback = 1 };
+  enum class Deployment { kCurrent = 0, kPending, kRollback };
 
   explicit Sysroot(std::string sysroot_path, BootedType booted = BootedType::kBooted, std::string os_name = "lmp");
 
   const std::string& path() const { return path_; }
 
   virtual std::string getDeploymentHash(Deployment deployment_type) const;
+  bool reload();
 
  private:
   static OstreeDeployment* getDeploymentIfBooted(OstreeSysroot* sysroot, const char* os_name,

--- a/src/rootfstreemanager.cc
+++ b/src/rootfstreemanager.cc
@@ -31,6 +31,20 @@ bool RootfsTreeManager::fetchTarget(const Uptane::Target& target, Uptane::Fetche
   return pull_err.isSuccess();
 }
 
+void RootfsTreeManager::installNotify(const Uptane::Target& target) {
+  if (sysroot_->reload()) {
+    LOG_DEBUG << "Change in the ostree-based sysroot has been detected after installation;"
+              << " booted on: " << sysroot_->getDeploymentHash(OSTree::Sysroot::Deployment::kCurrent)
+              << " pending: " << sysroot_->getDeploymentHash(OSTree::Sysroot::Deployment::kPending);
+
+  } else {
+    LOG_WARNING << "Change in the ostree-based sysroot has NOT been detected after installation;"
+                << " booted on: " << sysroot_->getDeploymentHash(OSTree::Sysroot::Deployment::kCurrent)
+                << " pending: " << sysroot_->getDeploymentHash(OSTree::Sysroot::Deployment::kPending);
+  }
+  OstreeManager::installNotify(target);
+}
+
 void RootfsTreeManager::getAdditionalRemotes(std::vector<Remote>& remotes, const std::string& target_name) {
   const auto resp = http_client_->post(gateway_url_ + "/download-urls", Json::Value::null);
 

--- a/src/rootfstreemanager.h
+++ b/src/rootfstreemanager.h
@@ -29,7 +29,9 @@ class RootfsTreeManager : public OstreeManager {
                    const FetcherProgressCb& progress_cb, const api::FlowControlToken* token) override;
 
  private:
-  std::string getCurrentHash() const override { return sysroot_->getCurDeploymentHash(); }
+  std::string getCurrentHash() const override {
+    return sysroot_->getDeploymentHash(OSTree::Sysroot::Deployment::kCurrent);
+  }
   void getAdditionalRemotes(std::vector<Remote>& remotes, const std::string& target_name);
 
   void setRemote(const std::string& name, const std::string& url, const boost::optional<const KeyManager*>& keys);

--- a/src/rootfstreemanager.h
+++ b/src/rootfstreemanager.h
@@ -28,6 +28,10 @@ class RootfsTreeManager : public OstreeManager {
   bool fetchTarget(const Uptane::Target& target, Uptane::Fetcher& fetcher, const KeyManager& keys,
                    const FetcherProgressCb& progress_cb, const api::FlowControlToken* token) override;
 
+ protected:
+  void installNotify(const Uptane::Target& target) override;
+  const std::shared_ptr<OSTree::Sysroot>& sysroot() const { return sysroot_; }
+
  private:
   std::string getCurrentHash() const override {
     return sysroot_->getDeploymentHash(OSTree::Sysroot::Deployment::kCurrent);

--- a/tests/aklite_test.cc
+++ b/tests/aklite_test.cc
@@ -41,16 +41,17 @@ class AkliteTest : public fixtures::ClientTest,
   }
 
   std::shared_ptr<LiteClient> createLiteClient(InitialVersion initial_version = InitialVersion::kOn,
-                                               boost::optional<std::vector<std::string>> apps = boost::none) override {
+                                               boost::optional<std::vector<std::string>> apps = boost::none,
+                                               bool finalize = true) override {
     const auto app_engine_type{GetParam()};
 
     if (app_engine_type == "ComposeAppEngine") {
       return ClientTest::createLiteClient(app_engine, initial_version, apps, apps_root_dir.string(), boost::none,
-                                          create_containers_before_reboot_);
+                                          create_containers_before_reboot_, finalize);
     } else if (app_engine_type == "RestorableAppEngine") {
       return ClientTest::createLiteClient(app_engine, initial_version, apps, apps_root_dir.string(),
                                           !!apps ? apps : std::vector<std::string>{""},
-                                          create_containers_before_reboot_);
+                                          create_containers_before_reboot_, finalize);
     } else {
       throw std::invalid_argument("Unsupported AppEngine type: " + app_engine_type);
     }
@@ -374,8 +375,7 @@ TEST_P(AkliteTest, OstreeAndAppUpdateIfRollbackAndAfterBootRecreation) {
     reboot(client);
     // make sure that a rollback has happened and a client is still running the previous Target
     ASSERT_TRUE(targetsMatch(client->getCurrent(), target_01));
-    // we stopped the original app before update
-    ASSERT_FALSE(app_engine->isRunning(app01));
+
     ASSERT_FALSE(app_engine->isRunning(app01_updated));
     checkHeaders(*client, target_01);
     checkEvents(*client, target_01, UpdateType::kOstree);
@@ -689,6 +689,250 @@ TEST_P(AkliteTest, AppRollbackIfAppsInstallFails) {
     ASSERT_TRUE(targetsMatch(client->getCurrent(), target_01));
     ASSERT_TRUE(app_engine->isRunning(app01));
     // make sure that the bad target is still "known locally" (marked as a failing target)
+    ASSERT_TRUE(client->isRollback(target_02));
+  }
+}
+
+/**
+ * @brief Test rollback if new version App failed to start just after succcessful boot on a new sysroot version
+ *
+ * 1. Initiate an update to a new Target that includes both sysroot/ostree and App update
+ * 2. Download and install steps are successful
+ * 3. Reboot on the new sysroot version is successful
+ * 4. Failure to start the updated App occurs on aklite start
+ * 5. Mark the new Target as a failing Target
+ * 6. Trigger rollback to the previous successful Target
+ * 7. Check whether the previous Target has been successfully installed after reboot
+ */
+
+TEST_P(AkliteTest, OstreeAndAppRollbackIfAppsStartFails) {
+  // boot device
+  const auto app_engine_type{GetParam()};
+  auto client = createLiteClient();
+  ASSERT_TRUE(targetsMatch(client->getCurrent(), getInitialTarget()));
+
+  // Create a new Target: update both rootfs and add new app
+  auto app01 = registry.addApp(fixtures::ComposeApp::create("app-01"));
+  std::vector<AppEngine::App> apps{app01};
+  auto target_01 = createTarget(&apps);
+
+  {
+    // update to the latest version
+    update(*client, getInitialTarget(), target_01);
+  }
+
+  {
+    // reboot and make sure that the update succeeded
+    reboot(client);
+    ASSERT_TRUE(targetsMatch(client->getCurrent(), target_01));
+    checkHeaders(*client, target_01);
+    checkEvents(*client, target_01, UpdateType::kOstree);
+    ASSERT_TRUE(app_engine->isRunning(app01));
+    ASSERT_FALSE(client->isRollback(target_01));
+  }
+
+  // create a new "bad" Target, it includes both an ostree and app update, App is invalid,
+  // specifically its creation is succesful but it fails to start after reboot caused by the ostree update
+  auto app01_updated = registry.addApp(
+      fixtures::ComposeApp::create("app-01", "service-01", "image-02", fixtures::ComposeApp::ServiceTemplate,
+                                   Docker::ComposeAppEngine::ComposeFile, "compose-start-failure"));
+  std::vector<AppEngine::App> apps_updated{app01_updated};
+  auto target_02 = createTarget(&apps_updated);
+
+  {
+    // update to the latest version, it succeeds, assumption is that Apps' containers creation does not fail
+    update(*client, target_01, target_02, data::ResultCode::Numeric::kNeedCompletion);
+
+    // make sure that target_01 is still current because a reboot is required to apply target_01
+    ASSERT_TRUE(targetsMatch(client->getCurrent(), target_01));
+    // app01 should be stopped at this point since its containers re-creation had happenned
+    ASSERT_FALSE(app_engine->isRunning(app01));
+
+    // Both App version should be fetched/present until the new version is successfully started or rollback
+    ASSERT_TRUE(app_engine->isFetched(app01_updated));
+    // Unlike Restorable Apps, Compose App cannot have two versions that co-exist at the same
+    if (app_engine_type == "RestorableAppEngine") {
+      ASSERT_TRUE(app_engine->isFetched(app01));
+    }
+  }
+
+  {
+    boost::filesystem::remove(fixtures::ClientTest::test_dir_.Path() / "need_reboot");
+    client = createLiteClient(InitialVersion::kOff, boost::none, false);
+    ASSERT_FALSE(client->finalizeInstall());
+
+    // for some reason ostreemanager::getCurrent() is driven by currently booted ostree hash,
+    // so it thinks that current version is target_02
+    // target_02 is current since a device is booted on it, at the same time it is "rollback"/failing
+    // target since it's partially installed, just ostree
+    ASSERT_TRUE(targetsMatch(client->getCurrent(), target_02));
+    ASSERT_TRUE(targetsMatch(client->getRollbackTarget(), target_01));
+    ASSERT_TRUE(client->isRollback(target_02));
+
+    // Both App version should be fetched/present until the new version is successfully started or rollback
+    ASSERT_TRUE(app_engine->isFetched(app01_updated));
+    // Unlike Restorable Apps, Compose App cannot have two versions that co-exist at the same
+    if (app_engine_type == "RestorableAppEngine") {
+      ASSERT_TRUE(app_engine->isFetched(app01));
+    }
+
+    update(*client, target_02, target_01, data::ResultCode::Numeric::kNeedCompletion);
+
+    // Both App version should be fetched/present until the new version is successfully started or rollback
+    ASSERT_TRUE(app_engine->isFetched(app01));
+    // Unlike Restorable Apps, Compose App cannot have two versions that co-exist at the same
+    if (app_engine_type == "RestorableAppEngine") {
+      ASSERT_TRUE(app_engine->isFetched(app01_updated));
+    }
+  }
+
+  {
+    // reboot and make sure that the update succeeded
+    reboot(client);
+    ASSERT_TRUE(targetsMatch(client->getCurrent(), target_01));
+    checkHeaders(*client, target_01);
+    checkEvents(*client, target_01, UpdateType::kOstree);
+    ASSERT_TRUE(app_engine->isRunning(app01));
+    ASSERT_FALSE(client->isRollback(target_01));
+    ASSERT_TRUE(client->isRollback(target_02));
+
+    // just one version should be present on a device after successful installation
+    ASSERT_TRUE(app_engine->isFetched(app01));
+    ASSERT_FALSE(app_engine->isFetched(app01_updated));
+  }
+}
+
+/**
+ * @brief Test rollback if new version App failed to start just after succcessful
+ *        boot on a new sysroot version and power cut occurs
+ *
+ * 1. Initiate an update to a new Target that includes both sysroot/ostree and App update
+ * 2. Download and install steps are successful
+ * 3. Reboot on the new sysroot version is successful
+ * 4. Failure to start the updated App occurs on aklite start
+ * 5. Mark the new Target as a failing Target (finalization is completed)
+ * 6. Power cut
+ * 6. Boot again
+ * 7. Since finalization has been completed before the power cut then no finalization anymore
+ * 8. The current target is marked as a failing Target hence a rollback to the previous version is initiated
+ * 9. Reboot again and do a normal/succesful finalization of the initial valid Target
+ */
+
+TEST_P(AkliteTest, OstreeAndAppRollbackIfAppsStartFailsAndPowerCut) {
+  // boot device
+  const auto app_engine_type{GetParam()};
+  auto client = createLiteClient();
+  ASSERT_TRUE(targetsMatch(client->getCurrent(), getInitialTarget()));
+
+  // Create a new Target: update both rootfs and add new app
+  auto app01 = registry.addApp(fixtures::ComposeApp::create("app-01"));
+  std::vector<AppEngine::App> apps{app01};
+  auto target_01 = createTarget(&apps);
+
+  {
+    // update to the latest version
+    update(*client, getInitialTarget(), target_01);
+  }
+
+  {
+    // reboot and make sure that the update succeeded
+    reboot(client);
+    ASSERT_TRUE(targetsMatch(client->getCurrent(), target_01));
+    checkHeaders(*client, target_01);
+    checkEvents(*client, target_01, UpdateType::kOstree);
+    ASSERT_TRUE(app_engine->isRunning(app01));
+    ASSERT_FALSE(client->isRollback(target_01));
+  }
+
+  // create a new "bad" Target, it includes both an ostree and app update, App is invalid,
+  // specifically its creation is succesful but it fails to start after reboot caused by the ostree update
+  auto app01_updated = registry.addApp(
+      fixtures::ComposeApp::create("app-01", "service-01", "image-02", fixtures::ComposeApp::ServiceTemplate,
+                                   Docker::ComposeAppEngine::ComposeFile, "compose-start-failure"));
+  std::vector<AppEngine::App> apps_updated{app01_updated};
+  auto target_02 = createTarget(&apps_updated);
+
+  {
+    // update to the latest version, it succeeds, assumption is that Apps' containers creation does not fail
+    update(*client, target_01, target_02, data::ResultCode::Numeric::kNeedCompletion);
+
+    // make sure that target_01 is still current because a reboot is required to apply target_01
+    ASSERT_TRUE(targetsMatch(client->getCurrent(), target_01));
+    // app01 should be stopped at this point since its containers re-creation had happenned
+    ASSERT_FALSE(app_engine->isRunning(app01));
+
+    // Both App version should be fetched until the new version is successfully started or rollback
+    ASSERT_TRUE(app_engine->isFetched(app01_updated));
+    // Unlike Restorable Apps, Compose App cannot have two versions that co-exist at the same
+    if (app_engine_type == "RestorableAppEngine") {
+      ASSERT_TRUE(app_engine->isFetched(app01));
+    }
+  }
+
+  {
+    boost::filesystem::remove(fixtures::ClientTest::test_dir_.Path() / "need_reboot");
+    client = createLiteClient(InitialVersion::kOff, boost::none, false);
+    ASSERT_FALSE(client->finalizeInstall());
+
+    // for some reason ostreemanager::getCurrent() is driven by currently booted ostree hash,
+    // so it thinks that current version is target_02
+    // target_02 is current since a device is booted on it, at the same time it is "rollback"/failing
+    // target since it's partially installed, just ostree
+    ASSERT_TRUE(targetsMatch(client->getCurrent(), target_02));
+    ASSERT_TRUE(targetsMatch(client->getRollbackTarget(), target_01));
+    ASSERT_TRUE(client->isRollback(target_02));
+
+    // Still two versions of Apps should be present
+    ASSERT_TRUE(app_engine->isFetched(app01_updated));
+    // Unlike Restorable Apps, Compose App cannot have two versions that co-exist at the same
+    if (app_engine_type == "RestorableAppEngine") {
+      ASSERT_TRUE(app_engine->isFetched(app01));
+    }
+  }
+  {
+    // emulate power cut just after finalization followed up by boot
+    boost::filesystem::remove(fixtures::ClientTest::test_dir_.Path() / "need_reboot");
+    client = createLiteClient(InitialVersion::kOff, boost::none, false);
+
+    // since the finalization for target_02 has completed before then there is no any pending installation,
+    // thus the finalizeInstall() doesn't do anything
+    ASSERT_TRUE(client->finalizeInstall());
+
+    // Still two versions of Apps should be present
+    ASSERT_TRUE(app_engine->isFetched(app01_updated));
+    // Unlike Restorable Apps, Compose App cannot have two versions that co-exist at the same
+    if (app_engine_type == "RestorableAppEngine") {
+      ASSERT_TRUE(app_engine->isFetched(app01));
+    }
+
+    // New Target is considered as current since a device is booted on it
+    ASSERT_TRUE(targetsMatch(client->getCurrent(), target_02));
+    ASSERT_TRUE(client->isRollback(target_02));
+    // if current target is "rollback" target then the rollback is triggered
+    ASSERT_TRUE(targetsMatch(client->getRollbackTarget(), target_01));
+    update(*client, target_02, target_01, data::ResultCode::Numeric::kNeedCompletion);
+
+    // Still two versions of Apps should be present since Apps are not started yet
+    ASSERT_TRUE(app_engine->isFetched(app01));
+    // Unlike Restorable Apps, Compose App cannot have two versions that co-exist at the same
+    if (app_engine_type == "RestorableAppEngine") {
+      ASSERT_TRUE(app_engine->isFetched(app01_updated));
+    }
+  }
+  {
+    // emulate power cut just after finalization, reboot and make sure that the rollback succeeds
+    reboot(client);  // it includes finalization
+    ASSERT_TRUE(targetsMatch(client->getCurrent(), target_01));
+    checkHeaders(*client, target_01);
+    checkEvents(*client, target_01, UpdateType::kOstree);
+
+    // now onlye one version of App is stored/fetched for both types of Apps
+    ASSERT_TRUE(app_engine->isFetched(app01));
+    ASSERT_FALSE(app_engine->isFetched(app01_updated));
+
+    ASSERT_TRUE(app_engine->isRunning(app01));
+
+    ASSERT_FALSE(client->isRollback(target_01));
     ASSERT_TRUE(client->isRollback(target_02));
   }
 }

--- a/tests/apiclient_test.cc
+++ b/tests/apiclient_test.cc
@@ -61,7 +61,8 @@ class MockAppEngine : public AppEngine {
 class ApiClientTest : public fixtures::ClientTest {
  protected:
   std::shared_ptr<LiteClient> createLiteClient(InitialVersion initial_version = InitialVersion::kOn,
-                                               boost::optional<std::vector<std::string>> apps = boost::none) override {
+                                               boost::optional<std::vector<std::string>> apps = boost::none,
+                                               bool finalize = true) override {
     app_engine_mock_ = std::make_shared<NiceMock<MockAppEngine>>();
     return ClientTest::createLiteClient(app_engine_mock_, initial_version, apps);
   }

--- a/tests/composeapp_test.cc
+++ b/tests/composeapp_test.cc
@@ -205,7 +205,7 @@ struct TestClient {
       storage->savePrimaryInstalledVersion(*installedTarget, InstalledVersionUpdateMode::kCurrent);
     }
 
-    sysroot = (sysroot_hasher == nullptr) ? std::make_shared<OSTree::Sysroot>(config.pacman.sysroot.string(), BootedType::kStaged) :
+    sysroot = (sysroot_hasher == nullptr) ? std::make_shared<OSTree::Sysroot>(config.pacman.sysroot.string(), BootedType::kStaged, config.pacman.os) :
                                             std::make_shared<TestSysroot>(sysroot_hasher, config.pacman.sysroot.string());
 
     fetcher = std_::make_unique<Uptane::Fetcher>(config, std::make_shared<HttpClient>());

--- a/tests/docker-compose_fake.py
+++ b/tests/docker-compose_fake.py
@@ -21,6 +21,10 @@ def up(out_dir, app_name, compose, flags):
     if compose["x-fault-injection"]["failure-type"] == "container-failure":
         exit(0)
 
+    if compose["x-fault-injection"]["failure-type"] == "compose-start-failure" and "-d" in flags:
+        logger.info("Failed to start container: {}".format(app_name))
+        exit(1)
+
     logger.info("Run services...")
     with open(os.path.join(out_dir, "containers.json"), "r") as f:
         containers = json.load(f)

--- a/tests/fixtures/liteclienttest.cc
+++ b/tests/fixtures/liteclienttest.cc
@@ -192,9 +192,13 @@ class ClientTest :virtual public ::testing::Test {
   /**
    * method createAppTarget
    */
-  Uptane::Target createAppTarget(const std::vector<AppEngine::App>& apps) {
-    const auto& latest{getTufRepo().getLatest()};
-    const std::string version = std::to_string(std::stoi(latest.custom_version()) + 1);
+  Uptane::Target createAppTarget(const std::vector<AppEngine::App>& apps, const Uptane::Target& base_target = Uptane::Target::Unknown()) {
+    Uptane::Target base{base_target};
+    if (targetsMatch(base, Uptane::Target::Unknown())) {
+      base = getTufRepo().getLatest();
+    }
+
+    const std::string version = std::to_string(std::stoi(base.custom_version()) + 1);
     Json::Value apps_json;
     for (const auto& app : apps) {
       apps_json[app.name]["uri"] = app.uri;
@@ -202,7 +206,7 @@ class ClientTest :virtual public ::testing::Test {
 
     // add new target to TUF repo
     const std::string name = hw_id + "-" + os + "-" + version;
-    return getTufRepo().addTarget(name, latest.sha256Hash(), hw_id, version, apps_json);
+    return getTufRepo().addTarget(name, base.sha256Hash(), hw_id, version, apps_json);
   }
 
   /**

--- a/tests/fixtures/liteclienttest.cc
+++ b/tests/fixtures/liteclienttest.cc
@@ -28,7 +28,8 @@ class ClientTest :virtual public ::testing::Test {
 
 
   virtual std::shared_ptr<LiteClient> createLiteClient(InitialVersion initial_version = InitialVersion::kOn,
-                                                       boost::optional<std::vector<std::string>> apps = boost::none) = 0;
+                                                       boost::optional<std::vector<std::string>> apps = boost::none,
+                                                       bool finalize = true) = 0;
 
   /**
    * method createLiteClient
@@ -38,7 +39,7 @@ class ClientTest :virtual public ::testing::Test {
                                                boost::optional<std::vector<std::string>> apps = boost::none,
                                                const std::string& compose_apps_root = "",
                                                boost::optional<std::vector<std::string>> reset_apps = boost::none,
-                                               bool create_containers_before_reboot = true) {
+                                               bool create_containers_before_reboot = true, bool finalize = true) {
     Config conf;
     conf.tls.server = device_gateway_.getTlsUri();
     conf.uptane.repo_server = device_gateway_.getTufRepoUri();
@@ -142,7 +143,9 @@ class ClientTest :virtual public ::testing::Test {
     }
 
     auto client = std::make_shared<LiteClient>(conf, app_engine);
-    client->finalizeInstall();
+    if (finalize) {
+      client->finalizeInstall();
+    }
     return client;
   }
 

--- a/tests/liteclientHSM_test.cc
+++ b/tests/liteclientHSM_test.cc
@@ -63,7 +63,8 @@ class MockAppEngine : public AppEngine {
 class LiteClientHSMTest : public fixtures::ClientHSMTest {
  protected:
   std::shared_ptr<LiteClient> createLiteClient(InitialVersion initial_version = InitialVersion::kOn,
-                                               boost::optional<std::vector<std::string>> apps = boost::none) override {
+                                               boost::optional<std::vector<std::string>> apps = boost::none,
+                                               bool finalize = true) override {
     app_engine_mock_ = std::make_shared<NiceMock<MockAppEngine>>();
     return ClientHSMTest::createLiteClient(app_engine_mock_, initial_version, apps);
   }

--- a/tests/liteclient_test.cc
+++ b/tests/liteclient_test.cc
@@ -63,9 +63,10 @@ class MockAppEngine : public AppEngine {
 class LiteClientTest : public fixtures::ClientTest {
  protected:
   std::shared_ptr<LiteClient> createLiteClient(InitialVersion initial_version = InitialVersion::kOn,
-                                               boost::optional<std::vector<std::string>> apps = boost::none) override {
+                                               boost::optional<std::vector<std::string>> apps = boost::none,
+                                               bool finalize = true) override {
     app_engine_mock_ = std::make_shared<NiceMock<MockAppEngine>>();
-    return ClientTest::createLiteClient(app_engine_mock_, initial_version, apps);
+    return ClientTest::createLiteClient(app_engine_mock_, initial_version, apps, "", boost::none, true, finalize);
   }
 
   std::shared_ptr<NiceMock<MockAppEngine>>& getAppEngine() { return app_engine_mock_; }


### PR DESCRIPTION
1. If Apps fails to start just after successful boot on a new sysroot version (just sysroot update or both sysroot & Apps update):
  1.1 Mark the given Target as a failing Target (aka "known").
  2.2 Initiate rollback to the previously successfully installed Target, provided that there is such Target (two failing Targets/updates in a row).

2. If Apps (re-)creation fails before reboot (both sysroot and Apps update) then:
   2.1 Mark the given Target as a failing Target (aka "known").
   2.2 Undeploy currently pending sysroot by reinstalling the previously successfully installed Target (kind of Target sync).

Signed-off-by: Mike Sul <mike.sul@foundries.io>