### PR TITLE
Fix/clang compile

### DIFF
--- a/.jobserv.yml
+++ b/.jobserv.yml
@@ -27,4 +27,4 @@ scripts:
     #!/bin/bash -ex
     wrapdocker &
     chown -R testuser:testuser .
-    sudo -u testuser CCACHE_DIR=/tmp/ccache make -f dev-flow.mk config build format tidy test
+    sudo -u testuser CCACHE_DIR=/tmp/ccache CXX=clang++ CC=clang make -f dev-flow.mk config build format tidy test

--- a/apps/aklite-apps/CMakeLists.txt
+++ b/apps/aklite-apps/CMakeLists.txt
@@ -8,6 +8,7 @@ set(HEADERS cmds.h)
 
 add_executable(${TARGET} ${SRC})
 add_dependencies(aklite-tests ${TARGET})
+set_property(TARGET ${TARGET} PROPERTY CXX_STANDARD 17)
 
 set(INCS
   ${AKLITE_DIR}/include/

--- a/apps/aklite-apps/CMakeLists.txt
+++ b/apps/aklite-apps/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SRC main.cpp cmds.cpp)
 set(HEADERS cmds.h)
 
 add_executable(${TARGET} ${SRC})
+add_dependencies(aklite-tests ${TARGET})
 
 set(INCS
   ${AKLITE_DIR}/include/

--- a/dev-shell
+++ b/dev-shell
@@ -3,6 +3,7 @@
 ## A simple wrapper to allow development to occur in a container.
 
 container="aklite-dev"
+DEF_COMPILER_ARGS="-e CC=clang -e CXX=clang++"
 
 here=$(dirname $(readlink -f $0))
 cd $here
@@ -21,7 +22,7 @@ fi
 
 set -x
 if [ -n "${TEST}" ]; then
-	exec docker run --privileged $CCACHE_ARGS --entrypoint="wrapdocker" --rm -it -v $here:$here -w $here $container $*
+	exec docker run --privileged $DEF_COMPILER_ARGS $CCACHE_ARGS --entrypoint="wrapdocker" --rm -it -v $here:$here -w $here $container $*
 else
-	exec docker run --privileged $CCACHE_ARGS -u $(id -u):$(id -g) --rm -it -v $here:$here -w $here $container $*
+	exec docker run --privileged $DEF_COMPILER_ARGS $CCACHE_ARGS -u $(id -u):$(id -g) --rm -it -v $here:$here -w $here $container $*
 fi

--- a/unit-test
+++ b/unit-test
@@ -11,6 +11,8 @@ fi
 set -x
 
 build=$(mktemp -d)
+export CC=clang
+export CXX=clang++
 
 echo "## Compiling aklite"
 cmake -S . -B $build -DCMAKE_BUILD_TYPE=Debug -GNinja -DBUILD_P11=ON


### PR DESCRIPTION
- Use clang by default in the dev and test env.
- Fix `aklite-apps` compiling issue if clang is used.