### PR TITLE
aklite-offline: Support update if no Apps or dockerless system

### DIFF
--- a/apps/aklite-offline/cmds.cpp
+++ b/apps/aklite-offline/cmds.cpp
@@ -14,13 +14,19 @@ int InstallCmd::installUpdate(const Config& cfg_in, const boost::filesystem::pat
     switch (install_res) {
       case offline::PostInstallAction::NeedReboot: {
         ret_code = 100;
-        std::cout << "Please reboot a device and run `run` command to apply installation and start the updated Apps\n";
+        std::cout << "Please reboot a device and run `run` command to apply installation and start the updated Apps "
+                     "(unless no Apps to update or dockerless system)\n";
         break;
       }
       case offline::PostInstallAction::NeedDockerRestart: {
         std::cout << "Please restart `docker` service `systemctl restart docker` and run `run` command to start the "
                      "updated Apps\n";
         ret_code = 101;
+        break;
+      }
+      case offline::PostInstallAction::AlreadyInstalled: {
+        std::cout << "The given Target has been already installed\n";
+        ret_code = EXIT_SUCCESS;
         break;
       }
       default:
@@ -40,7 +46,7 @@ int RunCmd::runUpdate(const Config& cfg_in) const {
     const auto run_res = offline::client::run(cfg_in);
     switch (run_res) {
       case offline::PostRunAction::Ok: {
-        LOG_INFO << "Successfully applied new version of rootfs and started Apps";
+        LOG_INFO << "Successfully applied new version of rootfs and started Apps if present";
         ret_code = 0;
         break;
       }

--- a/src/offline/client.cc
+++ b/src/offline/client.cc
@@ -133,7 +133,7 @@ static std::unique_ptr<LiteClient> createOfflineClient(const Config& cfg_in, con
 
   ComposeAppManager::Config pacman_cfg(cfg.pacman);
   std::string compose_cmd{pacman_cfg.compose_bin.string()};
-  if (pacman_cfg.compose_bin.filename().compare("docker") == 0) {
+  if (boost::filesystem::exists(pacman_cfg.compose_bin) && pacman_cfg.compose_bin.filename().compare("docker") == 0) {
     compose_cmd = boost::filesystem::canonical(pacman_cfg.compose_bin).string() + " ";
     // if it is a `docker` binary then turn it into ` the  `docker compose` command
     // and make sure that the `compose` is actually supported by a given `docker` utility.

--- a/src/offline/client.h
+++ b/src/offline/client.h
@@ -20,7 +20,7 @@ struct UpdateSrc {
   std::string TargetName;
 };
 
-enum class PostInstallAction { Undefined = -1, NeedReboot, NeedDockerRestart };
+enum class PostInstallAction { Undefined = -1, NeedReboot, NeedDockerRestart, AlreadyInstalled };
 enum class PostRunAction { Undefined = -1, Ok, RollbackNeedReboot };
 
 class MetaFetcher : public Uptane::IMetadataFetcher {


### PR DESCRIPTION
Make sure the docker client path/file exists before its usage.

1. This is workaround to make the `aklite-offline` work on a device that does not include `/usr/bin/docker` but has `dockerd`.

2. More accurate support of just ostree update if docker installed or no Apps are present in the offline update content.

Signed-off-by: Mike Sul <mike.sul@foundries.io>