### PR TITLE
aktualizr: allow updating meta if the same ver

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "aktualizr"]
 	path = aktualizr
 	url = https://github.com/foundriesio/aktualizr
-	branch = 2022.1+fio
+	branch = 2022.2+fio

--- a/examples/custom-client-cxx/main.cc
+++ b/examples/custom-client-cxx/main.cc
@@ -71,6 +71,11 @@ int main(int argc, char **argv) {
       if (latest.Name() != current.Name() && !client.IsRollback(latest)) {
         std::string reason = "Updating from " + current.Name() + " to " + latest.Name();
         auto installer = client.Installer(latest, reason);
+        if (!installer) {
+          LOG_ERROR << "Found latest Target but failed to retrieve its metadata from DB, skipping update";
+          std::this_thread::sleep_for(std::chrono::seconds(interval));
+          continue;
+        }
         auto dres = installer->Download();
         if (dres.status != DownloadResult::Status::Ok) {
           LOG_ERROR << "Unable to download target: " << dres;

--- a/tests/fixtures/liteclient/tufrepomock.cc
+++ b/tests/fixtures/liteclient/tufrepomock.cc
@@ -1,15 +1,20 @@
 class TufRepoMock {
  public:
   TufRepoMock(const boost::filesystem::path& _root, std::string expires = "",
-              std::string correlation_id = "corellatio-id")
+              std::string correlation_id = "corellation-id", bool generate_keys = true)
       : root_{_root.string()}, repo_{_root, expires, correlation_id}, latest_{Uptane::Target::Unknown()}
   {
-    repo_.generateRepo(KeyType::kED25519);
+    if (generate_keys) {
+      repo_.generateRepo(KeyType::kED25519);
+    }
   }
 
+  ~TufRepoMock() { boost::filesystem::remove_all(root_);}
+
  public:
-  const std::string& getPath() const { return root_; }
+  const std::string& getPath() const { return root_.string(); }
   const Uptane::Target& getLatest() const { return latest_; }
+  void setLatest(const Uptane::Target& latest) { latest_ = latest; }
 
   Uptane::Target addTarget(const std::string& name, const std::string& hash, const std::string& hardware_id,
                            const std::string& version, const Json::Value& apps_json = Json::Value()) {
@@ -33,7 +38,7 @@ class TufRepoMock {
   }
 
  private:
-  const std::string root_;
+  const boost::filesystem::path root_;
   ImageRepo repo_;
   Uptane::Target latest_;
 };

--- a/tests/fixtures/liteclienttest.cc
+++ b/tests/fixtures/liteclienttest.cc
@@ -153,8 +153,9 @@ class ClientTest :virtual public ::testing::Test {
    * method createTarget
    */
   Uptane::Target createTarget(const std::vector<AppEngine::App>* apps = nullptr, std::string hwid = "",
-                              const std::string& rootfs_path = "") {
-    const auto& latest_target{getTufRepo().getLatest()};
+                              const std::string& rootfs_path = "", boost::optional<TufRepoMock&> tuf_repo = boost::none) {
+    auto& repo{!!tuf_repo?*tuf_repo:getTufRepo()};
+    const auto& latest_target{repo.getLatest()};
     std::string version;
     try {
       version = std::to_string(std::stoi(latest_target.custom_version()) + 1);
@@ -186,7 +187,7 @@ class ClientTest :virtual public ::testing::Test {
 
     // add new target to TUF repo
     const std::string name = hwid + "-" + os + "-" + version;
-    return getTufRepo().addTarget(name, hash, hwid, version, apps_json);
+    return repo.addTarget(name, hash, hwid, version, apps_json);
   }
 
   /**


### PR DESCRIPTION
Allow updating metadata if local and remote versions are the same
but they actually differ.
We need it for the use-case of switching tags on a device what may lead
to a need to update metadata of the same version.
Each tag has its own set of metadata (except root) so metadata
of different tags can have the same version but they actually differ
because they refer to different set of targets.

Signed-off-by: Mike Sul <mike.sul@foundries.io>