### PR TITLE
Image and container pruning

### DIFF
--- a/src/appengine.h
+++ b/src/appengine.h
@@ -22,6 +22,8 @@ class AppEngine {
     virtual const Json::Value& engineInfo() const = 0;
     virtual const std::string& arch() const = 0;
     virtual Json::Value getRunningApps(const std::function<void(const std::string&, Json::Value&)>& ext_func) = 0;
+    virtual void pruneImages() = 0;
+    virtual void pruneContainers() = 0;
 
     virtual ~Client() = default;
     Client(const Client&&) = delete;

--- a/src/containerd/client.cc
+++ b/src/containerd/client.cc
@@ -56,6 +56,21 @@ const std::string& Client::arch() const {
   // It's needed only for restorable Apps
   throw std::runtime_error("Arch obtaining is not implemented for containerd");
 }
+
+void Client::pruneImages() {
+  // https://github.com/containerd/nerdctl/issues/648
+  // Allegedly the prune cmd is supported in nerdctl v0.22.0, currently, LmP runs 0.18.0
+  // Also, I tried v0.22.0 and it doesn't work for me...
+  LOG_ERROR << "Image prunning is not supported in nerdctl";
+}
+
+void Client::pruneContainers() {
+  // https://github.com/containerd/nerdctl/issues/648
+  // Allegedly the prune cmd is supported in nerdctl v0.22.0, currently, LmP runs 0.18.0
+  // Also, I tried v0.22.0 and it doesn't work for me...
+  LOG_ERROR << "Container prunning is not supported in nerdctl";
+}
+
 Json::Value Client::getRunningApps(const std::function<void(const std::string&, Json::Value&)>& /* ext_func */) {
   Json::Value apps;
   Json::Value containers;

--- a/src/containerd/client.h
+++ b/src/containerd/client.h
@@ -16,6 +16,8 @@ class Client : public AppEngine::Client {
   const Json::Value& engineInfo() const override;
   const std::string& arch() const override;
   Json::Value getRunningApps(const std::function<void(const std::string&, Json::Value&)>& ext_func) override;
+  void pruneImages() override;
+  void pruneContainers() override;
 
  private:
   const std::string nerdctl_;

--- a/src/docker/composeappengine.cc
+++ b/src/docker/composeappengine.cc
@@ -385,17 +385,15 @@ void ComposeAppEngine::extractAppArchive(const App& app, const std::string& arch
   }
 }
 
-void ComposeAppEngine::pruneDockerStore() {
-  LOG_INFO << "Pruning unused docker containers";
-  if (std::system("docker container prune -f --filter=\"label!=aktualizr-no-prune\"") != 0) {
-    LOG_WARNING << "Unable to prune unused docker containers";
-  }
+void ComposeAppEngine::pruneDockerStore(AppEngine::Client& client) {
+  try {
+    LOG_INFO << "Pruning unused docker containers";
+    client.pruneContainers();
 
-  LOG_INFO << "Pruning unused docker images";
-  // Utils::shell which isn't interactive, we'll use std::system so that
-  // stdout/stderr is streamed while docker sets things up.
-  if (std::system("docker image prune -a -f --filter=\"label!=aktualizr-no-prune\"") != 0) {
-    LOG_WARNING << "Unable to prune unused docker images";
+    LOG_INFO << "Pruning unused docker images";
+    client.pruneImages();
+  } catch (const std::exception& exc) {
+    LOG_ERROR << exc.what();
   }
 }
 

--- a/src/docker/composeappengine.h
+++ b/src/docker/composeappengine.h
@@ -30,10 +30,10 @@ class ComposeAppEngine : public AppEngine {
   Json::Value getRunningAppsInfo() const override;
   void prune(const Apps& app_shortlist) override {
     (void)app_shortlist;
-    pruneDockerStore();
+    pruneDockerStore(*client_);
   }
 
-  static void pruneDockerStore();
+  static void pruneDockerStore(AppEngine::Client& client);
 
  protected:
   virtual void pullImages(const App& app);

--- a/src/docker/dockerclient.cc
+++ b/src/docker/dockerclient.cc
@@ -123,6 +123,31 @@ Json::Value DockerClient::getRunningApps(const std::function<void(const std::str
   return apps;
 }
 
+void DockerClient::pruneImages() {
+  // curl -G -X POST --unix-socket <sock> "http://localhost/images/prune" --data-urlencode
+  // 'filters={"dangling":{"false":true},"label!":{"aktualizr-no-prune":true}}'
+  // filters=%7B%22dangling%22%3A%7B%22false%22%3Atrue%7D%2C%22label%21%22%3A%7B%22aktualizr-no-prune%22%3Atrue%7D%7D
+  const std::string cmd{
+      "http://localhost/images/"
+      "prune?filters=%7B%22dangling%22%3A%7B%22false%22%3Atrue%7D%2C%22label%21%22%3A%7B%22aktualizr-no-prune%22%"
+      "3Atrue%7D%7D"};
+  auto resp = http_client_->post(cmd, Json::nullValue);
+  if (!resp.isOk()) {
+    throw std::runtime_error("Failed to prune unused images: " + resp.getStatusStr());
+  }
+}
+void DockerClient::pruneContainers() {
+  // curl -G -X POST --unix-socket <sock> "http://localhost/containers/prune" --data-urlencode
+  // 'filters={"label!":{"aktualizr-no-prune":true}}'
+  // filters=%7B%22label%21%22%3A%7B%22aktualizr-no-prune%22%3Atrue%7D%7D
+  const std::string cmd{
+      "http://localhost/containers/prune?filters=%7B%22label%21%22%3A%7B%22aktualizr-no-prune%22%3Atrue%7D%7D"};
+  auto resp = http_client_->post(cmd, Json::nullValue);
+  if (!resp.isOk()) {
+    throw std::runtime_error("Failed to prune unused containers: " + resp.getStatusStr());
+  }
+}
+
 Json::Value DockerClient::getEngineInfo() {
   Json::Value info;
   const std::string cmd{"http://localhost/version"};

--- a/src/docker/dockerclient.h
+++ b/src/docker/dockerclient.h
@@ -25,6 +25,8 @@ class DockerClient : public AppEngine::Client {
   const Json::Value& engineInfo() const override { return engine_info_; }
   const std::string& arch() const override { return arch_; }
   Json::Value getRunningApps(const std::function<void(const std::string&, Json::Value&)>& ext_func) override;
+  void pruneImages() override;
+  void pruneContainers() override;
 
  private:
   Json::Value getEngineInfo();

--- a/src/docker/restorableappengine.cc
+++ b/src/docker/restorableappengine.cc
@@ -357,7 +357,7 @@ void RestorableAppEngine::prune(const Apps& app_shortlist) {
 
   // prune docker store
   if (prune_docker_store) {
-    ComposeAppEngine::pruneDockerStore();
+    ComposeAppEngine::pruneDockerStore(*docker_client_);
   }
 }
 

--- a/tests/docker-daemon_fake.py
+++ b/tests/docker-daemon_fake.py
@@ -37,14 +37,15 @@ class Handler(SimpleHTTPRequestHandler):
     def do_POST(self):
         logger.info(">>> POST  %s" % self.path)
 
-        while True:
-            line = self.rfile.readline().strip()
-            chunk_length = int(line, 16)
-            if chunk_length == 0:
-                break
+        if not (self.path.startswith('/containers/prune') or self.path.startswith('/images/prune')):
+            while True:
+                line = self.rfile.readline().strip()
+                chunk_length = int(line, 16)
+                if chunk_length == 0:
+                    break
 
-            self.rfile.read(chunk_length)
-            self.rfile.readline()
+                self.rfile.read(chunk_length)
+                self.rfile.readline()
 
         self.send_response(200)
         self.end_headers()


### PR DESCRIPTION
appengine: Move pruning to an engine client impl
    
Don't call the image and container pruning commands directly from an app
engine. Instead, do it indirectly via the app engine client interface.
A specific implementation of the pruning is encapsulated within a
specific implementation of a container engine client.
