### PR TITLE
aklite: Import pre-provisioned root meta

### DIFF
--- a/src/api.cc
+++ b/src/api.cc
@@ -74,6 +74,7 @@ void AkliteClient::Init(Config& config) {
   }
   client_ = std::make_unique<LiteClient>(config, nullptr);
   if (!read_only_) {
+    client_->importRootMetaIfNeededAndPresent();
     client_->finalizeInstall();
   }
 }

--- a/src/liteclient.h
+++ b/src/liteclient.h
@@ -68,6 +68,9 @@ class LiteClient {
   bool isRollback(const Uptane::Target& target);
 
   void notifyDownloadFinished(const Uptane::Target& t, bool success, const std::string& err_msg = "");
+  std::tuple<bool, boost::filesystem::path> isRootMetaImportNeeded();
+  bool importRootMeta(const boost::filesystem::path& src, Uptane::Version max_ver = Uptane::Version());
+  void importRootMetaIfNeededAndPresent();
 
  private:
   FRIEND_TEST(helpers, locking);

--- a/src/main.cc
+++ b/src/main.cc
@@ -221,6 +221,7 @@ static data::ResultCode::Numeric do_app_sync(LiteClient& client) {
 
 static int update_main(LiteClient& client, const bpo::variables_map& variables_map) {
   FileLock lock;
+  client.importRootMetaIfNeededAndPresent();
   client.finalizeInstall();
   Uptane::HardwareIdentifier hwid(client.config.provision.primary_ecu_hardware_id);
 
@@ -271,6 +272,7 @@ static int daemon_main(LiteClient& client, const bpo::variables_map& variables_m
     return EXIT_FAILURE;
   }
 
+  client.importRootMetaIfNeededAndPresent();
   client.finalizeInstall();
 
   Uptane::HardwareIdentifier hwid(client.config.provision.primary_ecu_hardware_id);
@@ -555,7 +557,7 @@ int main(int argc, char* argv[]) {
     }
 
     Config config(commandline_map);
-    config.storage.uptane_metadata_path = utils::BasedPath(config.storage.path / "metadata");
+
     config.telemetry.report_network = !config.tls.server.empty();
     config.telemetry.report_config = !config.tls.server.empty();
 

--- a/src/offline/client.h
+++ b/src/offline/client.h
@@ -2,6 +2,7 @@
 #define AKTUALIZR_LITE_OFFLINE_CLIENT_H_
 
 #include <boost/filesystem.hpp>
+#include <sstream>
 #include <unordered_map>
 
 #include "libaktualizr/config.h"
@@ -21,6 +22,43 @@ struct UpdateSrc {
 
 enum class PostInstallAction { Undefined = -1, NeedReboot, NeedDockerRestart };
 enum class PostRunAction { Undefined = -1, Ok, RollbackNeedReboot };
+
+class MetaFetcher : public Uptane::IMetadataFetcher {
+ public:
+  class NotFoundException : public std::runtime_error {
+   public:
+    NotFoundException(const std::string& role, const std::string& version)
+        : std::runtime_error("Metadata hasn't been found; role: " + role + "; version: " + version) {}
+  };
+
+ public:
+  MetaFetcher(boost::filesystem::path tuf_repo_path, Uptane::Version max_root_ver = Uptane::Version())
+      : tuf_repo_path_{std::move(tuf_repo_path)}, max_root_ver_{std::move(max_root_ver)} {}
+
+  void fetchRole(std::string* result, int64_t maxsize, Uptane::RepositoryType repo, const Uptane::Role& role,
+                 Uptane::Version version) const override {
+    const boost::filesystem::path meta_file_path{tuf_repo_path_ / version.RoleFileName(role)};
+
+    if (!boost::filesystem::exists(meta_file_path) ||
+        (role == Uptane::Role::Root() && max_root_ver_ != Uptane::Version() && max_root_ver_ < version)) {
+      std::stringstream ver_str;
+      ver_str << version;
+      throw NotFoundException(role.ToString(), ver_str.str());
+    }
+
+    std::ifstream meta_file_stream(meta_file_path.string());
+    *result = {std::istreambuf_iterator<char>(meta_file_stream), std::istreambuf_iterator<char>()};
+  }
+
+  void fetchLatestRole(std::string* result, int64_t maxsize, Uptane::RepositoryType repo,
+                       const Uptane::Role& role) const override {
+    fetchRole(result, maxsize, repo, role, Uptane::Version());
+  }
+
+ private:
+  const boost::filesystem::path tuf_repo_path_;
+  const Uptane::Version max_root_ver_;
+};
 
 namespace client {
 

--- a/tests/fixtures/liteclient/tufrepomock.cc
+++ b/tests/fixtures/liteclient/tufrepomock.cc
@@ -38,6 +38,8 @@ class TufRepoMock {
     return latest_;
   }
 
+  ImageRepo& repo() { return repo_; }
+
  private:
   const boost::filesystem::path root_;
   ImageRepo repo_;

--- a/tests/fixtures/liteclienthsmtest.cc
+++ b/tests/fixtures/liteclienthsmtest.cc
@@ -31,6 +31,7 @@ class ClientHSMTest : public ClientTest {
     conf.storage.tls_clientcert_path = { "" };
     conf.storage.tls_pkey_path = { "" };
     conf.storage.path = test_dir_.Path();
+    conf.storage.uptane_metadata_path = utils::BasedPath(tuf_repo_.getRepoPath());
 
     conf.bootloader.reboot_command = "/bin/true";
     conf.bootloader.reboot_sentinel_dir = conf.storage.path; // note
@@ -171,6 +172,7 @@ class ClientHSMTest : public ClientTest {
     }
 
     auto lite_client = std::make_shared<LiteClient>(conf, app_engine, p11_);
+    lite_client->importRootMetaIfNeededAndPresent();
     lite_client->finalizeInstall();
     return lite_client;
   }


### PR DESCRIPTION
Import pre-provisioned root role metadata from a file system into the
aklite's DB if:
 - no any root meta found in DB;
 - root meta are found on a file system.

The import procedure detects whether it's a prod or CI device and imports correspondent root metadata.