### PR TITLE
Test the bootloader flag management and ostree package manager

### DIFF
--- a/src/bootloader/bootloaderlite.cc
+++ b/src/bootloader/bootloaderlite.cc
@@ -3,8 +3,9 @@
 #include "rollbacks/factory.h"
 #include "storage/invstorage.h"
 
-BootloaderLite::BootloaderLite(BootloaderConfig config, INvStorage& storage)
-    : Bootloader(std::move(config), storage), rollback_(RollbackFactory::makeRollback(config_.rollback_mode)) {}
+BootloaderLite::BootloaderLite(BootloaderConfig config, INvStorage& storage, const std::string& deployment_path)
+    : Bootloader(std::move(config), storage),
+      rollback_(RollbackFactory::makeRollback(config_.rollback_mode, deployment_path)) {}
 
 void BootloaderLite::setBootOK() const { rollback_->setBootOK(); }
 

--- a/src/bootloader/bootloaderlite.h
+++ b/src/bootloader/bootloaderlite.h
@@ -9,7 +9,7 @@ class INvStorage;
 
 class BootloaderLite : public Bootloader {
  public:
-  explicit BootloaderLite(BootloaderConfig config, INvStorage& storage);
+  explicit BootloaderLite(BootloaderConfig config, INvStorage& storage, const std::string& deployment_path);
 
   void setBootOK() const override;
   void updateNotify() const override;

--- a/src/bootloader/rollbackfactory.cc
+++ b/src/bootloader/rollbackfactory.cc
@@ -4,7 +4,7 @@
 #include "rollbacks/generic.h"
 #include "rollbacks/masked.h"
 
-std::unique_ptr<Rollback> RollbackFactory::makeRollback(RollbackMode mode) {
+std::unique_ptr<Rollback> RollbackFactory::makeRollback(RollbackMode mode, const std::string& deployment_path) {
   switch (mode) {
     case RollbackMode::kBootloaderNone:
       return std::make_unique<Rollback>();
@@ -13,10 +13,10 @@ std::unique_ptr<Rollback> RollbackFactory::makeRollback(RollbackMode mode) {
       return std::make_unique<GenericRollback>();
       break;
     case RollbackMode::kUbootMasked:
-      return std::make_unique<MaskedRollback>();
+      return std::make_unique<MaskedRollback>(deployment_path);
       break;
     case RollbackMode::kFioVB:
-      return std::make_unique<FiovbRollback>();
+      return std::make_unique<FiovbRollback>(deployment_path);
       break;
     default:
       return std::make_unique<ExceptionRollback>();

--- a/src/bootloader/rollbacks/factory.h
+++ b/src/bootloader/rollbacks/factory.h
@@ -6,7 +6,7 @@
 
 class RollbackFactory {
  public:
-  static std::unique_ptr<Rollback> makeRollback(RollbackMode mode);
+  static std::unique_ptr<Rollback> makeRollback(RollbackMode mode, const std::string& deployment_path);
 };
 
 #endif  // AKTUALIZR_LITE_ROLLBACK_FACTORY_H_

--- a/src/bootloader/rollbacks/fiovb.h
+++ b/src/bootloader/rollbacks/fiovb.h
@@ -6,6 +6,8 @@
 
 class FiovbRollback : public Rollback {
  public:
+  explicit FiovbRollback(const std::string& deployment_path) : Rollback(deployment_path) {}
+
   void setBootOK() override {
     std::string sink;
     if (Utils::shell("fiovb_setenv bootcount 0", &sink) != 0) {

--- a/src/bootloader/rollbacks/masked.h
+++ b/src/bootloader/rollbacks/masked.h
@@ -6,6 +6,8 @@
 
 class MaskedRollback : public Rollback {
  public:
+  explicit MaskedRollback(const std::string& deployment_path) : Rollback(deployment_path) {}
+
   void setBootOK() override {
     std::string sink;
     if (Utils::shell("fw_setenv bootcount 0", &sink) != 0) {

--- a/src/bootloader/rollbacks/rollback.h
+++ b/src/bootloader/rollbacks/rollback.h
@@ -13,7 +13,10 @@
 
 class Rollback {
  public:
-  Rollback() = default;
+  constexpr static const char* const VersionFile{"/usr/lib/firmware/version.txt"};
+
+  explicit Rollback(std::string deployment_dir = "/ostree/deploy/lmp/deploy/")
+      : deployment_dir_{std::move(deployment_dir)} {}
   virtual ~Rollback() = default;
   Rollback(const Rollback&) = delete;
   Rollback(Rollback&&) = delete;
@@ -25,16 +28,16 @@ class Rollback {
   virtual void installNotify(const Uptane::Target& target) { (void)target; }
 
  protected:
-  static std::string getVersion(const Uptane::Target& target) {
+  std::string getVersion(const Uptane::Target& target) {
     try {
       std::string file;
-      for (auto& p : boost::filesystem::directory_iterator("/ostree/deploy/lmp/deploy/")) {
+      for (auto& p : boost::filesystem::directory_iterator(deployment_dir_)) {
         std::string dir = p.path().string();
         if (!boost::filesystem::is_directory(dir)) {
           continue;
         }
         if (boost::algorithm::contains(dir, target.sha256Hash())) {
-          file = dir + "/usr/lib/firmware/version.txt";
+          file = dir + VersionFile;
           break;
         }
       }
@@ -61,6 +64,9 @@ class Rollback {
       return "";
     }
   }
+
+ private:
+  const std::string deployment_dir_;
 };
 
 #endif  // AKTUALIZR_LITE_ROLLBACK_H_

--- a/src/ostree/sysroot.cc
+++ b/src/ostree/sysroot.cc
@@ -4,7 +4,10 @@
 namespace OSTree {
 
 Sysroot::Sysroot(std::string sysroot_path, BootedType booted, std::string os_name)
-    : path_{std::move(sysroot_path)}, booted_{booted}, os_name_{std::move(os_name)} {
+    : path_{std::move(sysroot_path)},
+      booted_{booted},
+      os_name_{std::move(os_name)},
+      deployment_path_{path_ + "/ostree/deploy/" + os_name_ + "/deploy"} {
   sysroot_ = OstreeManager::LoadSysroot(path_);
 }
 

--- a/src/ostree/sysroot.h
+++ b/src/ostree/sysroot.h
@@ -15,6 +15,7 @@ class Sysroot {
   explicit Sysroot(std::string sysroot_path, BootedType booted = BootedType::kBooted, std::string os_name = "lmp");
 
   const std::string& path() const { return path_; }
+  const std::string& deployment_path() const { return deployment_path_; }
 
   virtual std::string getDeploymentHash(Deployment deployment_type) const;
   bool reload();
@@ -28,6 +29,7 @@ class Sysroot {
   const std::string path_;
   const BootedType booted_;
   const std::string os_name_;
+  const std::string deployment_path_;
 
   GObjectUniquePtr<OstreeSysroot> sysroot_;
 };

--- a/src/rootfstreemanager.h
+++ b/src/rootfstreemanager.h
@@ -22,7 +22,8 @@ class RootfsTreeManager : public OstreeManager, public Downloader {
   RootfsTreeManager(const PackageConfig& pconfig, const BootloaderConfig& bconfig,
                     const std::shared_ptr<INvStorage>& storage, const std::shared_ptr<HttpInterface>& http,
                     std::shared_ptr<OSTree::Sysroot> sysroot, const KeyManager& keys)
-      : OstreeManager(pconfig, bconfig, storage, http, new BootloaderLite(bconfig, *storage)),
+      : OstreeManager(pconfig, bconfig, storage, http,
+                      new BootloaderLite(bconfig, *storage, sysroot->deployment_path())),
         sysroot_{std::move(sysroot)},
         http_client_{http},
         gateway_url_{pconfig.ostree_server},

--- a/tests/fixtures/liteclient/fiovb.cc
+++ b/tests/fixtures/liteclient/fiovb.cc
@@ -1,0 +1,31 @@
+class FioVb {
+ public:
+  FioVb(const boost::filesystem::path& dir):dir_{dir} {
+    const std::string path{dir.string()};
+    setenv("PATH", (path + ":" + getenv("PATH")).c_str(), 1);
+    const auto script_file{dir / "fiovb_setenv"};
+    // Create `fiovb_setenv` mock dynamically.
+    // It stores bootloader variable values in corresponding files. Then unit tests can read and check the variable values.
+    Utils::writeFile(script_file, boost::str(boost::format(script_) % dir_));
+    boost::filesystem::permissions(script_file, boost::filesystem::status(script_file).permissions() | boost::filesystem::perms::owner_exe);
+  }
+
+  int bootcount() const {
+   return std::stoi(Utils::readFile(dir_/"bootcount"));
+  }
+  int upgrade_available() const {
+   return std::stoi(Utils::readFile(dir_/"upgrade_available"));
+  }
+  int rollback() const {
+   return std::stoi(Utils::readFile(dir_/"rollback"));
+  }
+  int bootupgrade_available() const {
+   return std::stoi(Utils::readFile(dir_/"bootupgrade_available"));
+  }
+
+ private:
+  const boost::filesystem::path dir_;
+  static const std::string script_;
+};
+
+const std::string FioVb::script_ = "#!/bin/bash\n\n echo ${2} > %s/${1}";

--- a/tests/fixtures/liteclienthsmtest.cc
+++ b/tests/fixtures/liteclienthsmtest.cc
@@ -35,6 +35,7 @@ class ClientHSMTest : public ClientTest {
 
     conf.bootloader.reboot_command = "/bin/true";
     conf.bootloader.reboot_sentinel_dir = conf.storage.path; // note
+    conf.bootloader.rollback_mode = RollbackMode::kFioVB;
 
     conf.uptane.repo_server = device_gateway_.getTufRepoUri();
 

--- a/tests/fixtures/liteclienttest.cc
+++ b/tests/fixtures/liteclienttest.cc
@@ -41,6 +41,7 @@ class ClientTest :virtual public ::testing::Test {
   virtual std::shared_ptr<LiteClient> createLiteClient(InitialVersion initial_version = InitialVersion::kOn,
                                                        boost::optional<std::vector<std::string>> apps = boost::none,
                                                        bool finalize = true) = 0;
+  virtual void tweakConf(Config& conf) {};
 
   /**
    * method createLiteClient
@@ -155,6 +156,7 @@ class ClientTest :virtual public ::testing::Test {
       getTufRepo().addTarget(initial_target_.filename(), initial_target_.sha256Hash(), hw_id, "1");
     }
 
+    tweakConf(conf);
     auto client = std::make_shared<LiteClient>(conf, app_engine);
     // Recreate the report queue with the configuration needed for tests, specifically:
     // - make the worker thread not to wait before reading from DB and sending to DG the next set of events;

--- a/tests/fixtures/liteclienttest.cc
+++ b/tests/fixtures/liteclienttest.cc
@@ -149,9 +149,9 @@ class ClientTest :virtual public ::testing::Test {
     }
 
     auto client = std::make_shared<LiteClient>(conf, app_engine);
-	// Recreate the report queue with the configuration needed for tests, specifically:
-	// - make the worker thread not to wait before reading from DB and sending to DG the next set of events;
-	// - make the report queue include just one event in a single request to DG.
+    // Recreate the report queue with the configuration needed for tests, specifically:
+    // - make the worker thread not to wait before reading from DB and sending to DG the next set of events;
+    // - make the report queue include just one event in a single request to DG.
     client->report_queue = std::make_unique<ReportQueue>(client->config, client->http_client, client->storage, 0, 1);
 
     // import root metadata
@@ -414,8 +414,8 @@ class ClientTest :virtual public ::testing::Test {
     };
     const std::vector<std::string>& expected_events{updateToevents.at(update_type)};
     auto expected_event_it = expected_events.begin();
-	// drain all events to DG by recreating the report queue instance
-	client.report_queue = std::make_unique<ReportQueue>(client.config, client.http_client, client.storage, 0, 1);
+    // drain all events to DG by recreating the report queue instance
+    client.report_queue = std::make_unique<ReportQueue>(client.config, client.http_client, client.storage, 0, 1);
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
     auto events = getDeviceGateway().getEvents();
     ASSERT_EQ(expected_events.size(), events.size()) << events;

--- a/tests/liteclient_test.cc
+++ b/tests/liteclient_test.cc
@@ -76,11 +76,16 @@ class LiteClientTest : public fixtures::ClientTest {
   std::shared_ptr<NiceMock<MockAppEngine>> app_engine_mock_;
 };
 
+class LiteClientTestMultiPacman : public LiteClientTest, public ::testing::WithParamInterface<std::string> {
+ protected:
+  void tweakConf(Config& conf) override { conf.pacman.type = GetParam(); };
+};
+
 /*----------------------------------------------------------------------------*/
 /*  TESTS                                                                     */
 /*                                                                            */
 /*----------------------------------------------------------------------------*/
-TEST_F(LiteClientTest, OstreeUpdateWhenNoInstalledVersions) {
+TEST_P(LiteClientTestMultiPacman, OstreeUpdateWhenNoInstalledVersions) {
   // boot device with no installed versions
   auto client = createLiteClient(InitialVersion::kOff);
   ASSERT_TRUE(targetsMatch(client->getCurrent(), getInitialTarget()));
@@ -102,7 +107,7 @@ TEST_F(LiteClientTest, OstreeUpdateWhenNoInstalledVersions) {
   checkHeaders(*client, new_target);
 }
 
-TEST_F(LiteClientTest, OstreeUpdateInstalledVersionsCorrupted1) {
+TEST_P(LiteClientTestMultiPacman, OstreeUpdateInstalledVersionsCorrupted1) {
   // boot device with an invalid initial_version json file (ostree sha)
   auto client = createLiteClient(InitialVersion::kCorrupted1);
 
@@ -125,7 +130,7 @@ TEST_F(LiteClientTest, OstreeUpdateInstalledVersionsCorrupted1) {
   checkHeaders(*client, new_target);
 }
 
-TEST_F(LiteClientTest, OstreeUpdateInstalledVersionsCorrupted2) {
+TEST_P(LiteClientTestMultiPacman, OstreeUpdateInstalledVersionsCorrupted2) {
   // boot device with a corrupted json file in the filesystem
   auto client = createLiteClient(InitialVersion::kCorrupted2);
 
@@ -148,7 +153,7 @@ TEST_F(LiteClientTest, OstreeUpdateInstalledVersionsCorrupted2) {
   checkHeaders(*client, new_target);
 }
 
-TEST_F(LiteClientTest, OstreeUpdate) {
+TEST_P(LiteClientTestMultiPacman, OstreeUpdate) {
   // boot device
   auto client = createLiteClient();
   ASSERT_TRUE(targetsMatch(client->getCurrent(), getInitialTarget()));
@@ -163,7 +168,7 @@ TEST_F(LiteClientTest, OstreeUpdate) {
   checkHeaders(*client, new_target);
 }
 
-TEST_F(LiteClientTest, OstreeUpdateNoSpace) {
+TEST_P(LiteClientTestMultiPacman, OstreeUpdateNoSpace) {
   // boot device
   auto client = createLiteClient();
   ASSERT_TRUE(targetsMatch(client->getCurrent(), getInitialTarget()));
@@ -181,7 +186,7 @@ TEST_F(LiteClientTest, OstreeUpdateNoSpace) {
   checkHeaders(*client, getInitialTarget());
 }
 
-TEST_F(LiteClientTest, OstreeUpdateRollback) {
+TEST_P(LiteClientTestMultiPacman, OstreeUpdateRollback) {
   // boot device
   auto client = createLiteClient();
   ASSERT_TRUE(targetsMatch(client->getCurrent(), getInitialTarget()));
@@ -210,7 +215,7 @@ TEST_F(LiteClientTest, OstreeUpdateRollback) {
   checkHeaders(*client, new_target_03);
 }
 
-TEST_F(LiteClientTest, OstreeUpdateToLatestAfterManualUpdate) {
+TEST_P(LiteClientTestMultiPacman, OstreeUpdateToLatestAfterManualUpdate) {
   // boot device
   auto client = createLiteClient();
   ASSERT_TRUE(targetsMatch(client->getCurrent(), getInitialTarget()));
@@ -436,7 +441,7 @@ TEST_F(LiteClientTest, CheckEmptyTargets) {
   ASSERT_GT(client->allTargets().size(), 0);
 }
 
-TEST_F(LiteClientTest, OstreeUpdateIfSameVersion) {
+TEST_P(LiteClientTestMultiPacman, OstreeUpdateIfSameVersion) {
   // boot device
   auto client = createLiteClient();
   ASSERT_TRUE(targetsMatch(client->getCurrent(), getInitialTarget()));
@@ -462,6 +467,9 @@ TEST_F(LiteClientTest, OstreeUpdateIfSameVersion) {
     checkHeaders(*client, target_01_1);
   }
 }
+
+INSTANTIATE_TEST_SUITE_P(MultiPacmanType, LiteClientTestMultiPacman,
+                         ::testing::Values(RootfsTreeManager::Name, ComposeAppManager::Name));
 
 /*
  * main

--- a/tests/liteclient_test.cc
+++ b/tests/liteclient_test.cc
@@ -91,8 +91,9 @@ TEST_P(LiteClientTestMultiPacman, OstreeUpdateWhenNoInstalledVersions) {
   ASSERT_TRUE(targetsMatch(client->getCurrent(), getInitialTarget()));
 
   // Create a new Target: update rootfs and commit it into Treehub's repo
-  auto new_target = createTarget();
-  update(*client, getInitialTarget(), new_target);
+  auto new_target = createTarget(nullptr, "", "", boost::none, "", "no_bootfirmware_update");
+  update(*client, getInitialTarget(), new_target, data::ResultCode::Numeric::kNeedCompletion,
+         {DownloadResult::Status::Ok, ""}, "", false);
 
   // check there is still no target
   auto req_headers = getDeviceGateway().getReqHeaders();


### PR DESCRIPTION
- Enable testing of the bootloader flag management in each liteclient test.
- Enable testing of the `ostree` package manager along with the composite one (`ostree+compose_apps`).