### PR TITLE
rootfstreemanager: make sure to call updateNotify and installNotify

### DIFF
--- a/src/rootfstreemanager.cc
+++ b/src/rootfstreemanager.cc
@@ -75,6 +75,39 @@ void RootfsTreeManager::installNotify(const Uptane::Target& target) {
   OstreeManager::installNotify(target);
 }
 
+data::InstallationResult RootfsTreeManager::install(const Uptane::Target& target) const {
+  data::InstallationResult res;
+  Uptane::Target current = OstreeManager::getCurrent();
+  // Do ostree install if the currently installed target's hash differs from the specified target's hash,
+  // or there is pending installation and it differs from the specified target so we undeploy it and make the new target
+  // pending
+  if ((current.sha256Hash() != target.sha256Hash()) ||
+      (!sysroot()->getDeploymentHash(OSTree::Sysroot::Deployment::kPending).empty() &&
+       sysroot()->getDeploymentHash(OSTree::Sysroot::Deployment::kPending) != target.sha256Hash())) {
+    // notify the bootloader before installation happens as it is not atomic
+    // and a false notification doesn't hurt with rollback support in place
+    // Hacking in order to invoke non-const method from the const one !!!
+    const_cast<RootfsTreeManager*>(this)->updateNotify();
+    res = OstreeManager::install(target);
+    if (res.result_code.num_code == data::ResultCode::Numeric::kInstallFailed) {
+      LOG_ERROR << "Failed to install OSTree target";
+      return res;
+    }
+    const_cast<RootfsTreeManager*>(this)->installNotify(target);
+    if (current.sha256Hash() == target.sha256Hash() &&
+        res.result_code.num_code == data::ResultCode::Numeric::kNeedCompletion) {
+      LOG_INFO << "Successfully undeployed the pending failing Target";
+      LOG_INFO << "Target " << target.sha256Hash() << " is same as current";
+      res = data::InstallationResult(data::ResultCode::Numeric::kOk, "OSTree hash already installed, same as current");
+    }
+  } else {
+    LOG_INFO << "Target " << target.sha256Hash() << " is same as current";
+    res = data::InstallationResult(data::ResultCode::Numeric::kOk, "OSTree hash already installed, same as current");
+  }
+
+  return res;
+}
+
 void RootfsTreeManager::getAdditionalRemotes(std::vector<Remote>& remotes, const std::string& target_name) {
   const auto resp = http_client_->post(gateway_url_ + "/download-urls", Json::Value::null);
 

--- a/src/rootfstreemanager.h
+++ b/src/rootfstreemanager.h
@@ -35,6 +35,7 @@ class RootfsTreeManager : public OstreeManager, public Downloader {
 
  protected:
   void installNotify(const Uptane::Target& target) override;
+  data::InstallationResult install(const Uptane::Target& target) const override;
   const std::shared_ptr<OSTree::Sysroot>& sysroot() const { return sysroot_; }
 
  private:


### PR DESCRIPTION
This fixes the setting of bootloader variables when using:
type = ostree

Signed-off-by: Michael Scott <mike@foundries.io>