### PR TITLE
Offline update with boot fw update

### DIFF
--- a/apps/aklite-offline/cmds.cpp
+++ b/apps/aklite-offline/cmds.cpp
@@ -12,6 +12,16 @@ int InstallCmd::installUpdate(const Config& cfg_in, const boost::filesystem::pat
         offline::client::install(cfg_in, {src_dir / "tuf", src_dir / "ostree_repo", src_dir / "apps"});
 
     switch (install_res) {
+      case offline::PostInstallAction::NeedRebootForBootFw: {
+        ret_code = 90;
+        std::cout
+            << "Please reboot a device to confirm a boot firmware update, and then run the `install` command again\n";
+        std::cout << "If the reboot doesn't help to proceed with the update, then make sure that "
+                     "`bootupgrade_available` is set to `0`.";
+        std::cout << "Try running `fw_setenv|fiovb_setenv bootupgrade_available 0`, reboot a device, and then run "
+                     "the `install` again";
+        break;
+      }
       case offline::PostInstallAction::NeedReboot: {
         ret_code = 100;
         std::cout << "Please reboot a device and run `run` command to apply installation and start the updated Apps "
@@ -48,6 +58,13 @@ int RunCmd::runUpdate(const Config& cfg_in) const {
       case offline::PostRunAction::Ok: {
         LOG_INFO << "Successfully applied new version of rootfs and started Apps if present";
         ret_code = 0;
+        break;
+      }
+      case offline::PostRunAction::OkNeedReboot: {
+        LOG_INFO << "Successfully applied new version of rootfs and started Apps if present.";
+        LOG_INFO << "Please, optionally reboot a device to confirm the boot firmware update;"
+                    " the reboot can be performed now, anytime later, or at the beginning of the next update";
+        ret_code = 90;
         break;
       }
       case offline::PostRunAction::RollbackNeedReboot: {

--- a/src/liteclient.cc
+++ b/src/liteclient.cc
@@ -355,6 +355,16 @@ bool LiteClient::isPendingTarget(const Uptane::Target& target) {
   return target.sha256Hash() == pending->sha256Hash();
 }
 
+bool LiteClient::isBootFwUpdateInProgress() const {
+  auto* rootfs_pacman = dynamic_cast<RootfsTreeManager*>(package_manager_.get());
+  if (rootfs_pacman == nullptr) {
+    LOG_ERROR << "Cannot downcast the package manager to the rootfs package manager";
+    return false;
+  }
+
+  return rootfs_pacman->bootFwUpdateStatus().isUpdateInProgress();
+}
+
 class DetailedDownloadReport : public EcuDownloadStartedReport {
  public:
   DetailedDownloadReport(const Uptane::EcuSerial& ecu, const std::string& correlation_id, const std::string& details)

--- a/src/liteclient.h
+++ b/src/liteclient.h
@@ -73,6 +73,7 @@ class LiteClient {
   bool importRootMeta(const boost::filesystem::path& src, Uptane::Version max_ver = Uptane::Version());
   void importRootMetaIfNeededAndPresent();
   bool isPendingTarget(const Uptane::Target& target);
+  bool isBootFwUpdateInProgress() const;
 
  private:
   FRIEND_TEST(helpers, locking);

--- a/src/liteclient.h
+++ b/src/liteclient.h
@@ -72,6 +72,7 @@ class LiteClient {
   std::tuple<bool, boost::filesystem::path> isRootMetaImportNeeded();
   bool importRootMeta(const boost::filesystem::path& src, Uptane::Version max_ver = Uptane::Version());
   void importRootMetaIfNeededAndPresent();
+  bool isPendingTarget(const Uptane::Target& target);
 
  private:
   FRIEND_TEST(helpers, locking);

--- a/src/offline/client.h
+++ b/src/offline/client.h
@@ -20,8 +20,8 @@ struct UpdateSrc {
   std::string TargetName;
 };
 
-enum class PostInstallAction { Undefined = -1, NeedReboot, NeedDockerRestart, AlreadyInstalled };
-enum class PostRunAction { Undefined = -1, Ok, RollbackNeedReboot };
+enum class PostInstallAction { Undefined = -1, NeedReboot, NeedRebootForBootFw, NeedDockerRestart, AlreadyInstalled };
+enum class PostRunAction { Undefined = -1, Ok, OkNeedReboot, RollbackNeedReboot };
 
 class MetaFetcher : public Uptane::IMetadataFetcher {
  public:

--- a/src/rootfstreemanager.h
+++ b/src/rootfstreemanager.h
@@ -28,6 +28,8 @@ class RootfsTreeManager : public OstreeManager, public Downloader {
   bool fetchTarget(const Uptane::Target& target, Uptane::Fetcher& fetcher, const KeyManager& keys,
                    const FetcherProgressCb& progress_cb, const api::FlowControlToken* token) override;
 
+  const bootloader::BootFwUpdateStatus& bootFwUpdateStatus() const { return *boot_fw_update_status_; }
+
  protected:
   void installNotify(const Uptane::Target& target) override;
   data::InstallationResult install(const Uptane::Target& target) const override;

--- a/tests/fixtures/liteclient/boot_flag_mgr.cc
+++ b/tests/fixtures/liteclient/boot_flag_mgr.cc
@@ -32,9 +32,11 @@ class BootFlagMgr {
   int bootupgrade_available() const {
    return std::stoi(Utils::readFile(dir_/"bootupgrade_available"));
   }
-
   void reset_bootupgrade_available() {
     Utils::writeFile(dir_/"bootupgrade_available", std::string("0"));
+  }
+  void set_bootupgrade_available() {
+    Utils::writeFile(dir_/"bootupgrade_available", std::string("1"));
   }
 
  private:


### PR DESCRIPTION
- Detect and inform a client about a boot firmware update and a need in a device reboot to confirm such the update.
- Add tests to cover the boot  firmware update case.