### PR TITLE
aklite-offline: Check the docker client path

### DIFF
--- a/src/offline/client.cc
+++ b/src/offline/client.cc
@@ -133,7 +133,7 @@ static std::unique_ptr<LiteClient> createOfflineClient(const Config& cfg_in, con
 
   ComposeAppManager::Config pacman_cfg(cfg.pacman);
   std::string compose_cmd{pacman_cfg.compose_bin.string()};
-  if (pacman_cfg.compose_bin.filename().compare("docker") == 0) {
+  if (boost::filesystem::exists(pacman_cfg.compose_bin) && pacman_cfg.compose_bin.filename().compare("docker") == 0) {
     compose_cmd = boost::filesystem::canonical(pacman_cfg.compose_bin).string() + " ";
     // if it is a `docker` binary then turn it into ` the  `docker compose` command
     // and make sure that the `compose` is actually supported by a given `docker` utility.


### PR DESCRIPTION
Make sure the docker client path/file exists before its usage.

This is workaround to make the aklite-offline work on a device that does not include /usr/bin/docker but has dockerd.

Signed-off-by: Mike Sul <mike.sul@foundries.io>