### PR TITLE
ci-retest aklite: enforce ostree update if hashes differ

### DIFF
--- a/src/liteclient.cc
+++ b/src/liteclient.cc
@@ -501,7 +501,8 @@ data::ResultCode::Numeric LiteClient::install(const Uptane::Target& target) {
 }
 
 bool LiteClient::isTargetActive(const Uptane::Target& target) const {
-  return target.filename() == getCurrent().filename();
+  const auto current{getCurrent()};
+  return target.filename() == current.filename() && target.sha256Hash() == current.sha256Hash();
 }
 
 bool LiteClient::appsInSync() const {

--- a/src/main.cc
+++ b/src/main.cc
@@ -344,7 +344,8 @@ static int daemon_main(LiteClient& client, const bpo::variables_map& variables_m
 
       if (!is_rollback_target && !client.isTargetActive(target_to_install)) {
         if (!rollback) {
-          LOG_INFO << "Found new and valid Target to update to: " << target_to_install.filename();
+          LOG_INFO << "Found new and valid Target to update to: " << target_to_install.filename()
+                   << ", sha256: " << target_to_install.sha256Hash();
         }
 
         client.checkForUpdatesEnd(target_to_install);

--- a/tests/fixtures/liteclienttest.cc
+++ b/tests/fixtures/liteclienttest.cc
@@ -153,15 +153,18 @@ class ClientTest :virtual public ::testing::Test {
    * method createTarget
    */
   Uptane::Target createTarget(const std::vector<AppEngine::App>* apps = nullptr, std::string hwid = "",
-                              const std::string& rootfs_path = "", boost::optional<TufRepoMock&> tuf_repo = boost::none) {
+                              const std::string& rootfs_path = "", boost::optional<TufRepoMock&> tuf_repo = boost::none,
+                              const std::string& ver = "") {
     auto& repo{!!tuf_repo?*tuf_repo:getTufRepo()};
     const auto& latest_target{repo.getLatest()};
-    std::string version;
-    try {
-      version = std::to_string(std::stoi(latest_target.custom_version()) + 1);
-    } catch (...) {
-      LOG_INFO << "No target available, preparing the first version";
-      version = "1";
+    std::string version{ver};
+    if (version.size() == 0) {
+      try {
+        version = std::to_string(std::stoi(latest_target.custom_version()) + 1);
+      } catch (...) {
+        LOG_INFO << "No target available, preparing the first version";
+        version = "1";
+      }
     }
 
     // update rootfs and commit it into Treehub's repo

--- a/tests/liteclient_test.cc
+++ b/tests/liteclient_test.cc
@@ -417,6 +417,33 @@ TEST_F(LiteClientTest, CheckEmptyTargets) {
   ASSERT_GT(client->allTargets().size(), 0);
 }
 
+TEST_F(LiteClientTest, OstreeUpdateIfSameVersion) {
+  // boot device
+  auto client = createLiteClient();
+  ASSERT_TRUE(targetsMatch(client->getCurrent(), getInitialTarget()));
+
+  auto target_01 = createTarget();
+  {
+    update(*client, getInitialTarget(), target_01);
+
+    // reboot device
+    reboot(client);
+    ASSERT_TRUE(targetsMatch(client->getCurrent(), target_01));
+    checkHeaders(*client, target_01);
+  }
+
+  {
+    // create new Target that has the same version (custom.version) but different hash
+    auto target_01_1 = createTarget(nullptr, "", "", boost::none, "2");
+    ASSERT_FALSE(client->isTargetActive(target_01_1));
+    update(*client, target_01, target_01_1);
+    // reboot device
+    reboot(client);
+    ASSERT_TRUE(targetsMatch(client->getCurrent(), target_01_1));
+    checkHeaders(*client, target_01_1);
+  }
+}
+
 /*
  * main
  */


### PR DESCRIPTION
Enforce an ostree update if current and the latest targets have different ostree hashes even if their versions match.

This is needed for the use-case when the same OE CI run is re-run one or more times and each time a new ostree and target are pushed to the backend.

Signed-off-by: Mike Sul <mike.sul@foundries.io>