### PR TITLE
Compare boot frmware versions to unset or increase the boot upgrade flag

### DIFF
--- a/src/bootloader/bootloaderlite.cc
+++ b/src/bootloader/bootloaderlite.cc
@@ -9,10 +9,12 @@
 
 namespace bootloader {
 
-std::string getVersion(const std::string& deployment_dir, const std::string& ver_file, const std::string& hash);
-
-BootloaderLite::BootloaderLite(BootloaderConfig config, INvStorage& storage, OSTree::Sysroot::Ptr sysroot)
-    : Bootloader(std::move(config), storage), sysroot_{std::move(sysroot)} {}
+BootloaderLite::BootloaderLite(BootloaderConfig config, INvStorage& storage, OSTree::Sysroot::Ptr sysroot,
+                               std::string ver_file_path, std::string ver_title)
+    : Bootloader(std::move(config), storage),
+      sysroot_{std::move(sysroot)},
+      ver_file_path_{std::move(ver_file_path)},
+      ver_title_{std::move(ver_title)} {}
 
 void BootloaderLite::installNotify(const Uptane::Target& target) const {
   std::string sink;
@@ -20,81 +22,125 @@ void BootloaderLite::installNotify(const Uptane::Target& target) const {
     case RollbackMode::kBootloaderNone:
     case RollbackMode::kUbootGeneric:
       break;
-    case RollbackMode::kUbootMasked: {
-      std::string version = getVersion(sysroot_->deployment_path(), VersionFile, target.sha256Hash());
-      if (version.empty()) {
-        return;
-      }
-      std::string sink;
-      if (Utils::shell("fw_printenv -n bootfirmware_version", &sink) != 0) {
-        LOG_WARNING << "Failed to read bootfirmware_version";
-        return;
-      }
-      LOG_INFO << "Current boot firmware version: " << sink;
-      if (sink != version) {
-        LOG_INFO << "Update firmware to version: " << version;
-        if (Utils::shell("fw_setenv bootupgrade_available 1", &sink) != 0) {
-          LOG_WARNING << "Failed to set bootupgrade_available";
-        }
-      }
-    } break;
-    case RollbackMode::kFioVB: {
-      std::string version = getVersion(sysroot_->deployment_path(), VersionFile, target.sha256Hash());
-      if (version.empty()) {
-        return;
-      }
-      std::string sink;
-      if (Utils::shell("fiovb_printenv bootfirmware_version", &sink) != 0) {
-        LOG_WARNING << "Failed to read bootfirmware_version";
-        sink = std::string();
-      }
-      LOG_INFO << "Current firmware version: " << sink;
-      if (sink != version) {
-        LOG_INFO << "Update firmware to version: " << version;
-        if (Utils::shell("fiovb_setenv bootupgrade_available 1", &sink) != 0) {
-          LOG_WARNING << "Failed to set bootupgrade_available";
-        }
-      }
-    } break;
+    case RollbackMode::kUbootMasked:
+      setBootUpgradeFlag(target.sha256Hash(), {"fw_printenv -n", "fw_setenv"});
+      break;
+    case RollbackMode::kFioVB:
+      setBootUpgradeFlag(target.sha256Hash(), {"fiovb_printenv", "fiovb_setenv"});
+      break;
     default:
       throw NotImplementedException();
   }
 }
 
-std::string getVersion(const std::string& deployment_dir, const std::string& ver_file, const std::string& hash) {
-  try {
-    std::string file;
-    for (auto& p : boost::filesystem::directory_iterator(deployment_dir)) {
-      std::string dir = p.path().string();
-      if (!boost::filesystem::is_directory(dir)) {
-        continue;
-      }
-      if (boost::algorithm::contains(dir, hash)) {
-        file = dir + ver_file;
-        break;
-      }
-    }
-    if (file.empty()) {
-      LOG_WARNING << "Target hash not found";
-      return std::string();
-    }
+void BootloaderLite::setBootUpgradeFlag(const std::string& hash, const GetSetCmd&& cmd) const {
+  const auto new_ver{getVersion(sysroot_->deployment_path(), ver_file_path_, ver_title_, hash)};
+  if (!new_ver.empty()) {
+    LOG_INFO << "New Target's bootfirmware version: " << new_ver;
+  }
+  const auto cur_ver{readVersion(sysroot_->path() + ver_file_path_, ver_title_)};
+  if (!cur_ver.empty()) {
+    LOG_INFO << "Current bootfirmware version: " << cur_ver;
+  }
 
-    LOG_INFO << "Target firmware file: " << file;
-    std::ifstream ifs(file);
-    std::string version((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
-    std::string watermark = "bootfirmware_version";
-    std::string::size_type i = version.find(watermark);
+  int bootupgrade_available{readBootUpgradeAvailable(std::get<0>(cmd))};
+
+  if (!new_ver.empty() && new_ver != cur_ver) {
+    // If a new Target includes a boot firmware (`version.txt` is present and  contains correct version value),
+    // and the boot fw version is different from the current fw version, then increase `bootupgrade_available`.
+
+    LOG_INFO << "Increasing a value of the bootloader flag `bootupgrade_available` to indicate that "
+             << "the new bootfirmware version is available;"
+             << " current: " << (cur_ver.empty() ? "unknown" : cur_ver)
+             << " new: " << (new_ver.empty() ? "unknown" : new_ver);
+
+    LOG_INFO << "Current `bootupgrade_available`: " << bootupgrade_available;
+    ++bootupgrade_available;
+    LOG_INFO << "Setting `bootupgrade_available` to: " << bootupgrade_available;
+    setBootUpgradeAvailable(std::get<1>(cmd), bootupgrade_available);
+    return;
+  }
+
+  if (bootupgrade_available == 0) {
+    return;
+  }
+
+  std::string sink;
+  LOG_INFO
+      << "Decreasing a value of the bootloader flag `bootupgrade_available` since no new bootfirmware version found;"
+      << " current: " << (cur_ver.empty() ? "unknown" : cur_ver)
+      << " new Target's: " << (new_ver.empty() ? "unknown" : new_ver);
+  LOG_INFO << "Current `bootupgrade_available`: " << bootupgrade_available;
+  --bootupgrade_available;
+  LOG_INFO << "Setting `bootupgrade_available` to: " << bootupgrade_available;
+  setBootUpgradeAvailable(std::get<1>(cmd), bootupgrade_available);
+}
+
+boost::filesystem::path findVersionFileInDeployment(const std::string& deployment_dir, const std::string& ver_file_path,
+                                                    const std::string& deployment_hash) {
+  boost::filesystem::path found_depl_ver_file;
+  for (auto& p : boost::filesystem::directory_iterator(deployment_dir)) {
+    if (!boost::filesystem::is_directory(p)) {
+      continue;
+    }
+    if (boost::algorithm::starts_with(p.path().filename().string(), deployment_hash)) {
+      found_depl_ver_file = p / ver_file_path;
+      break;
+    }
+  }
+  return found_depl_ver_file;
+}
+
+std::string BootloaderLite::getVersion(const std::string& deployment_dir, const std::string& ver_file_path,
+                                       const std::string& ver_title, const std::string& hash) {
+  std::string res_ver;
+  try {
+    const auto ver_file{findVersionFileInDeployment(deployment_dir, ver_file_path, hash)};
+    if (ver_file.empty()) {
+      LOG_INFO << "Bootfirmware version file has not been found in the Target's deployment; "
+               << "deployment dir: " << deployment_dir << "; hash: " << hash;
+      return "";
+    }
+    res_ver = readVersion(ver_file, ver_title);
+  } catch (const std::exception& exc) {
+    LOG_ERROR << "Failed to get a bootfirmware version: " << exc.what();
+  }
+  return res_ver;
+}
+
+std::string BootloaderLite::readVersion(const boost::filesystem::path& ver_file, const std::string& ver_title) {
+  std::string res_ver;
+  try {
+    const auto ver_str{Utils::readFile(ver_file)};
+    std::string::size_type i = ver_str.find(ver_title);
     if (i != std::string::npos) {
-      version.erase(i, watermark.length() + 1);
-      LOG_INFO << "Target firmware version: " << version;
-      return version;
-    } else {
-      LOG_WARNING << "Target firmware version not found";
-      return std::string();
+      res_ver = ver_str.substr(i + ver_title.size() + 1);
     }
   } catch (const std::exception& exc) {
-    LOG_ERROR << "Failed to obtain Target firmware version:  " << exc.what();
-    return "";
+    LOG_ERROR << "Failed to read a bootfirmware version from the file: " << ver_file << "; err: " << exc.what();
+  }
+  return res_ver;
+}
+
+int BootloaderLite::readBootUpgradeAvailable(const std::string& get_cmd) {
+  int bootupgrade_available{0};
+  std::string ba_str{"0"};
+
+  try {
+    if (Utils::shell(get_cmd + " bootupgrade_available", &ba_str) != 0) {
+      LOG_ERROR << "Failed to read bootupgrade_available, assume it is set to 0";
+    }
+    bootupgrade_available = std::stoi(ba_str);
+  } catch (const std::exception& exc) {
+    LOG_ERROR << "Failed to get `bootupgrade_available` value: " << exc.what() << "; assume it is set to 0";
+  }
+  return bootupgrade_available;
+}
+
+void BootloaderLite::setBootUpgradeAvailable(const std::string& set_cmd, int val) {
+  std::string sink;
+  if (Utils::shell(set_cmd + " bootupgrade_available " + std::to_string(val), &sink) != 0) {
+    LOG_ERROR << "Failed to set bootupgrade_available";
   }
 }
 

--- a/src/bootloader/bootloaderlite.h
+++ b/src/bootloader/bootloaderlite.h
@@ -12,13 +12,27 @@ namespace bootloader {
 class BootloaderLite : public Bootloader {
  public:
   static constexpr const char* const VersionFile{"/usr/lib/firmware/version.txt"};
+  static constexpr const char* const VersionTitle{"bootfirmware_version"};
 
-  explicit BootloaderLite(BootloaderConfig config, INvStorage& storage, OSTree::Sysroot::Ptr sysroot);
+  explicit BootloaderLite(BootloaderConfig config, INvStorage& storage, OSTree::Sysroot::Ptr sysroot,
+                          std::string ver_file_path = VersionFile, std::string ver_title = VersionTitle);
 
   void installNotify(const Uptane::Target& target) const override;
 
+  static std::string getVersion(const std::string& deployment_dir, const std::string& ver_file_path,
+                                const std::string& ver_title, const std::string& hash);
+  static std::string readVersion(const boost::filesystem::path& ver_file, const std::string& ver_title);
+  static int readBootUpgradeAvailable(const std::string& get_cmd);
+  static void setBootUpgradeAvailable(const std::string& set_cmd, int val);
+
  private:
+  using GetSetCmd = std::tuple<std::string, std::string>;
+
+  void setBootUpgradeFlag(const std::string& hash, const GetSetCmd&& cmd) const;
+
   OSTree::Sysroot::Ptr sysroot_;
+  const std::string ver_file_path_;
+  const std::string ver_title_;
 };
 
 }  // namespace bootloader

--- a/tests/fixtures/liteclient/boot_flag_mgr.cc
+++ b/tests/fixtures/liteclient/boot_flag_mgr.cc
@@ -33,6 +33,10 @@ class BootFlagMgr {
    return std::stoi(Utils::readFile(dir_/"bootupgrade_available"));
   }
 
+  void set_bootupgrade_available(int val) {
+    Utils::writeFile(dir_/"bootupgrade_available", std::to_string(val));
+  }
+
  private:
   const boost::filesystem::path dir_;
 };

--- a/tests/liteclient_test.cc
+++ b/tests/liteclient_test.cc
@@ -92,8 +92,7 @@ TEST_P(LiteClientTestMultiPacman, OstreeUpdateWhenNoInstalledVersions) {
 
   // Create a new Target: update rootfs and commit it into Treehub's repo
   auto new_target = createTarget(nullptr, "", "", boost::none, "", "no_bootfirmware_update");
-  update(*client, getInitialTarget(), new_target, data::ResultCode::Numeric::kNeedCompletion,
-         {DownloadResult::Status::Ok, ""}, "", false);
+  update(*client, getInitialTarget(), new_target);
 
   // check there is still no target
   auto req_headers = getDeviceGateway().getReqHeaders();


### PR DESCRIPTION
Change the way the value of the bootloader flag `bootupgrade_available`
is defined just after successful Target/ostree installation.
    
    - Read the current boot fw version from the rootfs that a device
      is currently booted on, instead of getting it from the boot flag.
    
    - If the boot fw version found in the new ostree deployment is
      different than the current one, then increase `bootupgrade_available`.
    
    - If the boot fw version found in the new ostree deployment is
      the same as the current then decrease `bootupgrade_available`,
      unless it's already equal zero.


Signed-off-by: Mike Sul <mike.sul@foundries.io>