### PR TITLE
apps: stop removed Apps before creating new one

### DIFF
--- a/src/appengine.h
+++ b/src/appengine.h
@@ -38,6 +38,7 @@ class AppEngine {
   virtual Result verify(const App& app) = 0;
   virtual Result install(const App& app) = 0;
   virtual Result run(const App& app) = 0;
+  virtual void stop(const App& app) = 0;
   virtual void remove(const App& app) = 0;
   virtual bool isFetched(const App& app) const = 0;
   virtual bool isRunning(const App& app) const = 0;

--- a/src/composeappmanager.h
+++ b/src/composeappmanager.h
@@ -64,7 +64,10 @@ class ComposeAppManager : public RootfsTreeManager {
   std::string getRunningAppsInfoForReport() const;
 
   AppsContainer getAppsToFetch(const Uptane::Target& target, bool check_store = true) const;
+  void stopDisabledComposeApps(const Uptane::Target& target) const;
   void removeDisabledComposeApps(const Uptane::Target& target) const;
+  void forEachRemovedApp(const Uptane::Target& target,
+                         const std::function<void(AppEngine::Ptr&, const std::string&)>& action) const;
 
   Config cfg_;
   mutable AppsContainer cur_apps_to_fetch_and_update_;

--- a/src/docker/composeappengine.cc
+++ b/src/docker/composeappengine.cc
@@ -151,6 +151,15 @@ AppEngine::Result ComposeAppEngine::run(const App& app) {
   return result;
 }
 
+void ComposeAppEngine::stop(const App& app) {
+  try {
+    const auto root_dir{appRoot(app)};
+    exec(compose_ + "down", "failed to bring App down", boost::process::start_dir = root_dir);
+  } catch (const std::exception& exc) {
+    LOG_ERROR << "docker-compose was unable to bring down: " << exc.what();
+  }
+}
+
 void ComposeAppEngine::remove(const App& app) {
   try {
     const auto root_dir{appRoot(app)};

--- a/src/docker/composeappengine.h
+++ b/src/docker/composeappengine.h
@@ -23,6 +23,7 @@ class ComposeAppEngine : public AppEngine {
   Result verify(const App& app) override;
   Result install(const App& app) override;
   Result run(const App& app) override;
+  void stop(const App& app) override;
   void remove(const App& app) override;
   bool isFetched(const App& app) const override;
   bool isRunning(const App& app) const override;

--- a/src/docker/restorableappengine.cc
+++ b/src/docker/restorableappengine.cc
@@ -181,6 +181,17 @@ AppEngine::Result RestorableAppEngine::run(const App& app) {
   return res;
 }
 
+void RestorableAppEngine::stop(const App& app) {
+  try {
+    const auto app_install_dir{install_root_ / app.name};
+
+    // just installed app are removed, the restorable store Apps will be removed by means of prune() call
+    stopComposeApp(compose_cmd_, app_install_dir);
+  } catch (const std::exception& exc) {
+    LOG_WARNING << "App: " << app.name << ", failed to remove: " << exc.what();
+  }
+}
+
 void RestorableAppEngine::remove(const App& app) {
   try {
     const auto app_install_dir{install_root_ / app.name};

--- a/src/docker/restorableappengine.h
+++ b/src/docker/restorableappengine.h
@@ -92,6 +92,7 @@ class RestorableAppEngine : public AppEngine {
   Result verify(const App& app) override;
   Result install(const App& app) override;
   Result run(const App& app) override;
+  void stop(const App& app) override;
   void remove(const App& app) override;
   bool isFetched(const App& app) const override;
   bool isRunning(const App& app) const override;

--- a/tests/apiclient_test.cc
+++ b/tests/apiclient_test.cc
@@ -51,6 +51,7 @@ class MockAppEngine : public AppEngine {
   MOCK_METHOD(AppEngine::Result, verify, (const App& app), (override));
   MOCK_METHOD(AppEngine::Result, install, (const App& app), (override));
   MOCK_METHOD(AppEngine::Result, run, (const App& app), (override));
+  MOCK_METHOD(void, stop, (const App& app), (override));
   MOCK_METHOD(void, remove, (const App& app), (override));
   MOCK_METHOD(bool, isFetched, (const App& app), (const, override));
   MOCK_METHOD(bool, isRunning, (const App& app), (const, override));

--- a/tests/liteclientHSM_test.cc
+++ b/tests/liteclientHSM_test.cc
@@ -53,6 +53,7 @@ class MockAppEngine : public AppEngine {
   MOCK_METHOD(AppEngine::Result, verify, (const App& app), (override));
   MOCK_METHOD(AppEngine::Result, install, (const App& app), (override));
   MOCK_METHOD(AppEngine::Result, run, (const App& app), (override));
+  MOCK_METHOD(void, stop, (const App& app), (override));
   MOCK_METHOD(void, remove, (const App& app), (override));
   MOCK_METHOD(bool, isFetched, (const App& app), (const, override));
   MOCK_METHOD(bool, isRunning, (const App& app), (const, override));

--- a/tests/liteclient_test.cc
+++ b/tests/liteclient_test.cc
@@ -53,6 +53,7 @@ class MockAppEngine : public AppEngine {
   MOCK_METHOD(AppEngine::Result, verify, (const App& app), (override));
   MOCK_METHOD(AppEngine::Result, install, (const App& app), (override));
   MOCK_METHOD(AppEngine::Result, run, (const App& app), (override));
+  MOCK_METHOD(void, stop, (const App& app), (override));
   MOCK_METHOD(void, remove, (const App& app), (override));
   MOCK_METHOD(bool, isFetched, (const App& app), (const, override));
   MOCK_METHOD(bool, isRunning, (const App& app), (const, override));


### PR DESCRIPTION
Apps that have been removed from a config or are not present in a new
Target should be stopped before creating/starting new Apps because they
may interfere with each other, e.g. the same port is re-used.

- Add a new method to AppEngine to stop App.
- Stop removed Apps before creating and/or starting new Apps.

Signed-off-by: Mike Sul <mike.sul@foundries.io>