### PR TITLE
offline: Don't pull images at App start

### DIFF
--- a/apps/aklite-apps/cmds.cpp
+++ b/apps/aklite-apps/cmds.cpp
@@ -172,8 +172,19 @@ int RunCmd::runApps(const std::vector<std::string>& shortlist, const std::string
   auto http_client = std::make_shared<HttpClient>();
   auto docker_client{std::make_shared<Docker::DockerClient>()};
   auto registry_client{std::make_shared<Docker::RegistryClient>(http_client, "")};
-  Docker::RestorableAppEngine app_engine{store_root,    compose_root, docker_root, registry_client,
-                                         docker_client, client,       docker_host, compose_client};
+  Docker::RestorableAppEngine app_engine{
+      store_root,
+      compose_root,
+      docker_root,
+      registry_client,
+      docker_client,
+      client,
+      docker_host,
+      compose_client,
+      Docker::RestorableAppEngine::GetDefStorageSpaceFunc(),
+      [](const Docker::Uri& /* app_uri */, const std::string& image_uri) { return "docker://" + image_uri; },
+      false,
+      true};
 
   for (const auto& app : apps) {
     LOG_INFO << "Starting App: " << app.name;

--- a/src/docker/restorableappengine.h
+++ b/src/docker/restorableappengine.h
@@ -90,7 +90,7 @@ class RestorableAppEngine : public AppEngine {
       StorageSpaceFunc storage_space_func = RestorableAppEngine::GetDefStorageSpaceFunc(),
       ClientImageSrcFunc client_image_src_func = [](const Docker::Uri& /* app_uri */,
                                                     const std::string& image_uri) { return "docker://" + image_uri; },
-      bool create_containers_if_install = true);
+      bool create_containers_if_install = true, bool offline = false);
 
   Result fetch(const App& app) override;
   Result verify(const App& app) override;
@@ -172,6 +172,7 @@ class RestorableAppEngine : public AppEngine {
   StorageSpaceFunc storage_space_func_;
   ClientImageSrcFunc client_image_src_func_;
   bool create_containers_if_install_;
+  bool offline_;
 };
 
 }  // namespace Docker

--- a/src/offline/client.cc
+++ b/src/offline/client.cc
@@ -173,9 +173,10 @@ static std::unique_ptr<LiteClient> createOfflineClient(const Config& cfg_in, con
                " oci:" + offline_registry->appsDir().string() + "/" + app_uri.app + "/" + app_uri.digest.hash() +
                "/images/" + uri.registryHostname + "/" + uri.repo + "/" + uri.digest.hash();
       },
-      false /* don't create containers on install because it makes dockerd check if pinned images
-    present in its store what we should avoid until images are registered (hacked) in dockerd store
-  */)};
+      false, /* don't create containers on install because it makes dockerd check if pinned images
+    present in its store what we should avoid until images are registered (hacked) in dockerd store */
+      true   /* indicate that this is an offline client */
+      )};
 
   return std::make_unique<LiteClient>(cfg, app_engine, nullptr, std::make_shared<MetaFetcher>(src.TufDir));
 }


### PR DESCRIPTION
offline: Don't pull images at App start
    
By default, aklite/restorable-engine tries to pull images at App start
to distinguish between download and install failure during target
installation. E.g. if a device goes offline just after App download and
before installation then install will fail because it cannot check App
image manifest at Registry. Having ability to distinguish between fetch
and a real install failure allows aklite to keep target install retrying
if it is just fetch failure.
But it does not work for the offline client and the early app startup
because a device is really offline and it is assumed that all App data
are already preloaded, so no need to do `compose pull` at App startup.
Otherwise, it will just fail since `compose pull` tries to fetch an
image manifest regardless its presence in a local docker store.
