### PR TITLE
aklite: Limit event number sent to Device Gateway

### DIFF
--- a/src/liteclient.cc
+++ b/src/liteclient.cc
@@ -107,7 +107,8 @@ LiteClient::LiteClient(Config& config_in, const AppEngine::Ptr& app_engine, cons
   if (!uptane_fetcher_) {
     uptane_fetcher_ = std::make_shared<Uptane::Fetcher>(config, http_client);
   }
-  report_queue = std_::make_unique<ReportQueue>(config, http_client, storage);
+  report_queue = std_::make_unique<ReportQueue>(config, http_client, storage, report_queue_run_pause_s_,
+                                                report_queue_event_limit_);
 
   if (config.pacman.type == ComposeAppManager::Name) {
     package_manager_ = std::make_shared<ComposeAppManager>(config.pacman, config.bootloader, storage, http_client,

--- a/src/liteclient.h
+++ b/src/liteclient.h
@@ -107,6 +107,8 @@ class LiteClient {
 
   std::shared_ptr<Downloader> downloader_;
   Json::Value apps_state_;
+  const int report_queue_run_pause_s_{10};
+  const int report_queue_event_limit_{6};
 };
 
 #endif  // AKTUALIZR_LITE_CLIENT_H_

--- a/tests/fixtures/liteclienttest.cc
+++ b/tests/fixtures/liteclienttest.cc
@@ -410,7 +410,7 @@ class ClientTest :virtual public ::testing::Test {
     // So, if we do the event draining by the queue instance re-creation then we need to fix/improve
     // the Device Gateway mock so it removes even duplicates.
     // sleep(2);
-    client.report_queue = std::make_unique<ReportQueue>(client.config, client.http_client, client.storage);
+    client.report_queue = std::make_unique<ReportQueue>(client.config, client.http_client, client.storage, 0, 1);
 
     const std::unordered_map<UpdateType, std::vector<std::string>> updateToevents = {
         { UpdateType::kOstree, { "EcuDownloadStarted", "EcuDownloadCompleted", "EcuInstallationStarted", "EcuInstallationApplied", "EcuInstallationCompleted" }},
@@ -423,7 +423,7 @@ class ClientTest :virtual public ::testing::Test {
     const std::vector<std::string>& expected_events{updateToevents.at(update_type)};
     auto expected_event_it = expected_events.begin();
     // wait a bit to make sure all events arrive at Device Gateway before making the following call
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
     auto events = getDeviceGateway().getEvents();
     ASSERT_EQ(expected_events.size(), events.size());
     for (auto rec_event_it = events.begin(); rec_event_it != events.end(); ++rec_event_it) {


### PR DESCRIPTION
- Add ability to limit a number of events to include into a single
  request to Device Gateway.
- Limit event number sent in a single HTTP POST /events request.
- Handle 413 response to HTTP POST /events request by re-trying with
  fewer events in a body until just one event is sent.
- If 413 to a request that carries just one event then just drop the
  event and stop trying to send it.
- Add unit tests for the aforementioned functionality.



Signed-off-by: Mike Sul <mike.sul@foundries.io>