### PR TITLE
offline: Fix dockerless system support

### DIFF
--- a/src/offline/client.h
+++ b/src/offline/client.h
@@ -63,11 +63,8 @@ class MetaFetcher : public Uptane::IMetadataFetcher {
 namespace client {
 
 PostInstallAction install(const Config& cfg_in, const UpdateSrc& src,
-                          std::shared_ptr<HttpInterface> docker_client_http_client =
-                              Docker::DockerClient::DefaultHttpClientFactory("unix:///var/run/docker.sock"));
-PostRunAction run(const Config& cfg_in,
-                  std::shared_ptr<HttpInterface> docker_client_http_client =
-                      Docker::DockerClient::DefaultHttpClientFactory("unix:///var/run/docker.sock"));
+                          std::shared_ptr<HttpInterface> docker_client_http_client = nullptr);
+PostRunAction run(const Config& cfg_in, std::shared_ptr<HttpInterface> docker_client_http_client = nullptr);
 
 }  // namespace client
 }  // namespace offline


### PR DESCRIPTION
Don't initialize and pass around the docker client's default http client within the offline updater, instead, do nothing as the docker client initializes the default one by itself if no custom http client is specified in its ctor.