### PR TITLE
Switch to the latest version of libaktualizr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ TASKS = config build format tidy
 
 
 all $(TASKS):
-	docker run -u $(shell id -u):$(shell id -g) --rm -v $(PWD):$(PWD) -w $(PWD) -eCCACHE_DIR=$(CCACHE_DIR) -eCC=$(CC) -eCXX=$(CXX) -eBUILD_DIR=$(BUILD_DIR) -eTARGET=$(TARGET) foundries/aklite-dev make -f dev-flow.mk $@
+	docker run -u $(shell id -u):$(shell id -g) --rm -v $(PWD):$(PWD) -w $(PWD) -eCCACHE_DIR=$(CCACHE_DIR) -eCC=$(CC) -eCXX=$(CXX) -eBUILD_DIR=$(BUILD_DIR) -eTARGET=$(TARGET) $(CONTAINER) make -f dev-flow.mk $@
 
 test:
 	docker run --privileged  --entrypoint="wrapdocker"  --rm -v $(PWD):$(PWD) -w $(PWD) $(CONTAINER) sudo -u testuser TEST_LABEL=$(TEST_LABEL) CTEST_ARGS=$(CTEST_ARGS) BUILD_DIR=$(BUILD_DIR) GTEST_FILTER=$(GTEST_FILTER) make -f dev-flow.mk $@

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,10 +14,10 @@ RUN apt-get update && apt-get -y install --no-install-suggests --no-install-reco
   bison \
   bash \
   ccache \
-  clang-10 \
-  clang-format-10 \
-  clang-tidy-10 \
-  clang-tools-10 \
+  clang-11 \
+  clang-format-11 \
+  clang-tidy-11 \
+  clang-tools-11 \
   cmake \
   curl \
   doxygen \
@@ -75,10 +75,11 @@ RUN apt-get update && apt-get -y install --no-install-suggests --no-install-reco
   xsltproc \
   zip \
   docker-compose \
-  sudo
+  sudo \
+  shellcheck
 
-RUN ln -s clang-10 /usr/bin/clang && \
-    ln -s clang++-10 /usr/bin/clang++
+RUN ln -s clang-11 /usr/bin/clang && \
+    ln -s clang++-11 /usr/bin/clang++
 
 WORKDIR /tmp
 RUN git clone https://github.com/pantoniou/libfyaml.git

--- a/include/aktualizr-lite/api.h
+++ b/include/aktualizr-lite/api.h
@@ -237,7 +237,7 @@ class AkliteClient {
   /**
    * Default files/paths to search for sota toml when configuration client.
    */
-  static std::vector<boost::filesystem::path> CONFIG_DIRS;
+  static const std::vector<boost::filesystem::path> CONFIG_DIRS;
 
  private:
   void Init(Config &config);

--- a/src/api.cc
+++ b/src/api.cc
@@ -2,6 +2,7 @@
 
 #include <sys/file.h>
 #include <unistd.h>
+#include <boost/property_tree/ini_parser.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
 
@@ -11,8 +12,8 @@
 #include "liteclient.h"
 #include "primary/reportqueue.h"
 
-std::vector<boost::filesystem::path> AkliteClient::CONFIG_DIRS = {"/usr/lib/sota/conf.d", "/var/sota/sota.toml",
-                                                                  "/etc/sota/conf.d/"};
+const std::vector<boost::filesystem::path> AkliteClient::CONFIG_DIRS = {"/usr/lib/sota/conf.d", "/var/sota/sota.toml",
+                                                                        "/etc/sota/conf.d/"};
 
 TufTarget CheckInResult::GetLatest(std::string hwid) const {
   if (hwid.empty()) {

--- a/src/docker/composeappengine.h
+++ b/src/docker/composeappengine.h
@@ -98,7 +98,7 @@ class ComposeAppEngine : public AppEngine {
     }
 
    private:
-    std::string version_{""};
+    std::string version_;
     State state_{State::kUnknown};
 
     File version_file_;

--- a/src/docker/docker.cc
+++ b/src/docker/docker.cc
@@ -1,6 +1,8 @@
 #include "docker.h"
+#include <fstream>
 
-#include <boost/algorithm/algorithm.hpp>
+#include <boost/algorithm/hex.hpp>
+#include <boost/algorithm/string/case_conv.hpp>
 
 #include "crypto/crypto.h"
 #include "http/httpclient.h"
@@ -65,7 +67,7 @@ HashedDigest::HashedDigest(const std::string& hash_digest) : digest_{boost::algo
   short_hash_ = hash_.substr(0, 7);
 }
 
-RegistryClient::HttpClientFactory RegistryClient::DefaultHttpClientFactory =
+const RegistryClient::HttpClientFactory RegistryClient::DefaultHttpClientFactory =
     [](const std::vector<std::string>* headers) { return std::make_shared<HttpClient>(headers); };
 
 const std::string RegistryClient::ManifestEndpoint{"/manifests/"};

--- a/src/docker/docker.h
+++ b/src/docker/docker.h
@@ -110,7 +110,7 @@ class RegistryClient {
   static const std::string SupportedRegistryVersion;
 
   using HttpClientFactory = std::function<std::shared_ptr<HttpInterface>(const std::vector<std::string>*)>;
-  static HttpClientFactory DefaultHttpClientFactory;
+  static const HttpClientFactory DefaultHttpClientFactory;
   using Ptr = std::shared_ptr<RegistryClient>;
 
   explicit RegistryClient(std::shared_ptr<HttpInterface> ota_lite_client,

--- a/src/docker/dockerclient.cc
+++ b/src/docker/dockerclient.cc
@@ -7,7 +7,7 @@
 
 namespace Docker {
 
-DockerClient::HttpClientFactory DockerClient::DefaultHttpClientFactory = [](const std::string& docker_host_in) {
+const DockerClient::HttpClientFactory DockerClient::DefaultHttpClientFactory = [](const std::string& docker_host_in) {
   std::string docker_host{docker_host_in};
   auto env{boost::this_process::environment()};
   if (env.end() != env.find("DOCKER_HOST")) {

--- a/src/docker/dockerclient.h
+++ b/src/docker/dockerclient.h
@@ -12,7 +12,7 @@ class DockerClient {
  public:
   using Ptr = std::shared_ptr<DockerClient>;
   using HttpClientFactory = std::function<std::shared_ptr<HttpInterface>(const std::string& docker_host)>;
-  static HttpClientFactory DefaultHttpClientFactory;
+  static const HttpClientFactory DefaultHttpClientFactory;
 
   explicit DockerClient(
       std::shared_ptr<HttpInterface> http_client = DefaultHttpClientFactory("unix:///var/run/docker.sock"));

--- a/src/docker/restorableappengine.cc
+++ b/src/docker/restorableappengine.cc
@@ -4,6 +4,7 @@
 #include <limits>
 #include <unordered_set>
 
+#include <boost/algorithm/hex.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 #include <boost/process.hpp>

--- a/src/liteclient.cc
+++ b/src/liteclient.cc
@@ -17,6 +17,7 @@
 #include "rootfstreemanager.h"
 #include "storage/invstorage.h"
 #include "target.h"
+#include "uptane/exceptions.h"
 #include "uptane/fetcher.h"
 
 LiteClient::LiteClient(Config& config_in, const AppEngine::Ptr& app_engine, const std::shared_ptr<P11EngineGuard>& p11,

--- a/src/main.cc
+++ b/src/main.cc
@@ -2,6 +2,7 @@
 #include <thread>
 #include <unordered_map>
 
+#include <boost/algorithm/string/join.hpp>
 #include <boost/container/flat_map.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/format.hpp>

--- a/src/ostree/sysroot.cc
+++ b/src/ostree/sysroot.cc
@@ -1,4 +1,5 @@
 #include "sysroot.h"
+#include "logging/logging.h"
 
 namespace OSTree {
 

--- a/src/rootfstreemanager.h
+++ b/src/rootfstreemanager.h
@@ -3,6 +3,7 @@
 
 #include "bootloader/bootloaderlite.h"
 #include "downloader.h"
+#include "http/httpinterface.h"
 #include "ostree/sysroot.h"
 #include "package_manager/ostreemanager.h"
 

--- a/src/target.cc
+++ b/src/target.cc
@@ -1,5 +1,6 @@
 #include "target.h"
 
+#include <boost/algorithm/string/join.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -51,7 +51,7 @@ add_aktualizr_test(NAME compose-apps
 )
 
 target_compile_definitions(t_compose-apps PRIVATE ${TEST_DEFS})
-target_include_directories(t_compose-apps PRIVATE ${AKTUALIZR_DIR}/tests ${TEST_INCS})
+target_include_directories(t_compose-apps PRIVATE ${AKTUALIZR_DIR}/tests ${TEST_INCS} ${AKTUALIZR_DIR}/src/)
 target_link_libraries(t_compose-apps ${TEST_LIBS})
 set_tests_properties(test_compose-apps PROPERTIES LABELS "aklite:compose-apps")
 

--- a/tests/composeapp_test.cc
+++ b/tests/composeapp_test.cc
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <boost/filesystem.hpp>
 #include <boost/process.hpp>
+#include <boost/algorithm/hex.hpp>
 
 #include "http/httpclient.h"
 #include "test_utils.h"
@@ -10,6 +11,7 @@
 #include "storage/invstorage.h"
 #include "uptane/fetcher.h"
 #include "http/httpinterface.h"
+#include "libaktualizr/crypto/crypto.h"
 
 #include "composeappmanager.h"
 #include "docker/composeappengine.h"

--- a/tests/fixtures/composeapp.cc
+++ b/tests/fixtures/composeapp.cc
@@ -2,6 +2,8 @@
 #include <random>
 
 #include <boost/optional.hpp>
+#include <boost/algorithm/hex.hpp>
+#include "libaktualizr/crypto/crypto.h"
 
 
 namespace fixtures {

--- a/tests/fixtures/liteclienthsmtest.cc
+++ b/tests/fixtures/liteclienthsmtest.cc
@@ -158,11 +158,11 @@ class ClientHSMTest : public ClientTest {
 
     conf.p11.tls_clientcert_id = subscriber_->certId_;
     conf.p11.tls_pkey_id = subscriber_->keyId_;
-    conf.p11.module = { hsm_->module_.c_str() };
+    conf.p11.module = hsm_->module_.c_str();
     conf.p11.pass = hsm_->pin_;
 
     if (!p11_) {
-      p11_ = std::make_shared<P11EngineGuard>(conf.p11);
+      p11_ = std::make_shared<P11EngineGuard>(conf.p11.module, conf.p11.pass);
     }
 
     if (version == InitialVersion::kOn ||

--- a/tests/fixtures/liteclienttest.cc
+++ b/tests/fixtures/liteclienttest.cc
@@ -1,4 +1,7 @@
 #include "primary/reportqueue.h"
+#include "crypto/p11engine.h"
+#include "http/httpclient.h"
+
 
 namespace fixtures {
 
@@ -407,7 +410,7 @@ class ClientTest :virtual public ::testing::Test {
     // So, if we do the event draining by the queue instance re-creation then we need to fix/improve
     // the Device Gateway mock so it removes even duplicates.
     // sleep(2);
-    client.report_queue = std_::make_unique<ReportQueue>(client.config, client.http_client, client.storage);
+    client.report_queue = std::make_unique<ReportQueue>(client.config, client.http_client, client.storage);
 
     const std::unordered_map<UpdateType, std::vector<std::string>> updateToevents = {
         { UpdateType::kOstree, { "EcuDownloadStarted", "EcuDownloadCompleted", "EcuInstallationStarted", "EcuInstallationApplied", "EcuInstallationCompleted" }},

--- a/tests/liteclientHSM_test.cc
+++ b/tests/liteclientHSM_test.cc
@@ -6,6 +6,7 @@
 #include <boost/process.hpp>
 #include <boost/process/env.hpp>
 
+#include "crypto/p11engine.h"
 #include "libaktualizr/types.h"
 #include "logging/logging.h"
 #include "test_utils.h"


### PR DESCRIPTION
Switch to the latest version of libaktualizr and adjust aklite to it.

Relevant changes in libaktualizr:
- 6fc8e722 Upgrade to clang-format-11 (and friends)
- 388a50eb [fio extras]: add 'length' and 'hashes' to snapshot
- 9d3ee3ae [fio extras]: allow updating meta if the same ver
- 9a298772 Remove STORAGE_TYPE option from CMakeLists and tests
- 068ea357 [fio extras]: httpclient: follow redirects by default
- 1b6e9ae2 http: Remove redundant curl options
- d2ab5e51 Add test for extra keys in root.json
- 3cb7e2a2 scripts: Fix the script to run tests in docker
- caf558b2 docker: Create a home directory of the test user
- 81ab71da crypto: Make the p11 engine singleton within a test suite
- bf0494df Speed up compiles with Include What You Use
- 07937a70 tuf-test-vectors: Test update if metadata version is the same
- 846edc03 Attempt to fix int conversion error found on ARM
- f1002f44 Added default path for pkcs11 for arm