### PR TITLE
apps: Use `docker compose` by default

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -74,7 +74,8 @@ RUN apt-get update && apt-get -y install --no-install-suggests --no-install-reco
   wget \
   xsltproc \
   zip \
-  docker-compose
+  docker-compose \
+  sudo
 
 RUN ln -s clang-10 /usr/bin/clang && \
     ln -s clang++-10 /usr/bin/clang++
@@ -111,6 +112,6 @@ RUN apt-get update && apt-get -y install skopeo && ln -s /usr/bin/skopeo /sbin/s
 # Install specific version of docker-compose
 RUN pip3 install docker==4.2.1 && pip3 install docker-compose==1.26
 
-RUN useradd testuser
+RUN useradd -m testuser && usermod -aG docker testuser
 
 WORKDIR /

--- a/src/composeappmanager.cc
+++ b/src/composeappmanager.cc
@@ -106,7 +106,10 @@ ComposeAppManager::ComposeAppManager(const PackageConfig& pconfig, const Bootloa
   if (!app_engine_) {
     auto docker_client{std::make_shared<Docker::DockerClient>()};
     auto registry_client{std::make_shared<Docker::RegistryClient>(http, cfg_.hub_auth_creds_endpoint)};
-    const auto compose_cmd{boost::filesystem::canonical(cfg_.compose_bin).string() + " "};
+    std::string compose_cmd{boost::filesystem::canonical(cfg_.compose_bin).string() + " "};
+    if (cfg_.compose_bin.filename().compare("docker") == 0) {
+      compose_cmd += "compose ";  // "make it `docker compose` command
+    }
     const std::string skopeo_cmd{boost::filesystem::canonical(cfg_.skopeo_bin).string()};
     const std::string docker_host{"unix:///var/run/docker.sock"};
 

--- a/src/composeappmanager.h
+++ b/src/composeappmanager.h
@@ -22,7 +22,7 @@ class ComposeAppManager : public RootfsTreeManager {
     boost::optional<std::vector<std::string>> reset_apps;
     boost::filesystem::path apps_root{"/var/sota/compose-apps"};
     boost::filesystem::path reset_apps_root{"/var/sota/reset-apps"};
-    boost::filesystem::path compose_bin{"/usr/bin/docker-compose"};
+    boost::filesystem::path compose_bin{"/usr/bin/docker"};
     boost::filesystem::path skopeo_bin{"/sbin/skopeo"};
     bool docker_prune{true};
     bool force_update{false};

--- a/unit-test
+++ b/unit-test
@@ -5,7 +5,7 @@ cd $here
 
 if [ $# -eq 0 ] ; then
 	echo "Launching unit tests in docker"
-	TEST=1 exec ./dev-shell ./unit-test indocker
+	TEST=1 exec ./dev-shell sudo -u testuser ./unit-test indocker
 fi
 
 set -x


### PR DESCRIPTION
Switch from the python based `docker-compose` to golang based
`docker compose` owned by docker org.

Signed-off-by: Mike Sul <mike.sul@foundries.io>