### PR TITLE
apps: prune stopped containers after successful update

### DIFF
--- a/src/docker/composeappengine.cc
+++ b/src/docker/composeappengine.cc
@@ -397,6 +397,11 @@ void ComposeAppEngine::extractAppArchive(const App& app, const std::string& arch
 }
 
 void ComposeAppEngine::pruneDockerStore() {
+  LOG_INFO << "Pruning unused docker containers";
+  if (std::system("docker container prune -f --filter=\"label!=aktualizr-no-prune\"") != 0) {
+    LOG_WARNING << "Unable to prune unused docker containers";
+  }
+
   LOG_INFO << "Pruning unused docker images";
   // Utils::shell which isn't interactive, we'll use std::system so that
   // stdout/stderr is streamed while docker sets things up.


### PR DESCRIPTION
Make sure that stopped containers are removed after successful
app update, i.e. download and container creation and start.

Signed-off-by: Mike Sul <mike.sul@foundries.io>