### PR TITLE
boot: Block update if boot fw update is in progress

### DIFF
--- a/src/bootloader/bootloaderlite.h
+++ b/src/bootloader/bootloaderlite.h
@@ -9,7 +9,21 @@ class INvStorage;
 
 namespace bootloader {
 
-class BootloaderLite : public Bootloader {
+class BootFwUpdateStatus {
+ public:
+  BootFwUpdateStatus(const BootFwUpdateStatus&) = delete;
+  BootFwUpdateStatus& operator=(const BootFwUpdateStatus&) = delete;
+  BootFwUpdateStatus& operator=(BootFwUpdateStatus&&) = delete;
+  virtual ~BootFwUpdateStatus() = default;
+
+  virtual bool isUpdateInProgress() const = 0;
+
+ protected:
+  BootFwUpdateStatus() = default;
+  BootFwUpdateStatus(BootFwUpdateStatus&&) = default;
+};
+
+class BootloaderLite : public Bootloader, public BootFwUpdateStatus {
  public:
   static constexpr const char* const VersionFile{"/usr/lib/firmware/version.txt"};
 
@@ -17,7 +31,11 @@ class BootloaderLite : public Bootloader {
 
   void installNotify(const Uptane::Target& target) const override;
 
+  bool isUpdateInProgress() const override;
+
  private:
+  static int readBootUpgradeAvailable(const std::string& get_cmd);
+
   OSTree::Sysroot::Ptr sysroot_;
 };
 

--- a/src/rootfstreemanager.h
+++ b/src/rootfstreemanager.h
@@ -21,13 +21,7 @@ class RootfsTreeManager : public OstreeManager, public Downloader {
 
   RootfsTreeManager(const PackageConfig& pconfig, const BootloaderConfig& bconfig,
                     const std::shared_ptr<INvStorage>& storage, const std::shared_ptr<HttpInterface>& http,
-                    std::shared_ptr<OSTree::Sysroot> sysroot, const KeyManager& keys)
-      : OstreeManager(pconfig, bconfig, storage, http, new bootloader::BootloaderLite(bconfig, *storage, sysroot)),
-        sysroot_{std::move(sysroot)},
-        boot_fw_update_status_{new bootloader::BootloaderLite(bconfig, *storage, sysroot)},
-        http_client_{http},
-        gateway_url_{pconfig.ostree_server},
-        keys_{keys} {}
+                    std::shared_ptr<OSTree::Sysroot> sysroot, const KeyManager& keys);
 
   DownloadResult Download(const TufTarget& target) override;
 
@@ -52,6 +46,9 @@ class RootfsTreeManager : public OstreeManager, public Downloader {
   std::unique_ptr<bootloader::BootFwUpdateStatus> boot_fw_update_status_;
   std::shared_ptr<HttpInterface> http_client_;
   const std::string gateway_url_;
+  // A flag enabling/disabling ostree update blocking if there is ongoing boot firmware update
+  // that requires confirmation by means of reboot.
+  bool update_block_{true};
 };
 
 #endif  // AKTUALIZR_LITE_ROOTFS_TREE_MANAGER_H_

--- a/src/rootfstreemanager.h
+++ b/src/rootfstreemanager.h
@@ -24,6 +24,7 @@ class RootfsTreeManager : public OstreeManager, public Downloader {
                     std::shared_ptr<OSTree::Sysroot> sysroot, const KeyManager& keys)
       : OstreeManager(pconfig, bconfig, storage, http, new bootloader::BootloaderLite(bconfig, *storage, sysroot)),
         sysroot_{std::move(sysroot)},
+        boot_fw_update_status_{new bootloader::BootloaderLite(bconfig, *storage, sysroot)},
         http_client_{http},
         gateway_url_{pconfig.ostree_server},
         keys_{keys} {}
@@ -48,6 +49,7 @@ class RootfsTreeManager : public OstreeManager, public Downloader {
 
   const KeyManager& keys_;
   std::shared_ptr<OSTree::Sysroot> sysroot_;
+  std::unique_ptr<bootloader::BootFwUpdateStatus> boot_fw_update_status_;
   std::shared_ptr<HttpInterface> http_client_;
   const std::string gateway_url_;
 };

--- a/tests/aklite_rollback_test.cc
+++ b/tests/aklite_rollback_test.cc
@@ -150,7 +150,8 @@ TEST_P(AkliteTest, RollbackIfOstreeInstallFails) {
     auto target_02 = createTarget(&apps, "", broken_rootfs_dir.PathString());
 
     // try to update to the latest version, it must fail because the target's rootfs is invalid (no kernel)
-    update(*client, target_01, target_02, data::ResultCode::Numeric::kInstallFailed, {DownloadResult::Status::Ok, ""});
+    update(*client, target_01, target_02, data::ResultCode::Numeric::kInstallFailed, {DownloadResult::Status::Ok, ""},
+           "Failed to find kernel", false);
 
     // emulate next iteration/update cycle of daemon_main
     client->checkForUpdatesBegin();

--- a/tests/fixtures/liteclient/boot_flag_mgr.cc
+++ b/tests/fixtures/liteclient/boot_flag_mgr.cc
@@ -33,6 +33,10 @@ class BootFlagMgr {
    return std::stoi(Utils::readFile(dir_/"bootupgrade_available"));
   }
 
+  void reset_bootupgrade_available() {
+    Utils::writeFile(dir_/"bootupgrade_available", std::string("0"));
+  }
+
  private:
   const boost::filesystem::path dir_;
 };

--- a/tests/fixtures/liteclienttest.cc
+++ b/tests/fixtures/liteclienttest.cc
@@ -81,6 +81,7 @@ class ClientTest :virtual public ::testing::Test {
     conf.bootloader.reboot_command = "/bin/true";
     conf.bootloader.reboot_sentinel_dir = conf.storage.path;
     conf.bootloader.rollback_mode = RollbackMode::kFioVB;
+    conf.pacman.extra["ostree_update_block"] = "0";
     conf.import.base_path = test_dir_ / "import";
 
     if (initial_version == InitialVersion::kOn || initial_version == InitialVersion::kCorrupted1 ||

--- a/tests/liteclient_test.cc
+++ b/tests/liteclient_test.cc
@@ -231,7 +231,8 @@ TEST_P(LiteClientTestMultiPacman, OstreeUpdateToLatestAfterManualUpdate) {
   checkHeaders(*client, new_target);
 
   // emulate manuall update to the previous version
-  update(*client, new_target, getInitialTarget());
+  update(*client, new_target, getInitialTarget(), data::ResultCode::Numeric::kNeedCompletion,
+         {DownloadResult::Status::Ok, ""}, "", false);
 
   // reboot device and make sure that the previous version is installed
   reboot(client);


### PR DESCRIPTION
Ban ostree update if there is ongoing boot fw update and implicitly initiate device reboot by returning the `need completion` return code. The reboot is need to confirm and finalize the boot fw update.

Signed-off-by: Mike Sul <mike.sul@foundries.io>