### PR TITLE
aklite: include App start err into report event

### DIFF
--- a/src/appengine.h
+++ b/src/appengine.h
@@ -29,8 +29,8 @@ class AppEngine {
 
   virtual Result fetch(const App& app) = 0;
   virtual Result verify(const App& app) = 0;
-  virtual bool install(const App& app) = 0;
-  virtual bool run(const App& app) = 0;
+  virtual Result install(const App& app) = 0;
+  virtual Result run(const App& app) = 0;
   virtual void remove(const App& app) = 0;
   virtual bool isFetched(const App& app) const = 0;
   virtual bool isRunning(const App& app) const = 0;

--- a/src/docker/composeappengine.h
+++ b/src/docker/composeappengine.h
@@ -21,8 +21,8 @@ class ComposeAppEngine : public AppEngine {
 
   Result fetch(const App& app) override;
   Result verify(const App& app) override;
-  bool install(const App& app) override;
-  bool run(const App& app) override;
+  Result install(const App& app) override;
+  Result run(const App& app) override;
   void remove(const App& app) override;
   bool isFetched(const App& app) const override;
   bool isRunning(const App& app) const override;

--- a/src/docker/composeappengine.h
+++ b/src/docker/composeappengine.h
@@ -67,15 +67,10 @@ class ComposeAppEngine : public AppEngine {
     enum class State {
       kUnknown = 0,
       kDownloaded = 0x10,
-      kDownloadFailed,
       kVerified = 0x20,
-      kVerifyFailed,
       kPulled = 0x30,
-      kPullFailed,
       kInstalled = 0x40,
-      kInstallFail,
-      kStarted = 0x50,
-      kStartFailed
+      kStarted = 0x50
     };
 
     AppState(const App& app, const boost::filesystem::path& root, bool set_version = false);
@@ -91,19 +86,12 @@ class ComposeAppEngine : public AppEngine {
     const State& operator()() const { return state_; }
     const std::string& version() const { return version_; }
     std::string toStr() const {
-      static std::map<State, std::string> state2Str = {
-          {State::kUnknown, "Unknown"},
-          {State::kDownloaded, "Downloaded"},
-          {State::kVerified, "Compose file verified"},
-          {State::kPulled, "Images are pulled"},
-          {State::kInstalled, "Created"},
-          // TODO: kInstallFail and kStartFailed will/should be removed once we make install/run return Result
-          // and refactor underlying functions (e.g. areContainersCreated) so they catch stderr correctly and throw
-          // exception
-          {State::kInstallFail, "Creation failed"},
-          {State::kStarted, "Started"},
-          {State::kStartFailed, "Start failed"},
-      };
+      static std::map<State, std::string> state2Str = {{State::kUnknown, "Unknown"},
+                                                       {State::kDownloaded, "Downloaded"},
+                                                       {State::kVerified, "Compose file verified"},
+                                                       {State::kPulled, "Images are pulled"},
+                                                       {State::kInstalled, "Created"},
+                                                       {State::kStarted, "Started"}};
 
       return state2Str[state_];
     }

--- a/src/docker/restorableappengine.h
+++ b/src/docker/restorableappengine.h
@@ -87,8 +87,8 @@ class RestorableAppEngine : public AppEngine {
 
   Result fetch(const App& app) override;
   Result verify(const App& app) override;
-  bool install(const App& app) override;
-  bool run(const App& app) override;
+  Result install(const App& app) override;
+  Result run(const App& app) override;
   void remove(const App& app) override;
   bool isFetched(const App& app) const override;
   bool isRunning(const App& app) const override;

--- a/src/liteclient.cc
+++ b/src/liteclient.cc
@@ -244,6 +244,13 @@ void LiteClient::notify(const Uptane::Target& t, std::unique_ptr<ReportEvent> ev
   if (!config.tls.server.empty()) {
     event->custom["targetName"] = t.filename();
     event->custom["version"] = t.custom_version();
+    if (event->custom.isMember("details")) {
+      static const size_t max_details_size{2048};
+      const auto detail_str{event->custom["details"].asString()};
+      if (detail_str.size() > max_details_size) {
+        event->custom["details"] = detail_str.substr(0, max_details_size);
+      }
+    }
     report_queue->enqueue(std::move(event));
   }
 }

--- a/tests/apiclient_test.cc
+++ b/tests/apiclient_test.cc
@@ -49,8 +49,8 @@ class MockAppEngine : public AppEngine {
  public:
   MOCK_METHOD(AppEngine::Result, fetch, (const App& app), (override));
   MOCK_METHOD(AppEngine::Result, verify, (const App& app), (override));
-  MOCK_METHOD(bool, install, (const App& app), (override));
-  MOCK_METHOD(bool, run, (const App& app), (override));
+  MOCK_METHOD(AppEngine::Result, install, (const App& app), (override));
+  MOCK_METHOD(AppEngine::Result, run, (const App& app), (override));
   MOCK_METHOD(void, remove, (const App& app), (override));
   MOCK_METHOD(bool, isFetched, (const App& app), (const, override));
   MOCK_METHOD(bool, isRunning, (const App& app), (const, override));

--- a/tests/device-gateway_fake.py
+++ b/tests/device-gateway_fake.py
@@ -151,12 +151,18 @@ class Handler(SimpleHTTPRequestHandler):
         else:
             cur_events = []
 
+        event_ids = set()
+        for e in cur_events:
+            event_ids.add(e["id"])
+
         data_len = int(self.headers.get('content-length', 0))
         body = self.rfile.read(data_len)
         with open(self.server.events_file, "w+") as f:
             events = json.loads(body.decode('utf-8'))
             for e in events:
-                cur_events.append(e)
+                if e["id"] not in event_ids:
+                    cur_events.append(e)
+                    event_ids.add(e["id"])
             json.dump(cur_events, f)
 
 

--- a/tests/fixtures/liteclienthsmtest.cc
+++ b/tests/fixtures/liteclienthsmtest.cc
@@ -16,7 +16,7 @@ class ClientHSMTest : public ClientTest {
     conf.tls.pkey_source = CryptoSource::kPkcs11;
     conf.tls.cert_source = CryptoSource::kPkcs11;
     conf.tls.ca_source = CryptoSource::kFile;
-    conf.tls.server = device_gateway_.getTreeUri();
+    conf.tls.server = device_gateway_.getTlsUri();
 
     conf.import.base_path = hsm_->path_;
     conf.import.tls_cacert_path = { "ca.crt" };

--- a/tests/liteclientHSM_test.cc
+++ b/tests/liteclientHSM_test.cc
@@ -51,8 +51,8 @@ class MockAppEngine : public AppEngine {
  public:
   MOCK_METHOD(AppEngine::Result, fetch, (const App& app), (override));
   MOCK_METHOD(AppEngine::Result, verify, (const App& app), (override));
-  MOCK_METHOD(bool, install, (const App& app), (override));
-  MOCK_METHOD(bool, run, (const App& app), (override));
+  MOCK_METHOD(AppEngine::Result, install, (const App& app), (override));
+  MOCK_METHOD(AppEngine::Result, run, (const App& app), (override));
   MOCK_METHOD(void, remove, (const App& app), (override));
   MOCK_METHOD(bool, isFetched, (const App& app), (const, override));
   MOCK_METHOD(bool, isRunning, (const App& app), (const, override));

--- a/tests/liteclient_test.cc
+++ b/tests/liteclient_test.cc
@@ -51,8 +51,8 @@ class MockAppEngine : public AppEngine {
  public:
   MOCK_METHOD(AppEngine::Result, fetch, (const App& app), (override));
   MOCK_METHOD(AppEngine::Result, verify, (const App& app), (override));
-  MOCK_METHOD(bool, install, (const App& app), (override));
-  MOCK_METHOD(bool, run, (const App& app), (override));
+  MOCK_METHOD(AppEngine::Result, install, (const App& app), (override));
+  MOCK_METHOD(AppEngine::Result, run, (const App& app), (override));
   MOCK_METHOD(void, remove, (const App& app), (override));
   MOCK_METHOD(bool, isFetched, (const App& app), (const, override));
   MOCK_METHOD(bool, isRunning, (const App& app), (const, override));


### PR DESCRIPTION
- Catch `docker-compose up [--no-start]` stderr and include it
  into the install complete report event.
- Extend/adjust existing tests so they check whether the App start
  error message is cacthed and included into the event.

Signed-off-by: Mike Sul <mike.sul@foundries.io>