### PR TITLE
fixup! check targets are initialized before usage

### DIFF
--- a/src/liteclient.cc
+++ b/src/liteclient.cc
@@ -355,6 +355,15 @@ std::tuple<bool, std::string> LiteClient::updateImageMeta() {
   return {true, ""};
 }
 
+const std::vector<Uptane::Target>& LiteClient::allTargets() const {
+  std::shared_ptr<const Uptane::Targets> targets{image_repo_.getTargets()};
+  if (targets) {
+    return image_repo_.getTargets()->targets;
+  } else {
+    return no_targets_;
+  }
+}
+
 bool LiteClient::checkImageMetaOffline() {
   try {
     image_repo_.checkMetaOffline(*storage);

--- a/src/liteclient.h
+++ b/src/liteclient.h
@@ -48,7 +48,7 @@ class LiteClient {
   Uptane::Target getCurrent() const { return package_manager_->getCurrent(); }
   std::tuple<bool, std::string> updateImageMeta();
   bool checkImageMetaOffline();
-  const std::vector<Uptane::Target>& allTargets() const { return image_repo_.getTargets()->targets; }
+  const std::vector<Uptane::Target>& allTargets() const;
   TargetStatus VerifyTarget(const Uptane::Target& target) const { return package_manager_->verifyTarget(target); }
   void reportAktualizrConfiguration();
   void reportNetworkInfo();
@@ -96,6 +96,7 @@ class LiteClient {
   bool is_reboot_required_{false};
 
   std::shared_ptr<OSTree::Sysroot> sysroot_;
+  std::vector<Uptane::Target> no_targets_;
 };
 
 #endif  // AKTUALIZR_LITE_CLIENT_H_

--- a/tests/liteclient_test.cc
+++ b/tests/liteclient_test.cc
@@ -396,6 +396,27 @@ TEST_F(LiteClientTest, OstreeAndAppUpdateIfRollback) {
   }
 }
 
+TEST_F(LiteClientTest, CheckEmptyTargets) {
+  // boot device with no installed versions
+  auto client = createLiteClient(InitialVersion::kOff);
+  ASSERT_TRUE(targetsMatch(client->getCurrent(), getInitialTarget()));
+
+  // make sure getting targets doesn't crash if called before updating metadata
+  ASSERT_EQ(client->allTargets().size(), 0);
+
+  createTarget();
+
+  LOG_INFO << "Refreshing Targets metadata";
+  const auto rc = client->updateImageMeta();
+  if (!std::get<0>(rc)) {
+    LOG_WARNING << "Unable to update latest metadata, using local copy: " << std::get<1>(rc);
+    if (!client->checkImageMetaOffline()) {
+      LOG_ERROR << "Unable to use local copy of TUF data";
+    }
+  }
+  ASSERT_GT(client->allTargets().size(), 0);
+}
+
 /*
  * main
  */


### PR DESCRIPTION
Make sure that Targets are initialized at an image repo, so
the corresponding shared ptr is not null. If it is null then
just return an empty array of targets.

Signed-off-by: Mike Sul <mike.sul@foundries.io>