### PR TITLE
aklite: Send Apps status only if changed

### DIFF
--- a/src/composeappmanager.h
+++ b/src/composeappmanager.h
@@ -59,6 +59,7 @@ class ComposeAppManager : public RootfsTreeManager {
   void setAppsNotChecked() { are_apps_checked_ = false; }
   void handleRemovedApps(const Uptane::Target& target) const;
   Json::Value getAppsState() const;
+  static bool compareAppsStates(const Json::Value& left, const Json::Value& right);
 
  private:
   Json::Value getRunningAppsInfo() const;

--- a/src/liteclient.cc
+++ b/src/liteclient.cc
@@ -586,13 +586,18 @@ void LiteClient::reportAppsState() {
     return;
   }
   const auto apps_state{compose_pacman->getAppsState()};
-
   if (apps_state.isNull()) {
     LOG_WARNING << "Failed to obtain Apps state, skipping sending it to Device Gateway";
     return;
   }
+  if (ComposeAppManager::compareAppsStates(apps_state_, apps_state)) {
+    LOG_DEBUG << "Apps state has not changed, skipping sending it to Device Gateway";
+    return;
+  }
   auto resp = http_client->post(config.tls.server + "/apps-states", apps_state);
-  if (!resp.isOk()) {
+  if (resp.isOk()) {
+    apps_state_ = apps_state;
+  } else {
     LOG_WARNING << "Failed to send App states to Device Gateway: " << resp.getStatusStr();
   }
 }

--- a/src/liteclient.h
+++ b/src/liteclient.h
@@ -106,6 +106,7 @@ class LiteClient {
   std::vector<Uptane::Target> no_targets_;
 
   std::shared_ptr<Downloader> downloader_;
+  Json::Value apps_state_;
 };
 
 #endif  // AKTUALIZR_LITE_CLIENT_H_

--- a/tests/composeapp_test.cc
+++ b/tests/composeapp_test.cc
@@ -962,6 +962,58 @@ TEST(ComposeApp, DISABLED_resumeAppUpdate) {
   }
 }
 
+TEST(ComposeApp, AppsStateComparison) {
+  {
+    ASSERT_TRUE(ComposeAppManager::compareAppsStates(Json::Value(), Json::Value()));
+  }
+  {
+    Json::Value new_state;
+    Json::Value cur_state;
+    new_state["deviceTime"] = Json::Value();
+    cur_state["deviceTime"] = Json::Value();
+    ASSERT_TRUE(ComposeAppManager::compareAppsStates(cur_state, new_state));
+   }
+  {
+    Json::Value new_state;
+    new_state["apps"]["app-01"] = Json::Value();
+    ASSERT_FALSE(ComposeAppManager::compareAppsStates(Json::Value(), new_state));
+   }
+   {
+    Json::Value new_state;
+    Json::Value cur_state;
+    new_state["apps"]["app-01"] = Json::Value();
+    cur_state["apps"]["app-02"] = Json::Value();
+
+    ASSERT_FALSE(ComposeAppManager::compareAppsStates(cur_state, new_state));
+   }
+   {
+    Json::Value new_state{Json::Value()};
+    Json::Value cur_state{Json::Value()};
+    new_state["apps"]["app-01"]["state"] = "healthy";
+    cur_state["apps"]["app-01"]["state"] = "unhealthy";
+    ASSERT_FALSE(ComposeAppManager::compareAppsStates(cur_state, new_state));
+   }
+   {
+    Json::Value new_state{Json::Value()};
+    Json::Value cur_state{Json::Value()};
+    new_state["apps"]["app-01"]["state"] = "healthy";
+    new_state["apps"]["app-01"]["uri"] = "123";
+    cur_state["apps"]["app-01"]["state"] = "healthy";
+    cur_state["apps"]["app-01"]["uri"] = "345";
+    ASSERT_FALSE(ComposeAppManager::compareAppsStates(cur_state, new_state));
+   }
+   {
+    Json::Value new_state{Json::Value()};
+    Json::Value cur_state{Json::Value()};
+    cur_state["apps"]["app-01"]["state"] = "healthy";
+    cur_state["apps"]["app-01"]["services"][0] = "";
+    new_state["apps"]["app-01"]["state"] = "healthy";
+    new_state["apps"]["app-01"]["services"][0] = "";
+    new_state["apps"]["app-01"]["services"][1] = "";
+    ASSERT_FALSE(ComposeAppManager::compareAppsStates(cur_state, new_state));
+   }
+}
+
 #ifndef __NO_MAIN__
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Send Apps status to Device Gateway only if it has changed since the last time it was checked.

Signed-off-by: Mike Sul <mike.sul@foundries.io>