### PR TITLE
Invoke callback just before install finalization

### DIFF
--- a/src/liteclient.cc
+++ b/src/liteclient.cc
@@ -170,6 +170,7 @@ bool LiteClient::finalizeInstall() {
   // finalize pending installs
   storage->loadInstalledVersions("", nullptr, &pending);
   if (!!pending) {
+    callback("install-final-pre", *pending);
     ret = finalizePendingUpdate(pending);
   } else {
     LOG_INFO << "No Pending Installs";


### PR DESCRIPTION
Add a new callback and invoke it just before running the install finalization procedure. It allows clients to be notified about the beginning of the final stage of the update installation that happens just after reboot.

Signed-off-by: Mike Sul <mike.sul@foundries.io>