### PR TITLE
offline-client: Return 404 if requested blob is missing

### DIFF
--- a/src/docker/docker.cc
+++ b/src/docker/docker.cc
@@ -182,7 +182,8 @@ std::string RegistryClient::getAppManifest(const Uri& uri, const std::string& fo
   }
 
   if (!manifest_resp.isOk()) {
-    throw std::runtime_error("Failed to download App manifest: " + manifest_resp.getStatusStr());
+    throw std::runtime_error("Failed to download App manifest: " + manifest_resp.getStatusStr() + "; " +
+                             manifest_resp.body);
   }
 
   if (!!manifest_size) {

--- a/src/offline/client.cc
+++ b/src/offline/client.cc
@@ -95,6 +95,10 @@ class OfflineRegistry : public BaseHttpClient {
     }
     const auto hash_pos{digest_pos + hash_prefix.size()};
     const auto hash{url.substr(hash_pos)};
+    const auto blob_path{blobs_dir_ / hash};
+    if (!boost::filesystem::exists(blob_path)) {
+      return HttpResponse("The app blob is missing: " + blob_path.string(), 404, CURLE_OK, "Not found");
+    }
     return HttpResponse(Utils::readFile(blobs_dir_ / hash), 200, CURLE_OK, "");
   }
 


### PR DESCRIPTION
Return HTTP 404 with the file path if the requested App blob is missing in the specified source directory.