### PR TITLE
docker: align image URI parsing with OCI dist spec

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ if(BUILD_AKLITE)
   add_dependencies(aklite aktualizr-lite)
 
   add_custom_target(aklite-tests)
-  add_dependencies(aklite-tests aklite t_lite-helpers uptane-generator t_compose-apps t_ostree t_liteclient t_yaml2json t_composeappengine t_restorableappengine t_aklite t_apiclient t_exec)
+  add_dependencies(aklite-tests aklite t_lite-helpers uptane-generator t_compose-apps t_ostree t_liteclient t_yaml2json t_composeappengine t_restorableappengine t_aklite t_apiclient t_exec t_docker)
 
   set(CMAKE_MODULE_PATH "${AKTUALIZR_DIR}/cmake-modules;${CMAKE_MODULE_PATH}")
 

--- a/src/docker/docker.h
+++ b/src/docker/docker.h
@@ -26,13 +26,18 @@ struct HashedDigest {
 };
 
 struct Uri {
-  static Uri parseUri(const std::string& uri);
+  static Uri parseUri(const std::string& uri, bool factory_app = true);
   Uri createUri(const HashedDigest& digest_in) const;
 
   const HashedDigest digest;
   const std::string app;
   const std::string factory;
-  const std::string repo;
+  // This is the <name> field as described in the OCI distribution spec
+  // https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pulling-manifests
+  // <registryHostname>[:port]/<name>@<digest>
+  // <name> == <factory>/<app> in the case of Compose App stored in Fio Registry
+  // <name> == <foo> | <foo>/<bar> | <foo>/<bar>/<whatever> - in the case of third party registries
+  const std::string repo;  // repo == name
   const std::string registryHostname;
 };
 

--- a/src/docker/restorableappengine.cc
+++ b/src/docker/restorableappengine.cc
@@ -267,7 +267,7 @@ void RestorableAppEngine::prune(const Apps& app_shortlist) {
       ComposeInfo compose{(entry.path() / ComposeFile).string()};
       for (const auto& service : compose.getServices()) {
         const auto image = compose.getImage(service);
-        const Uri image_uri{Uri::parseUri(image)};
+        const Uri image_uri{Uri::parseUri(image, false)};
         const auto image_root{app_dir / app_version_dir / "images" / image_uri.registryHostname / image_uri.repo /
                               image_uri.digest.hash()};
 
@@ -413,10 +413,10 @@ void RestorableAppEngine::pullAppImages(const boost::filesystem::path& app_compo
   for (const auto& service : compose.getServices()) {
     const auto image_uri = compose.getImage(service);
 
-    const Uri uri{Uri::parseUri(image_uri)};
+    const Uri uri{Uri::parseUri(image_uri, false)};
     const auto image_dir{dst_dir / uri.registryHostname / uri.repo / uri.digest.hash()};
 
-    LOG_INFO << uri.app << ": downloading image from Registry if missing: " << image_uri << " --> " << dst_dir;
+    LOG_INFO << uri.app << ": downloading image from Registry if missing: " << image_uri << " --> " << image_dir;
     pullImage(client_, image_uri, image_dir, blobs_root_);
   }
 }
@@ -447,7 +447,7 @@ void RestorableAppEngine::installAppImages(const boost::filesystem::path& app_di
   const auto compose{ComposeInfo((app_dir / ComposeFile).string())};
   for (const auto& service : compose.getServices()) {
     const auto image_uri = compose.getImage(service);
-    const Uri uri{Uri::parseUri(image_uri)};
+    const Uri uri{Uri::parseUri(image_uri, false)};
     const std::string tag{uri.registryHostname + '/' + uri.repo + ':' + uri.digest.shortHash()};
     const auto image_dir{app_dir / "images" / uri.registryHostname / uri.repo / uri.digest.hash()};
     installImage(client_, image_dir, blobs_root_, docker_host_, tag);
@@ -529,7 +529,7 @@ bool RestorableAppEngine::areAppImagesFetched(const App& app) const {
   ComposeInfo compose{compose_file.string()};
   for (const auto& service : compose.getServices()) {
     const auto image = compose.getImage(service);
-    const Uri image_uri{Uri::parseUri(image)};
+    const Uri image_uri{Uri::parseUri(image, false)};
     const auto image_root{app_dir / "images" / image_uri.registryHostname / image_uri.repo / image_uri.digest.hash()};
 
     const auto index_manifest{image_root / "index.json"};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -171,4 +171,12 @@ add_aktualizr_test(NAME exec
 )
 aktualizr_source_file_checks(exec_test.cc)
 target_include_directories(t_exec PRIVATE ${TEST_INCS})
-set_tests_properties(test_apiclient PROPERTIES LABELS "aklite:exec")
+set_tests_properties(test_exec PROPERTIES LABELS "aklite:exec")
+
+add_aktualizr_test(NAME docker
+  SOURCES $<TARGET_OBJECTS:${MAIN_TARGET_LIB}> docker_test.cc
+  PROJECT_WORKING_DIRECTORY
+)
+aktualizr_source_file_checks(docker_test.cc)
+target_include_directories(t_docker PRIVATE ${TEST_INCS})
+set_tests_properties(test_docker PROPERTIES LABELS "aklite:docker")

--- a/tests/aklite_test.cc
+++ b/tests/aklite_test.cc
@@ -100,9 +100,11 @@ TEST_P(AkliteTest, AppUpdate) {
   ASSERT_TRUE(targetsMatch(client->getCurrent(), target01));
   ASSERT_TRUE(app_engine->isRunning(app01));
 
-  // update app
+  // update app and add new one
   auto app01_updated = registry.addApp(fixtures::ComposeApp::create("app-01", "service-01", "image-02"));
-  auto target02 = createAppTarget({app01_updated});
+  auto app02 = registry.addApp(fixtures::ComposeApp::create("app-02", "service-01", "factory/image-01"));
+  auto app03 = registry.addApp(fixtures::ComposeApp::create("app-03", "service-01", "foo/bar/wierd/image-01"));
+  auto target02 = createAppTarget({app01_updated, app02, app03});
   updateApps(*client, target01, target02);
   ASSERT_TRUE(targetsMatch(client->getCurrent(), target02));
   ASSERT_TRUE(app_engine->isRunning(app01_updated));

--- a/tests/docker_test.cc
+++ b/tests/docker_test.cc
@@ -1,0 +1,103 @@
+#include <gtest/gtest.h>
+
+#include "boost/format.hpp"
+
+#include "docker/docker.h"
+
+TEST(Docker, ParseUri) {
+  const std::string host{"host"};
+  const std::string factory{"factory"};
+  const std::string app{"app"};
+  const std::string hash{"b0150d88116219cbf46ebb5dc08d8a559c4f1ab2731a788628fc7375b2372cb0"};
+
+  {
+    // regular Compose App hosted in Fio Registry
+    const Docker::Uri uri{
+        Docker::Uri::parseUri(boost::str(boost::format("%s/%s/%s@sha256:%s") % host % factory % app % hash))};
+    ASSERT_EQ(uri.registryHostname, host);
+    ASSERT_EQ(uri.factory, factory);
+    ASSERT_EQ(uri.app, app);
+    ASSERT_EQ(uri.digest.hash(), hash);
+  }
+
+  {
+    // regular Compose App hosted in Fio Registry, hostname includes port
+    const std::string host{"host:8080"};
+    const Docker::Uri uri{
+        Docker::Uri::parseUri(boost::str(boost::format("%s/%s/%s@sha256:%s") % host % factory % app % hash))};
+    ASSERT_EQ(uri.registryHostname, host);
+    ASSERT_EQ(uri.factory, factory);
+    ASSERT_EQ(uri.app, app);
+    ASSERT_EQ(uri.digest.hash(), hash);
+  }
+
+  {
+    // image hosted at 3rd party Registry, image name contains just one element
+    const std::string name{"alpine"};
+    const Docker::Uri uri{
+        Docker::Uri::parseUri(boost::str(boost::format("%s/%s@sha256:%s") % host % name % hash), false)};
+    ASSERT_EQ(uri.registryHostname, host);
+    ASSERT_EQ(uri.repo, name);
+    ASSERT_EQ(uri.app, name);
+    ASSERT_EQ(uri.factory.size(), 0);
+    ASSERT_EQ(uri.digest.hash(), hash);
+  }
+
+  {
+    // image hosted at 3rd party Registry, image name contains just one element. hostname includes port
+    const std::string host{"host:8080"};
+    const std::string name{"alpine"};
+    const Docker::Uri uri{
+        Docker::Uri::parseUri(boost::str(boost::format("%s/%s@sha256:%s") % host % name % hash), false)};
+    ASSERT_EQ(uri.registryHostname, host);
+    ASSERT_EQ(uri.repo, name);
+    ASSERT_EQ(uri.app, name);
+    ASSERT_EQ(uri.factory.size(), 0);
+    ASSERT_EQ(uri.digest.hash(), hash);
+  }
+
+  {
+    // image hosted at 3rd party Registry, image name contains two elements
+    const std::string name{"library/alpine"};
+    const Docker::Uri uri{
+        Docker::Uri::parseUri(boost::str(boost::format("%s/%s@sha256:%s") % host % name % hash), false)};
+    ASSERT_EQ(uri.registryHostname, host);
+    ASSERT_EQ(uri.repo, name);
+    ASSERT_EQ(uri.app, "alpine");
+    ASSERT_EQ(uri.factory, "library");
+    ASSERT_EQ(uri.digest.hash(), hash);
+  }
+
+  {
+    // image hosted at 3rd party Registry, image name contains three elements
+    const std::string name{"library/alpine/latest"};
+    const Docker::Uri uri{
+        Docker::Uri::parseUri(boost::str(boost::format("%s/%s@sha256:%s") % host % name % hash), false)};
+    ASSERT_EQ(uri.registryHostname, host);
+    ASSERT_EQ(uri.repo, name);
+    ASSERT_EQ(uri.app, "latest");
+    ASSERT_EQ(uri.factory, "library/alpine");
+    ASSERT_EQ(uri.digest.hash(), hash);
+  }
+}
+
+TEST(Docker, ParseUriNegative) {
+  EXPECT_THROW(Docker::Uri::parseUri(""), std::invalid_argument);
+  EXPECT_THROW(Docker::Uri::parseUri("foo"), std::invalid_argument);
+
+  EXPECT_THROW(Docker::Uri::parseUri("host/factory/app@"), std::invalid_argument);
+  EXPECT_THROW(Docker::Uri::parseUri("host/factory/app@sha256"), std::invalid_argument);
+  EXPECT_THROW(Docker::Uri::parseUri("host/factory/app@sha256:"), std::invalid_argument);
+  EXPECT_THROW(Docker::Uri::parseUri("host/factory/app@sha256:131313"), std::invalid_argument);
+
+  EXPECT_THROW(Docker::Uri::parseUri("no-path@sha256:b0150d88116219cbf46ebb5dc08d8a559c4f1ab2731a788628fc7375b2372cb0"),
+               std::invalid_argument);
+  EXPECT_THROW(
+      Docker::Uri::parseUri("host/no-factory@sha256:b0150d88116219cbf46ebb5dc08d8a559c4f1ab2731a788628fc7375b2372cb0"),
+      std::invalid_argument);
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tests/fixtures/composeapp.cc
+++ b/tests/fixtures/composeapp.cc
@@ -68,12 +68,12 @@ class ComposeApp {
 
  public:
   static Ptr create(const std::string& name,
-                    const std::string& service = "service-01", const std::string& image = "image-01",
+                    const std::string& service = "service-01", const std::string& image_name = "factory/image-01",
                     const std::string& service_template = ServiceTemplate,
                     const std::string& compose_file = Docker::ComposeAppEngine::ComposeFile,
                     const std::string& failure = "none",
                     const Json::Value& layers = Json::Value()) {
-    Ptr app{new ComposeApp(name, compose_file, "factory/" + image)};
+    Ptr app{new ComposeApp(name, compose_file, image_name)};
 
     // layers manifest
     Json::Value layers_json{layers};

--- a/tests/restorableappengine_test.cc
+++ b/tests/restorableappengine_test.cc
@@ -157,7 +157,7 @@ TEST_F(RestorableAppEngineTest, FetchCheckAndRefetch) {
   const auto compose_file{app_dir / Docker::RestorableAppEngine::ComposeFile};
   Docker::ComposeInfo compose{compose_file.string()};
   const auto image = compose.getImage(compose.getServices()[0]);
-  const Docker::Uri image_uri{Docker::Uri::parseUri(image)};
+  const Docker::Uri image_uri{Docker::Uri::parseUri(image, false)};
   const auto image_root{app_dir / "images" / image_uri.registryHostname / image_uri.repo / image_uri.digest.hash()};
   const auto index_manifest{image_root / "index.json"};
 


### PR DESCRIPTION
- Fix Docker::Uri::parseUri implementation so it accepts image URIs
  that contains one or more elements in the `name` (aka `path`) field
  of an image URI. E.g. fiotesting1.azurecr.io/alpine@sha256:<hash>,
  fiotesting1.azurecr.io/library/alpine/latest@sha256:<hash>.

- Extend existing tests so they verify images referred by different
  and acceptable URI formats.

- Add new unit test to cover the image URI parsing logic.

Signed-off-by: Mike Sul <mike.sul@foundries.io>