### PR TITLE
Skip update if download failed before

### DIFF
--- a/include/aktualizr-lite/api.h
+++ b/include/aktualizr-lite/api.h
@@ -102,6 +102,7 @@ class DownloadResult {
   };
   Status status;
   std::string description;
+  std::string destination_path;
 
   // NOLINTNEXTLINE(hicpp-explicit-conversions,google-explicit-constructor)
   operator bool() const { return status == Status::Ok; }

--- a/src/liteclient.h
+++ b/src/liteclient.h
@@ -65,6 +65,8 @@ class LiteClient {
   std::unique_ptr<ReportQueue> report_queue;
   bool isRollback(const Uptane::Target& target);
 
+  void notifyDownloadFinished(const Uptane::Target& t, bool success, const std::string& err_msg = "");
+
  private:
   FRIEND_TEST(helpers, locking);
   FRIEND_TEST(helpers, callback);
@@ -75,9 +77,7 @@ class LiteClient {
 
   void notify(const Uptane::Target& t, std::unique_ptr<ReportEvent> event) const;
   void notifyDownloadStarted(const Uptane::Target& t, const std::string& reason);
-  void notifyDownloadFinished(const Uptane::Target& t, bool success, const std::string& err_msg = "");
   void notifyInstallStarted(const Uptane::Target& t);
-
   void writeCurrentTarget(const Uptane::Target& t) const;
 
   data::InstallationResult installPackage(const Uptane::Target& target);

--- a/src/rootfstreemanager.cc
+++ b/src/rootfstreemanager.cc
@@ -33,7 +33,8 @@ DownloadResult RootfsTreeManager::Download(const TufTarget& target) {
         (pull_err.description.find("min-free-space-size") != std::string::npos ||
          pull_err.description.find("min-free-space-percent") != std::string::npos)) {
       res = {DownloadResult::Status::DownloadFailed_NoSpace,
-             "Insufficient storage available; path: " + config.sysroot.string() + "; err: " + pull_err.description};
+             "Insufficient storage available; path: " + config.sysroot.string() + "; err: " + pull_err.description,
+             sysroot_->path()};
       break;
     }
     error_desc += pull_err.description + "\n";

--- a/tests/fixtures/liteclienttest.cc
+++ b/tests/fixtures/liteclienttest.cc
@@ -240,6 +240,9 @@ class ClientTest :virtual public ::testing::Test {
     const auto download_result{client.download(to, "")};
     ASSERT_EQ(download_result.status, expected_download_result.status);
     ASSERT_TRUE(download_result.description.find(expected_download_result.description) != std::string::npos) << "Actuall error message: " << download_result.description;
+    if (expected_download_result.noSpace()) {
+      ASSERT_EQ(download_result.destination_path, sys_repo_.getPath());
+    }
     if (download_result) {
       ASSERT_EQ(client.install(to), expected_install_code);
       // make sure that the new Target hasn't been applied/finalized before reboot


### PR DESCRIPTION
aklite: Skip update download if failed before
    
Skip an attempt to download an update/Target if:
    1) its ostree download failed before due to lack of free space;
    2) size of free space has not increased since the failure time.
