### PR TITLE
Change the target download interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ if(BUILD_AKLITE)
   add_dependencies(aklite aktualizr-lite)
 
   add_custom_target(aklite-tests)
-  add_dependencies(aklite-tests aklite t_lite-helpers uptane-generator t_compose-apps t_ostree t_liteclient t_yaml2json t_composeappengine t_restorableappengine t_aklite t_apiclient)
+  add_dependencies(aklite-tests aklite t_lite-helpers uptane-generator t_compose-apps t_ostree t_liteclient t_yaml2json t_composeappengine t_restorableappengine t_aklite t_apiclient t_exec)
 
   set(CMAKE_MODULE_PATH "${AKTUALIZR_DIR}/cmake-modules;${CMAKE_MODULE_PATH}")
 

--- a/include/aktualizr-lite/api.h
+++ b/include/aktualizr-lite/api.h
@@ -101,6 +101,9 @@ class DownloadResult {
   };
   Status status;
   std::string description;
+
+  // NOLINTNEXTLINE(hicpp-explicit-conversions,google-explicit-constructor)
+  operator bool() const { return status == Status::Ok; }
 };
 
 std::ostream &operator<<(std::ostream &os, const InstallResult &res);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,7 +38,8 @@ set(HEADERS helpers.h
         bootloader/rollbacks/rollback.h
         liteclient.h
         yaml2json.h
-        target.h)
+        target.h
+        downloader.h)
 
 add_executable(${TARGET_EXE} main.cc)
 add_library(${TARGET} OBJECT ${SRC})
@@ -52,8 +53,9 @@ target_compile_definitions(${TARGET} PRIVATE BOOST_LOG_DYN_LINK)
 target_compile_definitions(${TARGET_EXE} PRIVATE BOOST_LOG_DYN_LINK)
 
 set(INCS
-  ${AKLITE_DIR}/src/compose
   ${AKLITE_DIR}/src/
+  ${AKLITE_DIR}/src/compose
+  ${AKLITE_DIR}/include/
   ${AKTUALIZR_DIR}/include
   ${AKTUALIZR_DIR}/src/libaktualizr
   ${AKTUALIZR_DIR}/third_party/jsoncpp/include

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,7 +39,8 @@ set(HEADERS helpers.h
         liteclient.h
         yaml2json.h
         target.h
-        downloader.h)
+        downloader.h
+        exec.h)
 
 add_executable(${TARGET_EXE} main.cc)
 add_library(${TARGET} OBJECT ${SRC})

--- a/src/api.cc
+++ b/src/api.cc
@@ -196,9 +196,9 @@ class LiteInstall : public InstallContext {
 
     client_->logTarget("Downloading: ", *target_);
 
-    data::ResultCode::Numeric rc = client_->download(*target_, reason);
-    if (rc != data::ResultCode::Numeric::kOk) {
-      return DownloadResult{DownloadResult::Status::DownloadFailed, "Unable to download target"};
+    auto download_res{client_->download(*target_, reason)};
+    if (!download_res) {
+      return download_res;
     }
 
     if (client_->VerifyTarget(*target_) != TargetStatus::kGood) {

--- a/src/appengine.h
+++ b/src/appengine.h
@@ -28,7 +28,7 @@ class AppEngine {
   using Ptr = std::shared_ptr<AppEngine>;
 
   virtual Result fetch(const App& app) = 0;
-  virtual bool verify(const App& app) = 0;
+  virtual Result verify(const App& app) = 0;
   virtual bool install(const App& app) = 0;
   virtual bool run(const App& app) = 0;
   virtual void remove(const App& app) = 0;

--- a/src/appengine.h
+++ b/src/appengine.h
@@ -14,10 +14,20 @@ class AppEngine {
     std::string uri;
   };
 
+  struct Result {
+    // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
+    Result(bool var, std::string errMsg = "") : status{var}, err{std::move(errMsg)} {}
+    // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
+    operator bool() const { return status; }
+
+    bool status;
+    std::string err;
+  };
+
   using Apps = std::vector<App>;
   using Ptr = std::shared_ptr<AppEngine>;
 
-  virtual bool fetch(const App& app) = 0;
+  virtual Result fetch(const App& app) = 0;
   virtual bool verify(const App& app) = 0;
   virtual bool install(const App& app) = 0;
   virtual bool run(const App& app) = 0;

--- a/src/composeappmanager.cc
+++ b/src/composeappmanager.cc
@@ -2,6 +2,8 @@
 
 #include <set>
 
+#include <boost/format.hpp>
+
 #include "bootloader/bootloaderlite.h"
 #include "docker/restorableappengine.h"
 #include "target.h"
@@ -210,8 +212,12 @@ DownloadResult ComposeAppManager::Download(const TufTarget& target) {
 
   for (const auto& pair : all_apps_to_fetch) {
     LOG_INFO << "Fetching " << pair.first << " -> " << pair.second;
-    if (!app_engine_->fetch({pair.first, pair.second})) {
-      res = {DownloadResult::Status::DownloadFailed, "Download failed TODO"};
+    const auto fetch_res{app_engine_->fetch({pair.first, pair.second})};
+    if (!fetch_res) {
+      const std::string errDesc{boost::str(boost::format("failed to fetch App; app: %s; uri: %s; err: %s") %
+                                           pair.first % pair.second % fetch_res.err)};
+      res = {DownloadResult::Status::DownloadFailed, errDesc};
+      break;
     }
   }
 
@@ -221,12 +227,13 @@ DownloadResult ComposeAppManager::Download(const TufTarget& target) {
 
 bool ComposeAppManager::fetchTarget(const Uptane::Target& target, Uptane::Fetcher& fetcher, const KeyManager& keys,
                                     const FetcherProgressCb& progress_cb, const api::FlowControlToken* token) {
+  (void)target;
   (void)fetcher;
   (void)token;
   (void)progress_cb;
   (void)keys;
 
-  return Download(Target::toTufTarget(target));
+  throw std::runtime_error("Using obsolete method of package manager: fetchTarget()");
 }
 
 TargetStatus ComposeAppManager::verifyTarget(const Uptane::Target& target) const {

--- a/src/composeappmanager.cc
+++ b/src/composeappmanager.cc
@@ -214,9 +214,10 @@ DownloadResult ComposeAppManager::Download(const TufTarget& target) {
     LOG_INFO << "Fetching " << pair.first << " -> " << pair.second;
     const auto fetch_res{app_engine_->fetch({pair.first, pair.second})};
     if (!fetch_res) {
-      const std::string errDesc{boost::str(boost::format("failed to fetch App; app: %s; uri: %s; err: %s") %
-                                           pair.first % pair.second % fetch_res.err)};
-      res = {DownloadResult::Status::DownloadFailed, errDesc};
+      const std::string err_desc{boost::str(boost::format("failed to fetch App; app: %s; uri: %s; err: %s") %
+                                            pair.first % pair.second % fetch_res.err)};
+      LOG_ERROR << err_desc;
+      res = {DownloadResult::Status::DownloadFailed, err_desc};
       break;
     }
   }

--- a/src/composeappmanager.h
+++ b/src/composeappmanager.h
@@ -38,9 +38,11 @@ class ComposeAppManager : public RootfsTreeManager {
 
   ComposeAppManager(const PackageConfig& pconfig, const BootloaderConfig& bconfig,
                     const std::shared_ptr<INvStorage>& storage, const std::shared_ptr<HttpInterface>& http,
-                    std::shared_ptr<OSTree::Sysroot> sysroot, AppEngine::Ptr app_engine = nullptr);
+                    std::shared_ptr<OSTree::Sysroot> sysroot, const KeyManager& keys,
+                    AppEngine::Ptr app_engine = nullptr);
 
   std::string name() const override { return Name; }
+  DownloadResult Download(const TufTarget& target) override;
   bool fetchTarget(const Uptane::Target& target, Uptane::Fetcher& fetcher, const KeyManager& keys,
                    const FetcherProgressCb& progress_cb, const api::FlowControlToken* token) override;
 

--- a/src/docker/composeappengine.h
+++ b/src/docker/composeappengine.h
@@ -19,7 +19,7 @@ class ComposeAppEngine : public AppEngine {
   ComposeAppEngine(boost::filesystem::path root_dir, std::string compose_bin, Docker::DockerClient::Ptr docker_client,
                    Docker::RegistryClient::Ptr registry_client);
 
-  bool fetch(const App& app) override;
+  Result fetch(const App& app) override;
   bool verify(const App& app) override;
   bool install(const App& app) override;
   bool run(const App& app) override;

--- a/src/docker/composeappengine.h
+++ b/src/docker/composeappengine.h
@@ -20,7 +20,7 @@ class ComposeAppEngine : public AppEngine {
                    Docker::RegistryClient::Ptr registry_client);
 
   Result fetch(const App& app) override;
-  bool verify(const App& app) override;
+  Result verify(const App& app) override;
   bool install(const App& app) override;
   bool run(const App& app) override;
   void remove(const App& app) override;
@@ -94,12 +94,12 @@ class ComposeAppEngine : public AppEngine {
       static std::map<State, std::string> state2Str = {
           {State::kUnknown, "Unknown"},
           {State::kDownloaded, "Downloaded"},
-          {State::kDownloadFailed, "Download failed"},
           {State::kVerified, "Compose file verified"},
-          {State::kVerifyFailed, "Compose file verification failure"},
           {State::kPulled, "Images are pulled"},
-          {State::kPullFailed, "Image pull failed"},
           {State::kInstalled, "Created"},
+          // TODO: kInstallFail and kStartFailed will/should be removed once we make install/run return Result
+          // and refactor underlying functions (e.g. areContainersCreated) so they catch stderr correctly and throw
+          // exception
           {State::kInstallFail, "Creation failed"},
           {State::kStarted, "Started"},
           {State::kStartFailed, "Start failed"},
@@ -116,13 +116,12 @@ class ComposeAppEngine : public AppEngine {
     File state_file_;
   };
 
-  bool cmd_streaming(const std::string& cmd, const App& app);
   static std::pair<bool, std::string> cmd(const std::string& cmd);
 
-  bool download(const App& app);
-  bool pullImages(const App& app);
-  bool installApp(const App& app);
-  bool start(const App& app);
+  void download(const App& app);
+  void pullImages(const App& app);
+  void installApp(const App& app);
+  void start(const App& app);
   bool areContainersCreated(const App& app);
 
   static bool checkAvailableStorageSpace(const boost::filesystem::path& app_root, uint64_t& out_available_size);

--- a/src/docker/restorableappengine.cc
+++ b/src/docker/restorableappengine.cc
@@ -49,8 +49,8 @@ RestorableAppEngine::RestorableAppEngine(boost::filesystem::path store_root, boo
   boost::filesystem::create_directories(blobs_root_);
 }
 
-bool RestorableAppEngine::fetch(const App& app) {
-  bool res{false};
+AppEngine::Result RestorableAppEngine::fetch(const App& app) {
+  Result res{false};
   boost::filesystem::path app_dir;
   try {
     const Uri uri{Uri::parseUri(app.uri)};
@@ -78,6 +78,7 @@ bool RestorableAppEngine::fetch(const App& app) {
     if (boost::filesystem::exists(app_dir)) {
       boost::filesystem::remove_all(app_dir);
     }
+    res = Result{false, exc.what()};
   }
 
   return res;

--- a/src/docker/restorableappengine.cc
+++ b/src/docker/restorableappengine.cc
@@ -325,7 +325,7 @@ void RestorableAppEngine::pullApp(const Uri& uri, const boost::filesystem::path&
   registry_client_->downloadBlob(archive_uri, archive_full_path, manifest.archiveSize());
   Utils::writeFile(app_dir / Manifest::Filename, manifest_str);
   // extract docker-compose.yml, temporal hack, we don't need to extract it
-  exec(boost::format{"tar -xzf %s %s"} % archive_full_path % ComposeFile, "failed to extract the compose app archive",
+  exec(boost::format{"tar -xzf %s %s"} % archive_full_path % ComposeFile, "no compose file found in archive",
        boost::process::start_dir = app_dir);
 }
 

--- a/src/docker/restorableappengine.h
+++ b/src/docker/restorableappengine.h
@@ -86,7 +86,7 @@ class RestorableAppEngine : public AppEngine {
                       StorageSpaceFunc storage_space_func = RestorableAppEngine::DefStorageSpaceFunc);
 
   Result fetch(const App& app) override;
-  bool verify(const App& app) override;
+  Result verify(const App& app) override;
   bool install(const App& app) override;
   bool run(const App& app) override;
   void remove(const App& app) override;

--- a/src/docker/restorableappengine.h
+++ b/src/docker/restorableappengine.h
@@ -85,7 +85,7 @@ class RestorableAppEngine : public AppEngine {
                       std::string compose_cmd = "/usr/bin/docker-compose",
                       StorageSpaceFunc storage_space_func = RestorableAppEngine::DefStorageSpaceFunc);
 
-  bool fetch(const App& app) override;
+  Result fetch(const App& app) override;
   bool verify(const App& app) override;
   bool install(const App& app) override;
   bool run(const App& app) override;

--- a/src/downloader.h
+++ b/src/downloader.h
@@ -1,0 +1,20 @@
+#ifndef AKTUALIZR_LITE_DOWNLOADER_H_
+#define AKTUALIZR_LITE_DOWNLOADER_H_
+
+#include "aktualizr-lite/api.h"
+
+class Downloader {
+ public:
+  virtual DownloadResult Download(const TufTarget& target) = 0;
+
+  virtual ~Downloader() = default;
+  Downloader(const Downloader&) = delete;
+  Downloader(const Downloader&&) = delete;
+  Downloader& operator=(const Downloader&) = delete;
+  Downloader& operator=(const Downloader&&) = delete;
+
+ protected:
+  explicit Downloader() = default;
+};
+
+#endif  // AKTUALIZR_LITE_DOWNLOADER_H_

--- a/src/exec.h
+++ b/src/exec.h
@@ -1,0 +1,45 @@
+#ifndef AKTUALIZR_LITE_EXEC_H_
+#define AKTUALIZR_LITE_EXEC_H_
+
+#include <boost/asio/io_service.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/format.hpp>
+#include <boost/process.hpp>
+
+template <typename... Args>
+static void exec(const std::string& cmd, const std::string& err_msg_prefix, Args&&... args) {
+  // Implementation is based on test_utils.cc:Process::spawn that has been proven over time
+  std::future<std::string> err_output;
+  std::future<int> child_process_exit_code;
+  boost::asio::io_service io_service;
+
+  try {
+    boost::process::child child_process(cmd, boost::process::std_err > err_output,
+                                        boost::process::on_exit = child_process_exit_code, io_service,
+                                        std::forward<Args>(args)...);
+
+    io_service.run();
+
+    bool wait_successfull = child_process.wait_for(std::chrono::seconds(900));
+    if (!wait_successfull) {
+      throw std::runtime_error("Timeout occured while waiting for a child process completion");
+    }
+
+  } catch (const std::exception& exc) {
+    throw std::runtime_error("Failed to spawn process " + cmd + " exited with an error: " + exc.what());
+  }
+
+  const auto exit_code{child_process_exit_code.get()};
+
+  if (exit_code != EXIT_SUCCESS) {
+    const auto err_msg{err_output.get()};
+    throw std::runtime_error(err_msg_prefix + "\n\tcmd: " + cmd + "\n\terr: " + err_msg);
+  }
+}
+
+template <typename... Args>
+void exec(const boost::format& cmd, const std::string& err_msg, Args&&... args) {
+  exec(cmd.str(), err_msg, std::forward<Args>(args)...);
+}
+
+#endif  // AKTUALIZR_LITE_EXEC_H_

--- a/src/liteclient.cc
+++ b/src/liteclient.cc
@@ -103,10 +103,10 @@ LiteClient::LiteClient(Config& config_in, const AppEngine::Ptr& app_engine, cons
 
   if (config.pacman.type == ComposeAppManager::Name) {
     package_manager_ = std::make_shared<ComposeAppManager>(config.pacman, config.bootloader, storage, http_client,
-                                                           ostree_sysroot, app_engine);
+                                                           ostree_sysroot, *key_manager_, app_engine);
   } else if (config.pacman.type == RootfsTreeManager::Name) {
-    package_manager_ =
-        std::make_shared<RootfsTreeManager>(config.pacman, config.bootloader, storage, http_client, ostree_sysroot);
+    package_manager_ = std::make_shared<RootfsTreeManager>(config.pacman, config.bootloader, storage, http_client,
+                                                           ostree_sysroot, *key_manager_);
   } else {
     throw std::runtime_error("Unsupported package manager type: " + config.pacman.type);
   }

--- a/src/liteclient.cc
+++ b/src/liteclient.cc
@@ -482,15 +482,11 @@ void LiteClient::reportHwInfo() {
   }
 }
 
-data::ResultCode::Numeric LiteClient::download(const Uptane::Target& target, const std::string& reason) {
+DownloadResult LiteClient::download(const Uptane::Target& target, const std::string& reason) {
   notifyDownloadStarted(target, reason);
-  const auto download_result{downloadImage(target)};
-  if (!download_result) {
-    notifyDownloadFinished(target, false, download_result.description);
-    return data::ResultCode::Numeric::kDownloadFailed;
-  }
-  notifyDownloadFinished(target, true);
-  return data::ResultCode::Numeric::kOk;
+  auto download_result{downloadImage(target)};
+  notifyDownloadFinished(target, download_result, download_result.description);
+  return download_result;
 }
 
 data::ResultCode::Numeric LiteClient::install(const Uptane::Target& target) {

--- a/src/liteclient.h
+++ b/src/liteclient.h
@@ -14,6 +14,8 @@ class KeyManager;
 class P11EngineGuard;
 class ReportEvent;
 class ReportQueue;
+class DownloadResult;
+class Downloader;
 
 class LiteClient {
  public:
@@ -73,14 +75,13 @@ class LiteClient {
 
   void notify(const Uptane::Target& t, std::unique_ptr<ReportEvent> event) const;
   void notifyDownloadStarted(const Uptane::Target& t, const std::string& reason);
-  void notifyDownloadFinished(const Uptane::Target& t, bool success);
+  void notifyDownloadFinished(const Uptane::Target& t, bool success, const std::string& err_msg = "");
   void notifyInstallStarted(const Uptane::Target& t);
 
   void writeCurrentTarget(const Uptane::Target& t) const;
 
   data::InstallationResult installPackage(const Uptane::Target& target);
-  std::pair<bool, Uptane::Target> downloadImage(const Uptane::Target& target,
-                                                const api::FlowControlToken* token = nullptr);
+  DownloadResult downloadImage(const Uptane::Target& target, const api::FlowControlToken* token = nullptr);
   static void add_apps_header(std::vector<std::string>& headers, PackageConfig& config);
   data::InstallationResult finalizePendingUpdate(boost::optional<Uptane::Target>& target);
 
@@ -97,6 +98,8 @@ class LiteClient {
 
   std::shared_ptr<OSTree::Sysroot> sysroot_;
   std::vector<Uptane::Target> no_targets_;
+
+  std::shared_ptr<Downloader> downloader_;
 };
 
 #endif  // AKTUALIZR_LITE_CLIENT_H_

--- a/src/liteclient.h
+++ b/src/liteclient.h
@@ -39,7 +39,7 @@ class LiteClient {
   void checkForUpdatesEndWithFailure(const std::string& err);
   bool finalizeInstall();
   Uptane::Target getRollbackTarget();
-  data::ResultCode::Numeric download(const Uptane::Target& target, const std::string& reason);
+  DownloadResult download(const Uptane::Target& target, const std::string& reason);
   data::ResultCode::Numeric install(const Uptane::Target& target);
   void notifyInstallFinished(const Uptane::Target& t, data::InstallationResult& ir);
   std::pair<bool, std::string> isRebootRequired() const {

--- a/src/main.cc
+++ b/src/main.cc
@@ -181,9 +181,9 @@ static data::ResultCode::Numeric do_update(LiteClient& client, Uptane::Target ta
 
   generate_correlation_id(target);
 
-  data::ResultCode::Numeric rc = client.download(target, reason);
-  if (rc != data::ResultCode::Numeric::kOk) {
-    return rc;
+  const auto download_res{client.download(target, reason)};
+  if (!download_res) {
+    return data::ResultCode::Numeric::kDownloadFailed;
   }
 
   if (client.VerifyTarget(target) != TargetStatus::kGood) {
@@ -202,9 +202,9 @@ static data::ResultCode::Numeric do_app_sync(LiteClient& client) {
 
   generate_correlation_id(target);
 
-  data::ResultCode::Numeric rc = client.download(target, "Sync active Target Apps");
-  if (rc != data::ResultCode::Numeric::kOk) {
-    return rc;
+  const auto download_res{client.download(target, "Sync active Target Apps")};
+  if (!download_res) {
+    return data::ResultCode::Numeric::kDownloadFailed;
   }
 
   if (client.VerifyTarget(target) != TargetStatus::kGood) {

--- a/src/rootfstreemanager.cc
+++ b/src/rootfstreemanager.cc
@@ -36,12 +36,13 @@ DownloadResult RootfsTreeManager::Download(const TufTarget& target) {
 
 bool RootfsTreeManager::fetchTarget(const Uptane::Target& target, Uptane::Fetcher& fetcher, const KeyManager& keys,
                                     const FetcherProgressCb& progress_cb, const api::FlowControlToken* token) {
+  (void)target;
   (void)fetcher;
   (void)token;
   (void)progress_cb;
   (void)keys;
 
-  return Download(Target::toTufTarget(target));
+  throw std::runtime_error("Using obsolete method of package manager: fetchTarget()");
 }
 
 void RootfsTreeManager::installNotify(const Uptane::Target& target) {

--- a/src/rootfstreemanager.h
+++ b/src/rootfstreemanager.h
@@ -2,10 +2,11 @@
 #define AKTUALIZR_LITE_ROOTFS_TREE_MANAGER_H_
 
 #include "bootloader/bootloaderlite.h"
+#include "downloader.h"
 #include "ostree/sysroot.h"
 #include "package_manager/ostreemanager.h"
 
-class RootfsTreeManager : public OstreeManager {
+class RootfsTreeManager : public OstreeManager, public Downloader {
  public:
   static constexpr const char* const Name{"ostree"};
   using RequestHeaders = std::unordered_map<std::string, std::string>;
@@ -19,11 +20,14 @@ class RootfsTreeManager : public OstreeManager {
 
   RootfsTreeManager(const PackageConfig& pconfig, const BootloaderConfig& bconfig,
                     const std::shared_ptr<INvStorage>& storage, const std::shared_ptr<HttpInterface>& http,
-                    std::shared_ptr<OSTree::Sysroot> sysroot)
+                    std::shared_ptr<OSTree::Sysroot> sysroot, const KeyManager& keys)
       : OstreeManager(pconfig, bconfig, storage, http, new BootloaderLite(bconfig, *storage)),
         sysroot_{std::move(sysroot)},
         http_client_{http},
-        gateway_url_{pconfig.ostree_server} {}
+        gateway_url_{pconfig.ostree_server},
+        keys_{keys} {}
+
+  DownloadResult Download(const TufTarget& target) override;
 
   bool fetchTarget(const Uptane::Target& target, Uptane::Fetcher& fetcher, const KeyManager& keys,
                    const FetcherProgressCb& progress_cb, const api::FlowControlToken* token) override;
@@ -40,6 +44,7 @@ class RootfsTreeManager : public OstreeManager {
 
   void setRemote(const std::string& name, const std::string& url, const boost::optional<const KeyManager*>& keys);
 
+  const KeyManager& keys_;
   std::shared_ptr<OSTree::Sysroot> sysroot_;
   std::shared_ptr<HttpInterface> http_client_;
   const std::string gateway_url_;

--- a/src/target.cc
+++ b/src/target.cc
@@ -75,3 +75,22 @@ void Target::log(const std::string& prefix, const Uptane::Target& target,
     LOG_INFO << "\t" << app_status << ": " << app.name << " -> " << app.uri;
   }
 }
+
+Uptane::Target Target::fromTufTarget(const TufTarget& target) {
+  Json::Value target_json;
+  target_json["hashes"]["sha256"] = target.Sha256Hash();
+  target_json["length"] = 0;
+  target_json["custom"] = target.Custom();
+  return Uptane::Target{target.Name(), target_json};
+}
+
+TufTarget Target::toTufTarget(const Uptane::Target& target) {
+  int ver = -1;
+  try {
+    ver = std::stoi(target.custom_version(), nullptr, 0);
+  } catch (const std::invalid_argument& exc) {
+    LOG_ERROR << "Invalid version number format: " << exc.what();
+  }
+
+  return TufTarget{target.filename(), target.sha256Hash(), ver, target.custom_data()};
+}

--- a/src/target.h
+++ b/src/target.h
@@ -4,6 +4,7 @@
 #include <boost/optional.hpp>
 #include "logging/logging.h"
 
+#include "aktualizr-lite/api.h"
 #include "uptane/tuf.h"
 
 class Target {
@@ -27,6 +28,9 @@ class Target {
                              const boost::optional<std::vector<std::string>>& app_shortlist = boost::none);
   static void log(const std::string& prefix, const Uptane::Target& target,
                   boost::optional<std::vector<std::string>> app_shortlist = boost::none);
+
+  static Uptane::Target fromTufTarget(const TufTarget& target);
+  static TufTarget toTufTarget(const Uptane::Target& target);
 
   class Apps {
    public:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -165,3 +165,10 @@ target_link_libraries(t_apiclient aktualizr_lite ${TEST_LIBS} uptane_generator_l
 add_dependencies(t_apiclient make_ostree_sysroot)
 set_tests_properties(test_apiclient PROPERTIES LABELS "aklite:apiclient")
 
+add_aktualizr_test(NAME exec
+  SOURCES $<TARGET_OBJECTS:${MAIN_TARGET_LIB}> exec_test.cc
+  PROJECT_WORKING_DIRECTORY
+)
+aktualizr_source_file_checks(exec_test.cc)
+target_include_directories(t_exec PRIVATE ${TEST_INCS})
+set_tests_properties(test_apiclient PROPERTIES LABELS "aklite:exec")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ set(TEST_DEFS BOOST_LOG_DYN_LINK)
 set(TEST_INCS
   ${AKLITE_DIR}/src/compose
   ${AKLITE_DIR}/src/
+  ${AKLITE_DIR}/include/
   ${AKTUALIZR_DIR}/include
   ${AKTUALIZR_DIR}/src/libaktualizr
   ${AKTUALIZR_DIR}/third_party/jsoncpp/include

--- a/tests/aklite_test.cc
+++ b/tests/aklite_test.cc
@@ -176,7 +176,7 @@ TEST_P(AkliteTest, AppInvalidUpdate) {
   auto app01_updated = registry.addApp(fixtures::ComposeApp::create(
       "app-01", "service-01", "image-02", fixtures::ComposeApp::ServiceTemplate, "incorrect-compose-file.yml"));
   auto target02 = createAppTarget({app01_updated});
-  updateApps(*client, target01, target02, data::ResultCode::Numeric::kDownloadFailed);
+  updateApps(*client, target01, target02, DownloadResult::Status::DownloadFailed);
   ASSERT_FALSE(targetsMatch(client->getCurrent(), target02));
 
   ASSERT_TRUE(targetsMatch(client->getCurrent(), target01));
@@ -415,11 +415,11 @@ TEST_P(AkliteTest, InvalidAppComposeUpdate) {
   const auto app_engine_type{GetParam()};
 
   // in the case of Restorable App we expect that download/fetch is successfull
-  data::ResultCode::Numeric expected_download_res{data::ResultCode::Numeric::kOk};
+  DownloadResult::Status expected_download_res{DownloadResult::Status::Ok};
   if (app_engine_type == "ComposeAppEngine") {
     // App is verified (docker-compose config) at the "fetch" phase for ComposeAppEngine
     // this is a bug that became a feature bug, so let's adjust to it
-    expected_download_res = data::ResultCode::Numeric::kDownloadFailed;
+    expected_download_res = DownloadResult::Status::DownloadFailed;
   }
   // updateApps() emulates LiteClient's client which invokes the fecthed Target verification.
   // the verification is supposed to fail and the installation process is never invoked
@@ -560,8 +560,7 @@ TEST_P(AkliteTest, RollbackIfAppsInstallFails) {
 
     // try to update to the latest version, it must fail because App is invalid
     ASSERT_TRUE(client->sysroot_->getDeploymentHash(OSTree::Sysroot::Deployment::kPending).empty());
-    updateApps(*client, target_01, target_02, data::ResultCode::Numeric::kOk,
-               data::ResultCode::Numeric::kInstallFailed);
+    updateApps(*client, target_01, target_02, DownloadResult::Status::Ok, data::ResultCode::Numeric::kInstallFailed);
     ASSERT_TRUE(client->sysroot_->getDeploymentHash(OSTree::Sysroot::Deployment::kPending).empty());
 
     // emulate next iteration/update cycle of daemon_main
@@ -720,8 +719,7 @@ TEST_P(AkliteTest, RollbackIfAppsInstallFailsNoContainer) {
     auto target_02 = createAppTarget(apps);
 
     // try to update to the latest version, it must fail because App is invalid
-    updateApps(*client, target_01, target_02, data::ResultCode::Numeric::kOk,
-               data::ResultCode::Numeric::kInstallFailed);
+    updateApps(*client, target_01, target_02, DownloadResult::Status::Ok, data::ResultCode::Numeric::kInstallFailed);
 
     // emulate next iteration/update cycle of daemon_main
     client->checkForUpdatesBegin();
@@ -771,8 +769,7 @@ TEST_P(AkliteTest, AppRollbackIfAppsInstallFails) {
     auto target_02 = createAppTarget(apps);
 
     // try to update to the latest version, it must fail because App is invalid
-    updateApps(*client, target_01, target_02, data::ResultCode::Numeric::kOk,
-               data::ResultCode::Numeric::kInstallFailed);
+    updateApps(*client, target_01, target_02, DownloadResult::Status::Ok, data::ResultCode::Numeric::kInstallFailed);
 
     // emulate next iteration/update cycle of daemon_main
     client->checkForUpdatesBegin();

--- a/tests/apiclient_test.cc
+++ b/tests/apiclient_test.cc
@@ -48,7 +48,7 @@ class MockAppEngine : public AppEngine {
 
  public:
   MOCK_METHOD(AppEngine::Result, fetch, (const App& app), (override));
-  MOCK_METHOD(bool, verify, (const App& app), (override));
+  MOCK_METHOD(AppEngine::Result, verify, (const App& app), (override));
   MOCK_METHOD(bool, install, (const App& app), (override));
   MOCK_METHOD(bool, run, (const App& app), (override));
   MOCK_METHOD(void, remove, (const App& app), (override));
@@ -253,7 +253,7 @@ TEST_F(ApiClientTest, SwitchTag) {
     // for some reason Utils::copyDir fails time to time if a destination is not empty
     // even though it calls remove_all internally, so just remove by invoking a shell cmd
     std::string rm_out;
-    ASSERT_EQ(Utils::shell("rm -r " + getTufRepo().getPath(), &rm_out, true), 0) << rm_out;
+    ASSERT_EQ(Utils::shell("rm -rf " + getTufRepo().getPath(), &rm_out, true), 0) << rm_out;
     Utils::copyDir(tagged_repo_path, getTufRepo().getPath());
 
     restart(liteclient);

--- a/tests/apiclient_test.cc
+++ b/tests/apiclient_test.cc
@@ -47,7 +47,7 @@ class MockAppEngine : public AppEngine {
   }
 
  public:
-  MOCK_METHOD(bool, fetch, (const App& app), (override));
+  MOCK_METHOD(AppEngine::Result, fetch, (const App& app), (override));
   MOCK_METHOD(bool, verify, (const App& app), (override));
   MOCK_METHOD(bool, install, (const App& app), (override));
   MOCK_METHOD(bool, run, (const App& app), (override));

--- a/tests/composeapp_test.cc
+++ b/tests/composeapp_test.cc
@@ -225,7 +225,7 @@ struct TestClient {
                                                            boost::filesystem::canonical(pacman_cfg.compose_bin).string() + " ",
                                                            std::make_shared<Docker::DockerClient>(),
                                                            std::make_shared<Docker::RegistryClient>(http_client, pacman_cfg.hub_auth_creds_endpoint, registry_http_client_factory));
-    pacman = std::make_shared<ComposeAppManager>(config.pacman, config.bootloader, storage, http_client, sysroot, app_engine_);
+    pacman = std::make_shared<ComposeAppManager>(config.pacman, config.bootloader, storage, http_client, sysroot, *keys, app_engine_);
   }
 
   const boost::filesystem::path getRebootSentinel() const {
@@ -234,7 +234,7 @@ struct TestClient {
 
   void fakeReboot() {
     boost::filesystem::remove(getRebootSentinel());
-    pacman.reset(new ComposeAppManager(config.pacman, config.bootloader, storage, http_client, sysroot, app_engine_));
+    pacman.reset(new ComposeAppManager(config.pacman, config.bootloader, storage, http_client, sysroot, *keys, app_engine_));
   }
 
   Config config;

--- a/tests/exec_test.cc
+++ b/tests/exec_test.cc
@@ -1,0 +1,47 @@
+#include <gtest/gtest.h>
+
+#include "exec.h"
+#include "utilities/utils.h"
+
+TEST(Exec, SuccessfulExec) {
+  TemporaryDirectory test_dir;
+  const auto test_file{test_dir / "test-file"};
+  exec("touch " + test_file.string(), "touch failed", boost::process::start_dir = test_dir.Path());
+  ASSERT_TRUE(boost::filesystem::exists(test_file));
+}
+
+TEST(Exec, FailedExec) {
+  const auto executable{"non-existing-executable"};
+  try {
+    exec(executable, "");
+  } catch (const std::exception& exc) {
+    const std::string err_msg{exc.what()};
+
+    ASSERT_EQ(err_msg.find("Failed to spawn process"), 0);
+    ASSERT_NE(err_msg.find(executable), std::string::npos) << "Actual error message: " + err_msg;
+    ;
+    ASSERT_NE(err_msg.find("No such file or directory"), std::string::npos) << "Actual error message: " + err_msg;
+    ;
+  }
+}
+
+TEST(Exec, SuccessfulExecFailedExecutable) {
+  const std::string executable{"ls"};
+  const std::string bad_option{"--foobar"};
+  const std::string err_msg_prefix{executable + " failed"};
+
+  try {
+    exec(executable + " " + bad_option, err_msg_prefix);
+  } catch (const std::exception& exc) {
+    const std::string err_msg{exc.what()};
+
+    ASSERT_EQ(err_msg.find(err_msg_prefix), 0);
+    ASSERT_NE(err_msg.find("unrecognized option \'" + bad_option + "\'"), std::string::npos)
+        << "Actual error message: " + err_msg;
+  }
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tests/fixtures/dockerregistry.cc
+++ b/tests/fixtures/dockerregistry.cc
@@ -88,6 +88,10 @@ class DockerRegistry {
       } else if (std::string::npos != url.find(registry_.base_url_ + "/v2/")) {
         // request for manifest
         resp = registry_.getAppManifest(url);
+        if (resp.size() == 0) {
+          // manifest hasn't been found
+          return HttpResponse(resp, 404, CURLE_OK, "Not Found");
+        }
       } else if (url == registry_.auth_url_) {
         // request for a basic auth to Device Gateway
         resp = "{\"Secret\":\"secret\",\"Username\":\"test-user\"}";

--- a/tests/fixtures/liteclienttest.cc
+++ b/tests/fixtures/liteclienttest.cc
@@ -234,7 +234,7 @@ class ClientTest :virtual public ::testing::Test {
     ASSERT_TRUE(client.checkForUpdatesBegin());
 
     // TODO: call client->getTarget() once the method is moved to LiteClient
-    ASSERT_EQ(client.download(to, ""), data::ResultCode::Numeric::kOk);
+    ASSERT_TRUE(client.download(to, ""));
     ASSERT_EQ(client.install(to), expected_install_code);
 
     // make sure that the new Target hasn't been applied/finalized before reboot
@@ -248,16 +248,16 @@ class ClientTest :virtual public ::testing::Test {
    * method updateApps
    */
   void updateApps(LiteClient& client, const Uptane::Target& from, const Uptane::Target& to,
-                  data::ResultCode::Numeric expected_download_code = data::ResultCode::Numeric::kOk,
+                  DownloadResult::Status expected_download_code = DownloadResult::Status::Ok,
                   data::ResultCode::Numeric expected_install_code = data::ResultCode::Numeric::kOk) {
     device_gateway_.resetEvents();
     // TODO: remove it once aklite is moved to the newer version of LiteClient that exposes update() method
     ASSERT_TRUE(client.checkForUpdatesBegin());
 
     // TODO: call client->getTarget() once the method is moved to LiteClient
-    ASSERT_EQ(client.download(to, ""), expected_download_code);
+    ASSERT_EQ(client.download(to, "").status, expected_download_code);
 
-    if (expected_download_code != data::ResultCode::Numeric::kOk) {
+    if (expected_download_code != DownloadResult::Status::Ok) {
       ASSERT_EQ(client.getCurrent().sha256Hash(), from.sha256Hash());
       ASSERT_EQ(client.getCurrent().filename(), from.filename());
       checkHeaders(client, from);

--- a/tests/liteclientHSM_test.cc
+++ b/tests/liteclientHSM_test.cc
@@ -50,7 +50,7 @@ class MockAppEngine : public AppEngine {
 
  public:
   MOCK_METHOD(AppEngine::Result, fetch, (const App& app), (override));
-  MOCK_METHOD(bool, verify, (const App& app), (override));
+  MOCK_METHOD(AppEngine::Result, verify, (const App& app), (override));
   MOCK_METHOD(bool, install, (const App& app), (override));
   MOCK_METHOD(bool, run, (const App& app), (override));
   MOCK_METHOD(void, remove, (const App& app), (override));

--- a/tests/liteclientHSM_test.cc
+++ b/tests/liteclientHSM_test.cc
@@ -49,7 +49,7 @@ class MockAppEngine : public AppEngine {
   }
 
  public:
-  MOCK_METHOD(bool, fetch, (const App& app), (override));
+  MOCK_METHOD(AppEngine::Result, fetch, (const App& app), (override));
   MOCK_METHOD(bool, verify, (const App& app), (override));
   MOCK_METHOD(bool, install, (const App& app), (override));
   MOCK_METHOD(bool, run, (const App& app), (override));

--- a/tests/liteclient_test.cc
+++ b/tests/liteclient_test.cc
@@ -328,7 +328,7 @@ TEST_F(LiteClientTest, AppUpdateDownloadFailure) {
   EXPECT_CALL(*getAppEngine(), install).Times(0);
   EXPECT_CALL(*getAppEngine(), run).Times(0);
 
-  updateApps(*client, getInitialTarget(), new_target, data::ResultCode::Numeric::kDownloadFailed);
+  updateApps(*client, getInitialTarget(), new_target, DownloadResult::Status::DownloadFailed);
 }
 
 TEST_F(LiteClientTest, AppUpdateInstallFailure) {
@@ -348,7 +348,7 @@ TEST_F(LiteClientTest, AppUpdateInstallFailure) {
   EXPECT_CALL(*getAppEngine(), install).Times(0);
   EXPECT_CALL(*getAppEngine(), run).Times(1);
 
-  updateApps(*client, getInitialTarget(), new_target, data::ResultCode::Numeric::kOk,
+  updateApps(*client, getInitialTarget(), new_target, DownloadResult::Status::Ok,
              data::ResultCode::Numeric::kInstallFailed);
 }
 

--- a/tests/liteclient_test.cc
+++ b/tests/liteclient_test.cc
@@ -50,7 +50,7 @@ class MockAppEngine : public AppEngine {
 
  public:
   MOCK_METHOD(AppEngine::Result, fetch, (const App& app), (override));
-  MOCK_METHOD(bool, verify, (const App& app), (override));
+  MOCK_METHOD(AppEngine::Result, verify, (const App& app), (override));
   MOCK_METHOD(bool, install, (const App& app), (override));
   MOCK_METHOD(bool, run, (const App& app), (override));
   MOCK_METHOD(void, remove, (const App& app), (override));

--- a/tests/liteclient_test.cc
+++ b/tests/liteclient_test.cc
@@ -49,7 +49,7 @@ class MockAppEngine : public AppEngine {
   }
 
  public:
-  MOCK_METHOD(bool, fetch, (const App& app), (override));
+  MOCK_METHOD(AppEngine::Result, fetch, (const App& app), (override));
   MOCK_METHOD(bool, verify, (const App& app), (override));
   MOCK_METHOD(bool, install, (const App& app), (override));
   MOCK_METHOD(bool, run, (const App& app), (override));

--- a/tests/liteclient_test.cc
+++ b/tests/liteclient_test.cc
@@ -348,7 +348,7 @@ TEST_F(LiteClientTest, AppUpdateInstallFailure) {
   EXPECT_CALL(*getAppEngine(), install).Times(0);
   EXPECT_CALL(*getAppEngine(), run).Times(1);
 
-  updateApps(*client, getInitialTarget(), new_target, DownloadResult::Status::Ok,
+  updateApps(*client, getInitialTarget(), new_target, DownloadResult::Status::Ok, "",
              data::ResultCode::Numeric::kInstallFailed);
 }
 


### PR DESCRIPTION
This PR goal is twofold, report download error messages and make the first step towards getting rid of dependency on the package manager interface.

- Introduce a new interface of a target download that uses the api's download result type.
- Make the package managers implement the new interface.
- Change LiteClient so it uses the new download interface and includes a failure reason into a report event sent to the backend.
- Adjust LiteClient clients so they use the api's download result type.