### PR TITLE
bootloader: Inc the boot update flag if new firmware is found

### DIFF
--- a/src/bootloader/rollbacks/fiovb.h
+++ b/src/bootloader/rollbacks/fiovb.h
@@ -41,13 +41,13 @@ class FiovbRollback : public Rollback {
       LOG_WARNING << "Failed to read bootfirmware_version";
       sink = std::string();
     }
-    LOG_INFO << "Current firmware version: " << sink;
-    if (sink != version) {
-      LOG_INFO << "Update firmware to version: " << version;
-      if (Utils::shell("fiovb_setenv bootupgrade_available 1", &sink) != 0) {
-        LOG_WARNING << "Failed to set bootupgrade_available";
-      }
+    LOG_INFO << "Current bootfirmware version: " << sink;
+    if (sink == version) {
+      LOG_INFO << "No new bootfirmware version is found";
+      return;
     }
+    LOG_INFO << "New bootfirmware is found: " << version;
+    increaseBootUpgradeAvailable("fiovb_printenv", "fiovb_setenv");
   }
 };
 

--- a/src/bootloader/rollbacks/masked.h
+++ b/src/bootloader/rollbacks/masked.h
@@ -41,13 +41,13 @@ class MaskedRollback : public Rollback {
       LOG_WARNING << "Failed to read bootfirmware_version";
       return;
     }
-    LOG_INFO << "Current boot firmware version: " << sink;
-    if (sink != version) {
-      LOG_INFO << "Update firmware to version: " << version;
-      if (Utils::shell("fw_setenv bootupgrade_available 1", &sink) != 0) {
-        LOG_WARNING << "Failed to set bootupgrade_available";
-      }
+    LOG_INFO << "Current bootfirmware version: " << sink;
+    if (sink == version) {
+      LOG_INFO << "No new bootfirmware version is found";
+      return;
     }
+    LOG_INFO << "New bootfirmware is found: " << version;
+    increaseBootUpgradeAvailable("fw_printenv -n", "fw_setenv");
   }
 };
 

--- a/src/bootloader/rollbacks/rollback.h
+++ b/src/bootloader/rollbacks/rollback.h
@@ -65,6 +65,26 @@ class Rollback {
     }
   }
 
+  static void increaseBootUpgradeAvailable(const std::string& get_cmd, const std::string& set_cmd) {
+    std::string ba_str{"0"};
+    if (Utils::shell(get_cmd + " bootupgrade_available", &ba_str) != 0) {
+      LOG_WARNING << "Failed to read bootupgrade_available, assume it is set to 0";
+    }
+    int bootupgrade_available{0};
+    try {
+      bootupgrade_available = std::stoi(ba_str);
+    } catch (const std::exception& exc) {
+      LOG_ERROR << "Failed to convert `bootupgrade_available` value: " << exc.what() << "; assume it is set to 0";
+    }
+    ++bootupgrade_available;
+    std::string sink;
+    if (Utils::shell(set_cmd + " bootupgrade_available " + std::to_string(bootupgrade_available), &sink) == 0) {
+      LOG_INFO << "bootupgrade_available is set to " << bootupgrade_available;
+    } else {
+      LOG_WARNING << "Failed to set bootupgrade_available";
+    }
+  }
+
  private:
   const std::string deployment_dir_;
 };


### PR DESCRIPTION
Increase `bootupgrade_available` value if a new version of the bootfirmware is found.
Assume that `bootupgrade_available` is set to `0` if a failure to read or convert to integer happens.

Signed-off-by: Mike Sul <mike.sul@foundries.io>