### PR TITLE
No space reaction

### DIFF
--- a/include/aktualizr-lite/api.h
+++ b/include/aktualizr-lite/api.h
@@ -98,12 +98,14 @@ class DownloadResult {
     Ok = 0,
     DownloadFailed,
     VerificationFailed,
+    DownloadFailed_NoSpace,
   };
   Status status;
   std::string description;
 
   // NOLINTNEXTLINE(hicpp-explicit-conversions,google-explicit-constructor)
   operator bool() const { return status == Status::Ok; }
+  bool noSpace() const { return status == Status::DownloadFailed_NoSpace; }
 };
 
 std::ostream &operator<<(std::ostream &os, const InstallResult &res);

--- a/src/appengine.h
+++ b/src/appengine.h
@@ -15,12 +15,19 @@ class AppEngine {
   };
 
   struct Result {
+    enum class ID {
+      OK = 0,
+      Failed,
+      InsufficientSpace,
+    };
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    Result(bool var, std::string errMsg = "") : status{var}, err{std::move(errMsg)} {}
+    Result(bool var, std::string errMsg = "") : status{var ? ID::OK : ID::Failed}, err{std::move(errMsg)} {}
+    Result(Result::ID id, std::string errMsg) : status{id}, err{std::move(errMsg)} {}
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    operator bool() const { return status; }
+    operator bool() const { return status == ID::OK; }
+    bool noSpace() const { return status == ID::InsufficientSpace; }
 
-    bool status;
+    ID status;
     std::string err;
   };
 

--- a/src/composeappmanager.cc
+++ b/src/composeappmanager.cc
@@ -241,7 +241,9 @@ DownloadResult ComposeAppManager::Download(const TufTarget& target) {
       const std::string err_desc{boost::str(boost::format("failed to fetch App; app: %s; uri: %s; err: %s") %
                                             pair.first % pair.second % fetch_res.err)};
       LOG_ERROR << err_desc;
-      res = {DownloadResult::Status::DownloadFailed, err_desc};
+      res = {
+          fetch_res.noSpace() ? DownloadResult::Status::DownloadFailed_NoSpace : DownloadResult::Status::DownloadFailed,
+          err_desc};
       break;
     }
   }

--- a/src/liteclient.cc
+++ b/src/liteclient.cc
@@ -419,7 +419,7 @@ DownloadResult LiteClient::downloadImage(const Uptane::Target& target, const api
       }
     }
     if (!download_result) {
-      LOG_ERROR << "Download unsuccessful after " << tries << " attempts; err: " << download_result.description;
+      LOG_ERROR << "Download unsuccessful after " << tries + 1 << " attempts; err: " << download_result.description;
     }
   }
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -378,13 +378,19 @@ static int daemon_main(LiteClient& client, const bpo::variables_map& variables_m
           LOG_INFO << "Latest Target: " << target_to_install.filename() << " is a failing Target (aka known locally)."
                    << " Skipping its installation.";
         }
+        data::ResultCode::Numeric rc{data::ResultCode::Numeric::kOk};
         if (!client.appsInSync()) {
           client.checkForUpdatesEnd(target_to_install);
-          do_app_sync(client);
+          rc = do_app_sync(client);
+          if (rc == data::ResultCode::Numeric::kOk) {
+            LOG_INFO << "Device is up-to-date";
+          } else {
+            LOG_ERROR << "Failed to sync the current Target: " << target_to_install.filename();
+          }
         } else {
+          LOG_INFO << "Device is up-to-date";
           client.checkForUpdatesEnd(Uptane::Target::Unknown());
         }
-        LOG_INFO << "Device is up-to-date";
       }
 
     } catch (const std::exception& exc) {

--- a/tests/fixtures/liteclient/sysostreerepomock.cc
+++ b/tests/fixtures/liteclient/sysostreerepomock.cc
@@ -16,6 +16,10 @@ class SysOSTreeRepoMock {
     executeCmd("ostree", { "admin", "--sysroot=" + path_, "deploy", "--os=" + os_, hash }, "deploy " + hash);
   }
 
+  void setMinFreeSpace(const std::string& size) {
+    executeCmd("ostree", { "--repo=" + path_ + "/ostree/repo", "config", "set", "core.min-free-space-size", size }, "set config " + size);
+  }
+
  private:
   const std::string path_;
   const std::string os_;

--- a/tests/liteclient_test.cc
+++ b/tests/liteclient_test.cc
@@ -162,6 +162,24 @@ TEST_F(LiteClientTest, OstreeUpdate) {
   checkHeaders(*client, new_target);
 }
 
+TEST_F(LiteClientTest, OstreeUpdateNoSpace) {
+  // boot device
+  auto client = createLiteClient();
+  ASSERT_TRUE(targetsMatch(client->getCurrent(), getInitialTarget()));
+
+  sys_repo_.setMinFreeSpace("1TB");
+  // Create a new Target: update rootfs and commit it into Treehub's repo
+  auto new_target = createTarget();
+  update(*client, getInitialTarget(), new_target, data::ResultCode::Numeric::kDownloadFailed,
+         {DownloadResult::Status::DownloadFailed_NoSpace, "Insufficient storage available"});
+  ASSERT_TRUE(targetsMatch(client->getCurrent(), getInitialTarget()));
+
+  // reboot device
+  reboot(client);
+  ASSERT_TRUE(targetsMatch(client->getCurrent(), getInitialTarget()));
+  checkHeaders(*client, getInitialTarget());
+}
+
 TEST_F(LiteClientTest, OstreeUpdateRollback) {
   // boot device
   auto client = createLiteClient();

--- a/tests/restorableappengine_test.cc
+++ b/tests/restorableappengine_test.cc
@@ -281,7 +281,7 @@ TEST_F(RestorableAppEngineTest, CheckStorageWatermarkLimits) {
 TEST_F(RestorableAppEngineTest, FetchAndCheckSizeInsufficientSpace) {
   setAvailableStorageSpace(1024);
   auto app = registry.addApp(fixtures::ComposeApp::create("app-01"));
-  ASSERT_FALSE(app_engine->fetch(app));
+  ASSERT_TRUE(app_engine->fetch(app).noSpace());
   ASSERT_FALSE(app_engine->isFetched(app));
   ASSERT_FALSE(app_engine->isRunning(app));
 }
@@ -304,7 +304,7 @@ TEST_F(RestorableAppEngineTest, FetchAndCheckSizeInsufficientSpaceIfWatermark) {
     const auto compose_app{fixtures::ComposeApp::createAppWithCustomeLayers("app-01", layers)};
     setAvailableStorageSpaceWithoutWatermark(6144);
     auto app = registry.addApp(compose_app);
-    ASSERT_FALSE(app_engine->fetch(app));
+    ASSERT_TRUE(app_engine->fetch(app).noSpace());
     ASSERT_FALSE(app_engine->isFetched(app));
   }
 }
@@ -321,7 +321,7 @@ TEST_P(RestorableAppEngineTestParameterized, FetchAndCheckSizeInsufficientSpace)
   // but not sufficient to accomodate an uncompressed layer in the docker data root (store)
   setAvailableStorageSpace(layer_size * 1.5);
   auto app = registry.addApp(compose_app);
-  ASSERT_FALSE(app_engine->fetch(app));
+  ASSERT_TRUE(app_engine->fetch(app).noSpace());
   ASSERT_FALSE(app_engine->isFetched(app));
   ASSERT_FALSE(app_engine->isRunning(app));
 }


### PR DESCRIPTION
- Identify an insufficient space error if ostree or restorable App pull fails;
- Don't retry the pull if such the error is detected;
- Don't try new updates until aklite is restarted (or device is rebooted).