### PR TITLE
Stop updated containers before reboot

### DIFF
--- a/src/api.cc
+++ b/src/api.cc
@@ -172,9 +172,7 @@ TufTarget AkliteClient::GetCurrent() const {
   return TufTarget(current.filename(), current.sha256Hash(), ver, current.custom_data());
 }
 
-std::string AkliteClient::GetDeviceID() const {
-  return client_->getDeviceID();
-}
+std::string AkliteClient::GetDeviceID() const { return client_->getDeviceID(); }
 
 class LiteInstall : public InstallContext {
  public:


### PR DESCRIPTION
Stop the updated containers before reboot so they are not automatically
started by `dockerd` just after reboot. `aklite` is going to re-create
and start them during the update finalization.
