### PR TITLE
Check rootfs free space before next download attempt after "no space" failure

### DIFF
--- a/src/ostree/repo.h
+++ b/src/ostree/repo.h
@@ -23,6 +23,9 @@ class Repo {
 
   void pull(const std::string& remote_name, const std::string& branch, const std::string& commit_hash);
   void checkout(const std::string& commit_hash, const std::string& src_dir, const std::string& dst_dir);
+  void setConfigItem(const std::string& section, const std::string& key, const std::string& value);
+  std::string getConfigItem(const std::string& section, const std::string& key);
+  void unsetConfigItem(const std::string& section, const std::string& key);
 
  private:
   void init(bool create);

--- a/src/rootfstreemanager.cc
+++ b/src/rootfstreemanager.cc
@@ -3,6 +3,15 @@
 #include "target.h"
 
 DownloadResult RootfsTreeManager::Download(const TufTarget& target) {
+  if (!checkTargetInsufficientStorageLevelIfSet(target.Name())) {
+    const std::string err_msg{
+        "Skip Target download, available storage has not been increased since Target download failed last time due to "
+        "lack of space"};
+    LOG_ERROR << err_msg;
+    return {DownloadResult::Status::DownloadFailed_NoSpace,
+            "Insufficient storage available; path: " + config.sysroot.string() + "; err: " + err_msg};
+  }
+
   auto prog_cb = [this](const Uptane::Target& t, const std::string& description, unsigned int progress) {
     // report_progress_cb(events_channel.get(), t, description, progress);
     // TODO: consider make use of it for download progress reporting
@@ -24,6 +33,7 @@ DownloadResult RootfsTreeManager::Download(const TufTarget& target) {
                                    prog_cb, remote.isRemoteSet ? nullptr : remote.name.c_str(), remote.headers);
     if (pull_err.isSuccess()) {
       res = {DownloadResult::Status::Ok, ""};
+      unsetTargetInsufficientStorageLevel(target.Name());
       break;
     }
 
@@ -32,10 +42,12 @@ DownloadResult RootfsTreeManager::Download(const TufTarget& target) {
     if (pull_err.description.find("would be exceeded, at least") != std::string::npos &&
         (pull_err.description.find("min-free-space-size") != std::string::npos ||
          pull_err.description.find("min-free-space-percent") != std::string::npos)) {
+      setTargetInsufficientStorageLevel(target.Name());
       res = {DownloadResult::Status::DownloadFailed_NoSpace,
              "Insufficient storage available; path: " + config.sysroot.string() + "; err: " + pull_err.description};
       break;
     }
+    unsetTargetInsufficientStorageLevel(target.Name());
     error_desc += pull_err.description + "\n";
     res = {DownloadResult::Status::DownloadFailed, error_desc};
   }
@@ -100,5 +112,57 @@ void RootfsTreeManager::setRemote(const std::string& name, const std::string& ur
     repo.addRemote(name, url, (*keys)->getCaFile(), (*keys)->getCertFile(), (*keys)->getPkeyFile());
   } else {
     repo.addRemote(name, url, "", "", "");
+  }
+}
+
+void RootfsTreeManager::setTargetInsufficientStorageLevel(const std::string& target_name) {
+  boost::system::error_code ec;
+  const boost::filesystem::space_info store_info{boost::filesystem::space(sysroot_->path(), ec)};
+  if (ec.failed()) {
+    LOG_WARNING << "Failed to obtain info about available storage: " << ec.message();
+    return;
+  }
+
+  try {
+    const auto available_storage_size{std::to_string(store_info.available)};
+    OSTree::Repo repo{sysroot_->path() + "/ostree/repo"};
+    repo.setConfigItem("min-free-space-required", target_name, available_storage_size);
+  } catch (const std::exception& exc) {
+    LOG_ERROR << "Failed to set Target insufficient storage level: " << exc.what();
+  }
+}
+
+bool RootfsTreeManager::checkTargetInsufficientStorageLevelIfSet(const std::string& target_name) {
+  try {
+    OSTree::Repo repo{sysroot_->path() + "/ostree/repo"};
+    const std::string required_min_space_str{repo.getConfigItem("min-free-space-required", target_name)};
+    if (required_min_space_str.empty()) {
+      return true;
+    }
+    const boost::uintmax_t required_min_space{boost::lexical_cast<boost::uintmax_t>(required_min_space_str)};
+
+    boost::system::error_code ec;
+    const boost::filesystem::space_info store_info{boost::filesystem::space(sysroot_->path(), ec)};
+    if (ec.failed()) {
+      LOG_WARNING << "Failed to obtain info about available storage: " << ec.message();
+      return true;
+    }
+
+    const auto exp_required_min_space{required_min_space + (4 * 1024) /* at least 4K change */};
+    LOG_INFO << "Target " << target_name << " needs at least " << exp_required_min_space << " of free space, got "
+             << store_info.available;
+    return store_info.available > exp_required_min_space;
+  } catch (const std::exception& exc) {
+    LOG_ERROR << "Failed to check Target insufficient storage level: " << exc.what();
+  }
+  return true;
+}
+
+void RootfsTreeManager::unsetTargetInsufficientStorageLevel(const std::string& target_name) {
+  try {
+    OSTree::Repo repo{sysroot_->path() + "/ostree/repo"};
+    repo.unsetConfigItem("min-free-space-required", target_name);
+  } catch (const std::exception& exc) {
+    LOG_ERROR << "Failed to unset Target insufficient storage level: " << exc.what();
   }
 }

--- a/src/rootfstreemanager.h
+++ b/src/rootfstreemanager.h
@@ -43,6 +43,9 @@ class RootfsTreeManager : public OstreeManager, public Downloader {
   void getAdditionalRemotes(std::vector<Remote>& remotes, const std::string& target_name);
 
   void setRemote(const std::string& name, const std::string& url, const boost::optional<const KeyManager*>& keys);
+  void setTargetInsufficientStorageLevel(const std::string& target_name);
+  bool checkTargetInsufficientStorageLevelIfSet(const std::string& target_name);
+  void unsetTargetInsufficientStorageLevel(const std::string& target_name);
 
   const KeyManager& keys_;
   std::shared_ptr<OSTree::Sysroot> sysroot_;

--- a/tests/fixtures/liteclient/sysostreerepomock.cc
+++ b/tests/fixtures/liteclient/sysostreerepomock.cc
@@ -20,6 +20,10 @@ class SysOSTreeRepoMock {
     executeCmd("ostree", { "--repo=" + path_ + "/ostree/repo", "config", "set", "core.min-free-space-size", size }, "set config " + size);
   }
 
+  void unsetMinFreeSpace() {
+    executeCmd("ostree", { "--repo=" + path_ + "/ostree/repo", "config", "unset", "core.min-free-space-size"}, "unset config");
+  }
+
  private:
   const std::string path_;
   const std::string os_;

--- a/tests/ostree_test.cc
+++ b/tests/ostree_test.cc
@@ -48,6 +48,26 @@ TEST_F(OSTreeTest, AddRemote) {
   repo_->addRemote("treehub", "http://localhost", "", "", "");
 }
 
+TEST_F(OSTreeTest, Config) {
+  ASSERT_TRUE(isRepoInited());
+  {
+    repo_->setConfigItem("min-free-size-required", "target-001", "1024");
+    ASSERT_EQ(repo_->getConfigItem("min-free-size-required", "target-001"), "1024");
+    repo_->unsetConfigItem("min-free-size-required", "target-001");
+    ASSERT_EQ(repo_->getConfigItem("min-free-size-required", "target-001"), "");
+  }
+  {
+    ASSERT_EQ(repo_->getConfigItem("foo", "bar"), "");
+    ASSERT_NO_THROW(repo_->unsetConfigItem("foo1", "bar"));
+  }
+  {
+    repo_->setConfigItem("core", "min-free-size-required", "100");
+    ASSERT_EQ(repo_->getConfigItem("core", "min-free-size-required"), "100");
+    repo_->setConfigItem("core", "min-free-size-required", "200");
+    ASSERT_EQ(repo_->getConfigItem("core", "min-free-size-required"), "200");
+  }
+}
+
 // TODO: Add Treehub mock and uncomment the following tests
 //TEST_F(OSTreeTest, Pull) {
 //  ASSERT_TRUE(isRepoInited());


### PR DESCRIPTION
- Store currently available free space if an ostree download fails because insufficient available storage.
- Check whether free space has increased before the next ostree download attempt. Skip the download if a free space has not been increased, unless a new Target to be downloaded.  