### PR TITLE
apps: Docker pull images just after App install

### DIFF
--- a/include/aktualizr-lite/api.h
+++ b/include/aktualizr-lite/api.h
@@ -84,6 +84,7 @@ class InstallResult {
     Ok = 0,
     NeedsCompletion,
     Failed,
+    DownloadFailed,
   };
   Status status;
   std::string description;
@@ -164,7 +165,6 @@ class DeviceResult {
   std::string owner;
   std::string repo_id;
 };
-
 
 /**
  * AkliteClient provides an easy-to-use API for users wanting to customize

--- a/src/api.cc
+++ b/src/api.cc
@@ -47,6 +47,8 @@ std::ostream& operator<<(std::ostream& os, const InstallResult& res) {
     os << "NeedsCompletion/";
   } else if (res.status == InstallResult::Status::Failed) {
     os << "Failed/";
+  } else if (res.status == InstallResult::Status::DownloadFailed) {
+    os << "DownloadFailed/";
   }
   os << res.description;
   return os;
@@ -207,6 +209,8 @@ class LiteInstall : public InstallContext {
     } else if (rc == data::ResultCode::Numeric::kOk) {
       client_->http_client->updateHeader("x-ats-target", target_->filename());
       status = InstallResult::Status::Ok;
+    } else if (rc == data::ResultCode::Numeric::kDownloadFailed) {
+      status = InstallResult::Status::DownloadFailed;
     }
     return InstallResult{status, ""};
   }

--- a/src/appengine.h
+++ b/src/appengine.h
@@ -45,6 +45,7 @@ class AppEngine {
       OK = 0,
       Failed,
       InsufficientSpace,
+      ImagePullFailure,
     };
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
     Result(bool var, std::string errMsg = "") : status{var ? ID::OK : ID::Failed}, err{std::move(errMsg)} {}
@@ -52,6 +53,7 @@ class AppEngine {
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
     operator bool() const { return status == ID::OK; }
     bool noSpace() const { return status == ID::InsufficientSpace; }
+    bool imagePullFailure() const { return status == ID::ImagePullFailure; }
 
     ID status;
     std::string err;

--- a/src/composeappmanager.cc
+++ b/src/composeappmanager.cc
@@ -347,7 +347,9 @@ data::InstallationResult ComposeAppManager::install(const Uptane::Target& target
                                               pair.first % pair.second % run_res.err)};
         LOG_ERROR << err_desc;
 
-        res = data::InstallationResult(data::ResultCode::Numeric::kInstallFailed, err_desc);
+        res = data::InstallationResult(run_res.imagePullFailure() ? data::ResultCode::Numeric::kDownloadFailed
+                                                                  : data::ResultCode::Numeric::kInstallFailed,
+                                       err_desc);
       } else {
         res.description += "\n" + pair.second;
       }
@@ -423,7 +425,9 @@ data::InstallationResult ComposeAppManager::finalizeInstall(const Uptane::Target
         // this is a hack to distinguish between ostree install (rollback) and App start failures.
         // data::ResultCode::Numeric::kInstallFailed - boot on a new ostree version failed (rollback at boot)
         // data::ResultCode::Numeric::kCustomError - boot on a new version was successful but new App failed to start
-        return data::InstallationResult(data::ResultCode::Numeric::kCustomError, ir.description);
+        return data::InstallationResult(run_res.imagePullFailure() ? data::ResultCode::Numeric::kDownloadFailed
+                                                                   : data::ResultCode::Numeric::kCustomError,
+                                        ir.description);
       }
     }
     handleRemovedApps(target);

--- a/src/docker/restorableappengine.h
+++ b/src/docker/restorableappengine.h
@@ -111,7 +111,7 @@ class RestorableAppEngine : public AppEngine {
                      const boost::filesystem::path& dst_dir);
 
   // install App&Images
-  Result installAndCreateContainers(const App& app);
+  Result installAndCreateOrRunContainers(const App& app, bool run = false);
   Result installContainerless(const App& app);
   boost::filesystem::path installAppAndImages(const App& app);
   static void installApp(const boost::filesystem::path& app_dir, const boost::filesystem::path& dst_dir);

--- a/src/docker/restorableappengine.h
+++ b/src/docker/restorableappengine.h
@@ -139,6 +139,8 @@ class RestorableAppEngine : public AppEngine {
                            const std::string& tag, const std::string& format = "v2s2");
 
   static void verifyComposeApp(const std::string& compose_cmd, const boost::filesystem::path& app_dir);
+  static void pullComposeAppImages(const std::string& compose_cmd, const boost::filesystem::path& app_dir,
+                                   const std::string& flags = "--no-parallel");
   static void startComposeApp(const std::string& compose_cmd, const boost::filesystem::path& app_dir,
                               const std::string& flags = "up --remove-orphans -d");
 

--- a/src/liteclient.cc
+++ b/src/liteclient.cc
@@ -620,6 +620,9 @@ data::ResultCode::Numeric LiteClient::install(const Uptane::Target& target) {
   } else if (iresult.result_code.num_code == data::ResultCode::Numeric::kOk) {
     LOG_INFO << "Update complete. No reboot needed";
     storage->savePrimaryInstalledVersion(target, InstalledVersionUpdateMode::kCurrent);
+  } else if (iresult.result_code.num_code == data::ResultCode::Numeric::kDownloadFailed) {
+    LOG_INFO << "Apps installation failed while the install process was trying to fetch App images data,"
+                " will try the install again at the next update cycle.";
   } else {
     LOG_ERROR << "Unable to install update: " << iresult.description;
     LOG_ERROR << "Marking " << target.filename() << " as a failing Target";

--- a/tests/fixtures/dockerdaemon.cc
+++ b/tests/fixtures/dockerdaemon.cc
@@ -8,6 +8,7 @@ class DockerDaemon {
  public:
   // tests/docker-compose_fake.py fills/populates this file with "running" containers
   static constexpr const char* const ContainersFile{"containers.json"};
+  static constexpr const char* const ImagePullFailFlag{"image-pull-fails"};
  public:
   // run two processes, one (http) is needed for the test business logic, another one (unix) to mock docker daemon
   // since there are spots in the code where the `docker` CLI is invoked directly.
@@ -37,6 +38,14 @@ class DockerDaemon {
   bool areContainersCreated() const {
     const std::string cur_containers{Utils::readFile(dir_ / ContainersFile)};
     return !(cur_containers == none_containers_);
+  }
+
+  void setImagePullFailFlag(bool fail) {
+    if (fail) {
+      Utils::writeFile(dir_ / ImagePullFailFlag, std::string(""));
+    } else {
+      boost::filesystem::remove(dir_ / ImagePullFailFlag);
+    }
   }
 
 

--- a/tests/restorableappengine_test.cc
+++ b/tests/restorableappengine_test.cc
@@ -284,7 +284,11 @@ TEST_F(RestorableAppEngineTest, FetchAndInstall) {
   ASSERT_TRUE(app_engine->isFetched(app));
   ASSERT_TRUE(app_engine->verify(app));
   ASSERT_FALSE(app_engine->isRunning(app));
-  ASSERT_TRUE(app_engine->install(app));
+  daemon_.setImagePullFailFlag(true);
+  ASSERT_FALSE(app_engine->install(app));
+  daemon_.setImagePullFailFlag(false);
+  const auto install_res{app_engine->install(app)};
+  ASSERT_EQ(install_res, true) << install_res.err;
   ASSERT_FALSE(app_engine->isRunning(app));
 }
 
@@ -293,7 +297,12 @@ TEST_F(RestorableAppEngineTest, FetchAndRun) {
   ASSERT_TRUE(app_engine->fetch(app));
   ASSERT_TRUE(app_engine->isFetched(app));
   ASSERT_TRUE(app_engine->verify(app));
-  ASSERT_TRUE(app_engine->run(app));
+  daemon_.setImagePullFailFlag(true);
+  ASSERT_FALSE(app_engine->run(app));
+  ASSERT_FALSE(app_engine->isRunning(app));
+  daemon_.setImagePullFailFlag(false);
+  const auto run_res{app_engine->run(app)};
+  ASSERT_EQ(run_res, true) << run_res.err;
   ASSERT_TRUE(app_engine->isRunning(app));
 }
 


### PR DESCRIPTION
Run `docker-compose pull` for each installed App before creating or starting App. The pull command updates the docker store so it becomes aware of the App images. As result, the following `compose up` command won't require network connection to pull any App image data. It helps to distinguish between networking errors and pure container creation or start errors. The first one is NOT critical hence aklite should continue trying to install App. The second error type is critical and aklite should mark corresponding Target as "failing" in such the case.

Signed-off-by: Mike Sul <mike.sul@foundries.io>