### PR TITLE
Bootloader rollback protection

### DIFF
--- a/src/bootloader/bootloaderlite.cc
+++ b/src/bootloader/bootloaderlite.cc
@@ -2,6 +2,7 @@
 
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
+#include <boost/format.hpp>
 
 #include "bootloader/bootloader.h"
 #include "storage/invstorage.h"
@@ -18,40 +19,21 @@ void BootloaderLite::installNotify(const Uptane::Target& target) const {
     case RollbackMode::kBootloaderNone:
     case RollbackMode::kUbootGeneric:
       break;
-    case RollbackMode::kUbootMasked: {
-      std::string version = getVersion(sysroot_->deployment_path(), target.sha256Hash());
-      if (version.empty()) {
-        return;
-      }
-      std::string sink;
-      if (Utils::shell("fw_printenv -n bootfirmware_version", &sink) != 0) {
-        LOG_WARNING << "Failed to read bootfirmware_version";
-        return;
-      }
-      LOG_INFO << "Current boot firmware version: " << sink;
-      if (sink != version) {
-        LOG_INFO << "Update firmware to version: " << version;
-        if (Utils::shell("fw_setenv bootupgrade_available 1", &sink) != 0) {
-          LOG_WARNING << "Failed to set bootupgrade_available";
-        }
-      }
-    } break;
+    case RollbackMode::kUbootMasked:
     case RollbackMode::kFioVB: {
-      std::string version = getVersion(sysroot_->deployment_path(), target.sha256Hash());
-      if (version.empty()) {
+      std::string target_version = getVersion(sysroot_->deployment_path(), target.sha256Hash());
+      if (target_version.empty()) {
         return;
       }
-      std::string sink;
-      if (Utils::shell("fiovb_printenv bootfirmware_version", &sink) != 0) {
-        LOG_WARNING << "Failed to read bootfirmware_version";
-        sink = std::string();
+      const auto cur_version{getEnvVar("bootfirmware_version")};
+      if (std::get<1>(cur_version)) {
+        LOG_INFO << "Current bootloader version: " << std::get<0>(cur_version);
+      } else {
+        LOG_WARNING << "Failed to get bootloader version: " << std::get<0>(cur_version);
       }
-      LOG_INFO << "Current firmware version: " << sink;
-      if (sink != version) {
-        LOG_INFO << "Update firmware to version: " << version;
-        if (Utils::shell("fiovb_setenv bootupgrade_available 1", &sink) != 0) {
-          LOG_WARNING << "Failed to set bootupgrade_available";
-        }
+      if (std::get<0>(cur_version) != target_version) {
+        LOG_INFO << "Bootloader will be updated to version: " << target_version;
+        setEnvVar("bootupgrade_available", "1");
       }
     } break;
     default:
@@ -98,30 +80,51 @@ std::string BootloaderLite::getVersion(const std::string& deployment_dir, const 
 }
 
 bool BootloaderLite::isUpdateInProgress() const {
+  const auto ba_val{getEnvVar("bootupgrade_available")};
+  if (!std::get<1>(ba_val)) {
+    LOG_ERROR << "Failed to get `bootupgrade_available` value, assuming it is set to 0; err: " << std::get<0>(ba_val);
+    return false;
+  }
+  return std::get<0>(ba_val) == "1";
+}
+
+bool BootloaderLite::setEnvVar(const std::string& var_name, const std::string& var_val) const {
+  const std::unordered_map<RollbackMode, std::string> typeToCmd{
+      {RollbackMode::kUbootMasked, "fw_setenv"},
+      {RollbackMode::kFioVB, "fiovb_setenv"},
+  };
+  if (0 == typeToCmd.count(config_.rollback_mode)) {
+    LOG_DEBUG << "No command to set environment variable found for the given bootloader type: "
+              << config_.rollback_mode;
+    return false;
+  }
+  const auto cmd{boost::format{"%s %s %s"} % typeToCmd.at(config_.rollback_mode) % var_name % var_val};
+  std::string output;
+  if (Utils::shell(cmd.str(), &output) != 0) {
+    LOG_WARNING << "Failed to set the bootloader's environment variable" << var_name << "; err: " << output;
+    return false;
+  }
+  return true;
+}
+
+std::tuple<std::string, bool> BootloaderLite::getEnvVar(const std::string& var_name) const {
   const std::unordered_map<RollbackMode, std::string> typeToCmd{
       {RollbackMode::kUbootMasked, "fw_printenv -n"},
       {RollbackMode::kFioVB, "fiovb_printenv"},
   };
   if (0 == typeToCmd.count(config_.rollback_mode)) {
-    return false;
+    const auto er_msg{boost::format("No command to read environment variable found for `%s` bootloader type") %
+                      config_.rollback_mode};
+    return {er_msg.str(), false};
   }
-  int bootupgrade_available{readBootUpgradeAvailable(typeToCmd.at(config_.rollback_mode))};
-  return bootupgrade_available == 1;
-}
-
-int BootloaderLite::readBootUpgradeAvailable(const std::string& get_cmd) {
-  int bootupgrade_available{0};
-  std::string ba_str{"0"};
-
-  try {
-    if (Utils::shell(get_cmd + " bootupgrade_available", &ba_str) != 0) {
-      LOG_ERROR << "Failed to read bootupgrade_available, assume it is set to 0";
-    }
-    bootupgrade_available = std::stoi(ba_str);
-  } catch (const std::exception& exc) {
-    LOG_ERROR << "Failed to get `bootupgrade_available` value: " << exc.what() << "; assume it is set to 0";
+  const auto cmd{boost::format{"%s %s"} % typeToCmd.at(config_.rollback_mode) % var_name};
+  std::string output;
+  if (Utils::shell(cmd.str(), &output) != 0) {
+    const auto er_msg{boost::format("Failed to get a bootloader environment variable; cmd: %s, err: %s") % cmd %
+                      output};
+    return {er_msg.str(), false};
   }
-  return bootupgrade_available;
+  return {output, true};
 }
 
 }  // namespace bootloader

--- a/src/bootloader/bootloaderlite.cc
+++ b/src/bootloader/bootloaderlite.cc
@@ -9,8 +9,6 @@
 
 namespace bootloader {
 
-std::string getVersion(const std::string& deployment_dir, const std::string& ver_file, const std::string& hash);
-
 BootloaderLite::BootloaderLite(BootloaderConfig config, INvStorage& storage, OSTree::Sysroot::Ptr sysroot)
     : Bootloader(std::move(config), storage), sysroot_{std::move(sysroot)} {}
 
@@ -21,7 +19,7 @@ void BootloaderLite::installNotify(const Uptane::Target& target) const {
     case RollbackMode::kUbootGeneric:
       break;
     case RollbackMode::kUbootMasked: {
-      std::string version = getVersion(sysroot_->deployment_path(), VersionFile, target.sha256Hash());
+      std::string version = getVersion(sysroot_->deployment_path(), target.sha256Hash());
       if (version.empty()) {
         return;
       }
@@ -39,7 +37,7 @@ void BootloaderLite::installNotify(const Uptane::Target& target) const {
       }
     } break;
     case RollbackMode::kFioVB: {
-      std::string version = getVersion(sysroot_->deployment_path(), VersionFile, target.sha256Hash());
+      std::string version = getVersion(sysroot_->deployment_path(), target.sha256Hash());
       if (version.empty()) {
         return;
       }
@@ -61,7 +59,8 @@ void BootloaderLite::installNotify(const Uptane::Target& target) const {
   }
 }
 
-std::string getVersion(const std::string& deployment_dir, const std::string& ver_file, const std::string& hash) {
+std::string BootloaderLite::getVersion(const std::string& deployment_dir, const std::string& hash,
+                                       const std::string& ver_file) {
   try {
     std::string file;
     for (auto& p : boost::filesystem::directory_iterator(deployment_dir)) {

--- a/src/bootloader/bootloaderlite.cc
+++ b/src/bootloader/bootloaderlite.cc
@@ -115,6 +115,10 @@ std::string BootloaderLite::getVersion(const std::string& deployment_dir, const 
       LOG_WARNING << "Target deployment hash was not found";
       return std::string();
     }
+    if (!boost::filesystem::exists(file)) {
+      LOG_DEBUG << "Target's bootloader version file is not found, expected: " << file;
+      return std::string();
+    }
 
     LOG_DEBUG << "Target firmware file: " << file;
     std::ifstream ifs(file);

--- a/src/bootloader/bootloaderlite.h
+++ b/src/bootloader/bootloaderlite.h
@@ -32,6 +32,9 @@ class BootloaderLite : public Bootloader, public BootFwUpdateStatus {
 
   explicit BootloaderLite(BootloaderConfig config, INvStorage& storage, OSTree::Sysroot::Ptr sysroot);
 
+  VersionNumbRes getDeploymentVersion(const std::string& hash) const;
+  VersionNumbRes getCurrentVersion() const;
+
   static std::string getVersion(const std::string& deployment_dir, const std::string& hash,
                                 const std::string& ver_file = VersionFile);
 
@@ -42,6 +45,8 @@ class BootloaderLite : public Bootloader, public BootFwUpdateStatus {
  private:
   bool setEnvVar(const std::string& var_name, const std::string& var_val) const;
   std::tuple<std::string, bool> getEnvVar(const std::string& var_name) const;
+
+  static VersionNumbRes verStrToNumber(const std::string& ver_str);
 
   OSTree::Sysroot::Ptr sysroot_;
 };

--- a/src/bootloader/bootloaderlite.h
+++ b/src/bootloader/bootloaderlite.h
@@ -43,6 +43,7 @@ class BootloaderLite : public Bootloader, public BootFwUpdateStatus {
   bool isUpdateInProgress() const override;
 
  private:
+  bool isRollbackProtectionEnabled() const;
   bool setEnvVar(const std::string& var_name, const std::string& var_val) const;
   std::tuple<std::string, bool> getEnvVar(const std::string& var_name) const;
 

--- a/src/bootloader/bootloaderlite.h
+++ b/src/bootloader/bootloaderlite.h
@@ -25,6 +25,9 @@ class BootFwUpdateStatus {
 
 class BootloaderLite : public Bootloader, public BootFwUpdateStatus {
  public:
+  using VersionType = uint64_t;  // clang-tidy prefers uint64_t over unsigned long long int
+  using VersionNumbRes = std::tuple<VersionType, bool>;
+
   static constexpr const char* const VersionFile{"/usr/lib/firmware/version.txt"};
 
   explicit BootloaderLite(BootloaderConfig config, INvStorage& storage, OSTree::Sysroot::Ptr sysroot);
@@ -37,7 +40,8 @@ class BootloaderLite : public Bootloader, public BootFwUpdateStatus {
   bool isUpdateInProgress() const override;
 
  private:
-  static int readBootUpgradeAvailable(const std::string& get_cmd);
+  bool setEnvVar(const std::string& var_name, const std::string& var_val) const;
+  std::tuple<std::string, bool> getEnvVar(const std::string& var_name) const;
 
   OSTree::Sysroot::Ptr sysroot_;
 };

--- a/src/bootloader/bootloaderlite.h
+++ b/src/bootloader/bootloaderlite.h
@@ -17,6 +17,7 @@ class BootFwUpdateStatus {
   virtual ~BootFwUpdateStatus() = default;
 
   virtual bool isUpdateInProgress() const = 0;
+  virtual bool isUpdateSupported() const = 0;
 
  protected:
   BootFwUpdateStatus() = default;
@@ -41,6 +42,7 @@ class BootloaderLite : public Bootloader, public BootFwUpdateStatus {
   void installNotify(const Uptane::Target& target) const override;
 
   bool isUpdateInProgress() const override;
+  bool isUpdateSupported() const override { return !get_env_cmd_.empty(); }
 
  private:
   bool isRollbackProtectionEnabled() const;
@@ -48,6 +50,7 @@ class BootloaderLite : public Bootloader, public BootFwUpdateStatus {
   std::tuple<std::string, bool> getEnvVar(const std::string& var_name) const;
 
   static VersionNumbRes verStrToNumber(const std::string& ver_str);
+  static std::string extractVersionValue(const std::string& version_line);
 
   OSTree::Sysroot::Ptr sysroot_;
   const std::string get_env_cmd_;

--- a/src/bootloader/bootloaderlite.h
+++ b/src/bootloader/bootloaderlite.h
@@ -44,12 +44,14 @@ class BootloaderLite : public Bootloader, public BootFwUpdateStatus {
 
  private:
   bool isRollbackProtectionEnabled() const;
-  bool setEnvVar(const std::string& var_name, const std::string& var_val) const;
+  std::tuple<std::string, bool> setEnvVar(const std::string& var_name, const std::string& var_val) const;
   std::tuple<std::string, bool> getEnvVar(const std::string& var_name) const;
 
   static VersionNumbRes verStrToNumber(const std::string& ver_str);
 
   OSTree::Sysroot::Ptr sysroot_;
+  const std::string get_env_cmd_;
+  const std::string set_env_cmd_;
 };
 
 }  // namespace bootloader

--- a/src/bootloader/bootloaderlite.h
+++ b/src/bootloader/bootloaderlite.h
@@ -29,6 +29,9 @@ class BootloaderLite : public Bootloader, public BootFwUpdateStatus {
 
   explicit BootloaderLite(BootloaderConfig config, INvStorage& storage, OSTree::Sysroot::Ptr sysroot);
 
+  static std::string getVersion(const std::string& deployment_dir, const std::string& hash,
+                                const std::string& ver_file = VersionFile);
+
   void installNotify(const Uptane::Target& target) const override;
 
   bool isUpdateInProgress() const override;

--- a/src/ostree/repo.h
+++ b/src/ostree/repo.h
@@ -25,6 +25,7 @@ class Repo {
   void pull(const std::string& remote_name, const std::string& branch, const std::string& commit_hash);
   void checkout(const std::string& commit_hash, const std::string& src_dir, const std::string& dst_dir);
   std::unordered_map<std::string, std::string> getRefs() const;
+  std::string readFile(const std::string& commit_hash, const std::string& file) const;
 
  private:
   void init(bool create);

--- a/src/rootfstreemanager.cc
+++ b/src/rootfstreemanager.cc
@@ -114,21 +114,18 @@ void RootfsTreeManager::installNotify(const Uptane::Target& target) {
 data::InstallationResult RootfsTreeManager::install(const Uptane::Target& target) const {
   data::InstallationResult res;
   Uptane::Target current = OstreeManager::getCurrent();
+  if (current.sha256Hash() != target.sha256Hash() && boot_fw_update_status_->isUpdateSupported()) {
+    res = verifyBootloaderUpdate();
+    if (res.result_code.num_code != data::ResultCode::Numeric::kOk) {
+      return res;
+    }
+  }
   // Do ostree install if the currently installed target's hash differs from the specified target's hash,
   // or there is pending installation and it differs from the specified target so we undeploy it and make the new target
   // pending (app driven rollback)
   if ((current.sha256Hash() != target.sha256Hash()) ||
       (!sysroot()->getDeploymentHash(OSTree::Sysroot::Deployment::kPending).empty() &&
        sysroot()->getDeploymentHash(OSTree::Sysroot::Deployment::kPending) != target.sha256Hash())) {
-    // If the boot fw update is in progress and it is an installation of Target ostree of which differs
-    //  from the ostree a device is booted on then (unless `pacman.ostree_update_block` is set to `false` or "0")
-    if (update_block_ && boot_fw_update_status_->isUpdateInProgress() &&
-        (current.sha256Hash() != target.sha256Hash())) {
-      LOG_WARNING << "Boot fw update is in progress."
-                     " A device must be rebooted to confirm and finalize the boot fw update"
-                     " before installation of a new Target with ostree/rootfs change";
-      return data::InstallationResult(data::ResultCode::Numeric::kNeedCompletion, "");
-    }
     // notify the bootloader before installation happens as it is not atomic
     // and a false notification doesn't hurt with rollback support in place
     // Hacking in order to invoke non-const method from the const one !!!
@@ -207,4 +204,14 @@ void RootfsTreeManager::setRemote(const std::string& name, const std::string& ur
   } else {
     repo.addRemote(name, url, "", "", "");
   }
+}
+
+data::InstallationResult RootfsTreeManager::verifyBootloaderUpdate() const {
+  if (update_block_ && boot_fw_update_status_->isUpdateInProgress()) {
+    LOG_WARNING << "Bootlader update is in progress."
+                   " A device must be rebooted to confirm and finalize the boot fw update"
+                   " before installation of a new Target with ostree/rootfs change";
+    return data::InstallationResult(data::ResultCode::Numeric::kNeedCompletion, "bootlader update is in progress");
+  }
+  return data::InstallationResult(data::ResultCode::Numeric::kOk, "");
 }

--- a/src/rootfstreemanager.cc
+++ b/src/rootfstreemanager.cc
@@ -12,7 +12,7 @@ RootfsTreeManager::RootfsTreeManager(const PackageConfig& pconfig, const Bootloa
                                      std::shared_ptr<OSTree::Sysroot> sysroot, const KeyManager& keys)
     : OstreeManager(pconfig, bconfig, storage, http, new bootloader::BootloaderLite(bconfig, *storage, sysroot)),
       sysroot_{std::move(sysroot)},
-      boot_fw_update_status_{new bootloader::BootloaderLite(bconfig, *storage, sysroot)},
+      boot_fw_update_status_{new bootloader::BootloaderLite(bconfig, *storage, sysroot_)},
       http_client_{http},
       gateway_url_{pconfig.ostree_server},
       keys_{keys} {

--- a/src/rootfstreemanager.h
+++ b/src/rootfstreemanager.h
@@ -45,7 +45,7 @@ class RootfsTreeManager : public OstreeManager, public Downloader {
   void getAdditionalRemotes(std::vector<Remote>& remotes, const std::string& target_name);
 
   void setRemote(const std::string& name, const std::string& url, const boost::optional<const KeyManager*>& keys);
-  data::InstallationResult verifyBootloaderUpdate() const;
+  data::InstallationResult verifyBootloaderUpdate(const Uptane::Target& target) const;
 
   const KeyManager& keys_;
   std::shared_ptr<OSTree::Sysroot> sysroot_;

--- a/src/rootfstreemanager.h
+++ b/src/rootfstreemanager.h
@@ -45,6 +45,7 @@ class RootfsTreeManager : public OstreeManager, public Downloader {
   void getAdditionalRemotes(std::vector<Remote>& remotes, const std::string& target_name);
 
   void setRemote(const std::string& name, const std::string& url, const boost::optional<const KeyManager*>& keys);
+  data::InstallationResult verifyBootloaderUpdate() const;
 
   const KeyManager& keys_;
   std::shared_ptr<OSTree::Sysroot> sysroot_;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -73,8 +73,8 @@ add_aktualizr_test(NAME ostree
 )
 
 target_compile_definitions(t_ostree PRIVATE ${TEST_DEFS})
-target_include_directories(t_ostree PRIVATE ${TEST_INCS})
-target_link_libraries(t_ostree ${TEST_LIBS})
+target_include_directories(t_ostree PRIVATE ${TEST_INCS} ${AKTUALIZR_DIR}/tests/)
+target_link_libraries(t_ostree ${TEST_LIBS} testutilities)
 set_tests_properties(test_ostree PROPERTIES LABELS "aklite:ostree")
 
 add_aktualizr_test(NAME liteclient

--- a/tests/aklite_offline_test.cc
+++ b/tests/aklite_offline_test.cc
@@ -142,7 +142,7 @@ class AkliteOffline : public ::testing::Test {
     initial_target_.updateCustom(custom);
     // set initial bootloader version
     const auto boot_fw_ver{bootloader::BootloaderLite::getVersion(sys_repo_.getDeploymentPath(), hash)};
-    boot_flag_mgr_->set_bootfirmware_version(boot_fw_ver);
+    boot_flag_mgr_->set("bootfirmware_version", boot_fw_ver);
   }
   Uptane::Target addTarget(const std::vector<AppEngine::App>& apps, bool just_apps = false,
                            bool add_bootloader_update = false) {
@@ -343,11 +343,11 @@ TEST_F(AkliteOffline, UpdateIfBootFwUpdateIsNotConfirmedBefore) {
   // and ostree for the bootloader, so it finalizes the boot fw update and resets `bootupgrade_available`.
   // Also, it may happen that `bootupgrade_available` is set by mistake.
   // The bootloader will detect such situation and reset `bootupgrade_available`.
-  boot_flag_mgr_->set_bootupgrade_available();
+  boot_flag_mgr_->set("bootupgrade_available");
 
   ASSERT_EQ(install(), offline::PostInstallAction::NeedRebootForBootFw);
   reboot();
-  boot_flag_mgr_->reset_bootupgrade_available();
+  boot_flag_mgr_->set("bootupgrade_available", "0");
   ASSERT_EQ(install(), offline::PostInstallAction::NeedReboot);
   reboot();
   ASSERT_EQ(run(), offline::PostRunAction::Ok);
@@ -362,7 +362,7 @@ TEST_F(AkliteOffline, BootFwUpdate) {
   ASSERT_EQ(run(), offline::PostRunAction::OkNeedReboot);
   reboot();
   // emulate boot firmware update confirmation
-  boot_flag_mgr_->reset_bootupgrade_available();
+  boot_flag_mgr_->set("bootupgrade_available", "0");
   ASSERT_EQ(run(), offline::PostRunAction::Ok);
   ASSERT_TRUE(target.MatchTarget(getCurrent()));
 }

--- a/tests/aklite_offline_test.cc
+++ b/tests/aklite_offline_test.cc
@@ -134,10 +134,11 @@ class AkliteOffline : public ::testing::Test {
   void setInitialTarget(const std::string& hash, bool known = true) {
     Uptane::EcuMap ecus{{Uptane::EcuSerial("test_primary_ecu_serial_id"), Uptane::HardwareIdentifier(hw_id)}};
     std::vector<Hash> hashes{Hash(Hash::Type::kSha256, hash)};
-    initial_target_ = Uptane::Target{known ? hw_id + "-lmp-0" : Target::InitialTarget, ecus, hashes, 0, "", "OSTREE"};
+    initial_target_ = Uptane::Target{known ? hw_id + "-lmp-1" : Target::InitialTarget, ecus, hashes, 0, "", "OSTREE"};
     // update the initial Target to add the hardware ID so Target::MatchTarget() works correctly
     auto custom{initial_target_.custom_data()};
     custom["hardwareIds"][0] = cfg_.provision.primary_ecu_hardware_id;
+    custom["version"] = "1";
     initial_target_.updateCustom(custom);
   }
   Uptane::Target addTarget(const std::vector<AppEngine::App>& apps, bool just_apps = false) {
@@ -148,7 +149,7 @@ class AkliteOffline : public ::testing::Test {
         version = std::to_string(std::stoi(latest_target.custom_version()) + 1);
       } catch (...) {
         LOG_INFO << "No target available, preparing the first version";
-        version = "1";
+        version = "2";
       }
     }
     auto hash{latest_target.IsValid() ? latest_target.sha256Hash() : initial_target_.sha256Hash()};
@@ -178,7 +179,7 @@ class AkliteOffline : public ::testing::Test {
     for (const auto& app : apps) {
       apps_json[app.name]["uri"] = app.uri;
     }
-    tuf_repo_.addTarget(cfg_.provision.primary_ecu_hardware_id + "-lmp-0", initial_target_.sha256Hash(),
+    tuf_repo_.addTarget(cfg_.provision.primary_ecu_hardware_id + "-lmp-1", initial_target_.sha256Hash(),
                         cfg_.provision.primary_ecu_hardware_id, "0", apps_json);
 
     // content-based shortlisting
@@ -197,7 +198,7 @@ class AkliteOffline : public ::testing::Test {
       Json::Value custom;
       custom[Target::ComposeAppField] = apps_json;
       custom["name"] = cfg_.provision.primary_ecu_hardware_id + "-lmp";
-      custom["version"] = "0";
+      custom["version"] = "1";
       custom["hardwareIds"][0] = cfg_.provision.primary_ecu_hardware_id;
       custom["targetFormat"] = "OSTREE";
       custom["arch"] = "arm64";

--- a/tests/apiclient_test.cc
+++ b/tests/apiclient_test.cc
@@ -107,7 +107,7 @@ TEST_F(ApiClientTest, CheckIn) {
   ASSERT_NE(std::string::npos, val.find("[pacman]"));
 
   ASSERT_EQ(CheckInResult::Status::Ok, result.status);
-  ASSERT_EQ(0, result.Targets().size());
+  ASSERT_EQ(1, result.Targets().size());
 
   ASSERT_TRUE(getDeviceGateway().resetSotaToml());
   ASSERT_TRUE(getDeviceGateway().resetEvents());
@@ -117,9 +117,9 @@ TEST_F(ApiClientTest, CheckIn) {
   ASSERT_EQ(0, getDeviceGateway().getEvents().size());
   ASSERT_EQ("", getDeviceGateway().readSotaToml());
   ASSERT_EQ(CheckInResult::Status::Ok, result.status);
-  ASSERT_EQ(1, result.Targets().size());
-  ASSERT_EQ(new_target.filename(), result.Targets()[0].Name());
-  ASSERT_EQ(new_target.sha256Hash(), result.Targets()[0].Sha256Hash());
+  ASSERT_EQ(2, result.Targets().size());
+  ASSERT_EQ(new_target.filename(), result.Targets()[1].Name());
+  ASSERT_EQ(new_target.sha256Hash(), result.Targets()[1].Sha256Hash());
 }
 
 TEST_F(ApiClientTest, Rollback) {
@@ -213,7 +213,7 @@ TEST_F(ApiClientTest, Secondaries) {
   auto result = client.CheckIn();
   ASSERT_EQ(CheckInResult::Status::Ok, result.status);
 
-  ASSERT_EQ(2, result.Targets().size());
+  ASSERT_EQ(3, result.Targets().size());
   ASSERT_EQ(new_target.filename(), result.GetLatest().Name());
   ASSERT_EQ(secondary_target.filename(), result.GetLatest("riscv").Name());
 }

--- a/tests/boot_flag_mgmt_test.cc
+++ b/tests/boot_flag_mgmt_test.cc
@@ -60,7 +60,7 @@ class BootFlagMgmtTest : public fixtures::ClientTest {
 
     auto client =
         ClientTest::createLiteClient(app_engine_mock_, initial_version, apps, "", boost::none, true, finalize);
-    boot_flag_mgr_->set_rollback_protection();
+    boot_flag_mgr_->set("rollback_protection");
     return client;
   }
 
@@ -95,7 +95,7 @@ TEST_P(BootFlagMgmtTestSuite, OstreeUpdate) {
   auto new_target = createTarget();
   update(*client, getInitialTarget(), new_target);
   if (bootloader_type_ != RollbackMode::kUbootGeneric) {
-    ASSERT_EQ(boot_flag_mgr_->bootupgrade_available(), 1);
+    ASSERT_EQ(boot_flag_mgr_->get("bootupgrade_available"), 1);
     ASSERT_TRUE(client->isBootFwUpdateInProgress());
   }
 
@@ -121,7 +121,7 @@ TEST_P(BootFlagMgmtTestSuite, OstreeUpdate) {
   update(*client, new_target, new_target_01);
   reboot(client);
   ASSERT_TRUE(targetsMatch(client->getCurrent(), new_target_01));
-  ASSERT_EQ(boot_flag_mgr_->bootupgrade_available(), 0);
+  ASSERT_EQ(boot_flag_mgr_->get("bootupgrade_available"), 0);
   ASSERT_FALSE(client->isBootFwUpdateInProgress());
 }
 
@@ -135,14 +135,14 @@ TEST_P(BootFlagMgmtTestSuite, OstreeUpdateIfBootloaderRollbacks) {
   // Boot firmware update is not expected because the new target's version is lower (0) than the current one (1)
   update(*client, getInitialTarget(), new_target, data::ResultCode::Numeric::kNeedCompletion,
          {DownloadResult::Status::Ok, ""}, "", false);
-  ASSERT_EQ(boot_flag_mgr_->bootupgrade_available(), 0);
+  ASSERT_EQ(boot_flag_mgr_->get("bootupgrade_available"), 0);
   ASSERT_FALSE(client->isBootFwUpdateInProgress());
 
   // reboot device, and don't reset the boot upgrade flag to emulate the bootloader A/B update
   reboot(client);
   ASSERT_TRUE(targetsMatch(client->getCurrent(), new_target));
   checkHeaders(*client, new_target);
-  ASSERT_EQ(boot_flag_mgr_->bootupgrade_available(), 0);
+  ASSERT_EQ(boot_flag_mgr_->get("bootupgrade_available"), 0);
   ASSERT_FALSE(client->isBootFwUpdateInProgress());
 }
 

--- a/tests/fixtures/liteclient/boot_flag_mgr.cc
+++ b/tests/fixtures/liteclient/boot_flag_mgr.cc
@@ -38,6 +38,9 @@ class BootFlagMgr {
   void set_bootupgrade_available() {
     Utils::writeFile(dir_/"bootupgrade_available", std::string("1"));
   }
+  void set_bootfirmware_version(const std::string& ver) {
+    Utils::writeFile(dir_/"bootfirmware_version", ver);
+  }
 
  private:
   const boost::filesystem::path dir_;

--- a/tests/fixtures/liteclient/boot_flag_mgr.cc
+++ b/tests/fixtures/liteclient/boot_flag_mgr.cc
@@ -20,32 +20,18 @@ class BootFlagMgr {
     }
   }
 
-  int bootcount() const {
-   return std::stoi(Utils::readFile(dir_/"bootcount"));
+  int get(const std::string& flag) const {
+    int res{0};
+    try {
+      res = std::stoi(Utils::readFile(dir_/flag));
+    } catch (const std::exception& exc) {
+      LOG_DEBUG << "Failed to get the flag value; flag: " << flag << ", err: " << exc.what();
+    }
+    return res;
   }
-  int upgrade_available() const {
-   return std::stoi(Utils::readFile(dir_/"upgrade_available"));
-  }
-  int rollback() const {
-   return std::stoi(Utils::readFile(dir_/"rollback"));
-  }
-  int bootupgrade_available() const {
-   if (!boost::filesystem::exists(dir_/"bootupgrade_available")) {
-    return 0;
-   }
-   return std::stoi(Utils::readFile(dir_/"bootupgrade_available"));
-  }
-  void reset_bootupgrade_available() {
-    Utils::writeFile(dir_/"bootupgrade_available", std::string("0"));
-  }
-  void set_bootupgrade_available() {
-    Utils::writeFile(dir_/"bootupgrade_available", std::string("1"));
-  }
-  void set_bootfirmware_version(const std::string& ver) {
-    Utils::writeFile(dir_/"bootfirmware_version", ver);
-  }
-  void set_rollback_protection() {
-    Utils::writeFile(dir_/"rollback_protection", std::string("1"));
+
+  void set(const std::string& flag, const std::string& val = "1") {
+    Utils::writeFile(dir_/flag, val);
   }
 
  private:

--- a/tests/fixtures/liteclient/boot_flag_mgr.cc
+++ b/tests/fixtures/liteclient/boot_flag_mgr.cc
@@ -30,6 +30,9 @@ class BootFlagMgr {
    return std::stoi(Utils::readFile(dir_/"rollback"));
   }
   int bootupgrade_available() const {
+   if (!boost::filesystem::exists(dir_/"bootupgrade_available")) {
+    return 0;
+   }
    return std::stoi(Utils::readFile(dir_/"bootupgrade_available"));
   }
   void reset_bootupgrade_available() {
@@ -40,6 +43,9 @@ class BootFlagMgr {
   }
   void set_bootfirmware_version(const std::string& ver) {
     Utils::writeFile(dir_/"bootfirmware_version", ver);
+  }
+  void set_rollback_protection() {
+    Utils::writeFile(dir_/"rollback_protection", std::string("1"));
   }
 
  private:

--- a/tests/fixtures/liteclient/ostreerepomock.cc
+++ b/tests/fixtures/liteclient/ostreerepomock.cc
@@ -4,7 +4,6 @@ class OSTreeRepoMock {
   {
     if (!create) return;
     executeCmd("ostree", { "init", "--repo", path_, "--mode=" + mode }, "init an ostree repo at " + path_);
-    LOG_INFO << "OSTree repo was created at " + path_;
   }
 
   void pullLocal(const std::string& src_dir, const std::string& hash) {

--- a/tests/fixtures/liteclient/sysostreerepomock.cc
+++ b/tests/fixtures/liteclient/sysostreerepomock.cc
@@ -20,6 +20,8 @@ class SysOSTreeRepoMock {
     executeCmd("ostree", { "--repo=" + path_ + "/ostree/repo", "config", "set", "core.min-free-space-size", size }, "set config " + size);
   }
 
+  std::string getDeploymentPath() const { return path_ + "/ostree/deploy/" + os_ + "/deploy"; }
+
  private:
   const std::string path_;
   const std::string os_;

--- a/tests/fixtures/liteclient/sysrootfs.cc
+++ b/tests/fixtures/liteclient/sysrootfs.cc
@@ -16,5 +16,3 @@ class SysRootFS {
 };
 
 std::string SysRootFS::CreateCmd;
-
-

--- a/tests/fixtures/liteclient/sysrootfs.cc
+++ b/tests/fixtures/liteclient/sysrootfs.cc
@@ -7,6 +7,8 @@ class SysRootFS {
       : branch{std::move(_branch)}, hw_id{std::move(_hw_id)}, path{std::move(_path)}, os{std::move(_os)}
   {
     executeCmd(CreateCmd, { path, branch, hw_id, os }, "generate a system rootfs template");
+    // add bootloader version file
+    Utils::writeFile(path + bootloader::BootloaderLite::VersionFile, std::string("bootfirmware_version=1"), true);
   }
 
   const std::string branch;

--- a/tests/fixtures/liteclienttest.cc
+++ b/tests/fixtures/liteclienttest.cc
@@ -481,7 +481,9 @@ class ClientTest :virtual public ::testing::Test {
         // TODO: check whether a value of ["event"]["details"] macthes the current Target
         // makes sense to represent it as a json string
         const auto event_details = rec_event_json["event"]["details"].asString();
-        ASSERT_TRUE(event_details.find("Apps running:") != std::string::npos);
+        if (client.config.pacman.type == ComposeAppManager::Name) {
+          ASSERT_TRUE(event_details.find("Apps running:") != std::string::npos);
+        }
         ASSERT_TRUE(event_details.find(install_failure_err_msg) != std::string::npos) << event_details;
       }
       if (event_type == "EcuDownloadCompleted") {

--- a/tests/fixtures/liteclienttest.cc
+++ b/tests/fixtures/liteclienttest.cc
@@ -212,7 +212,7 @@ class ClientTest :virtual public ::testing::Test {
         break;
     }
     const auto boot_fw_ver{bootloader::BootloaderLite::getVersion(sys_repo_.getDeploymentPath(), client->getCurrent().sha256Hash())};
-    boot_flag_mgr_->set_bootfirmware_version(boot_fw_ver);
+    boot_flag_mgr_->set("bootfirmware_version", boot_fw_ver);
     return client;
   }
 
@@ -430,10 +430,10 @@ class ClientTest :virtual public ::testing::Test {
       app_shortlist_ = new_app_list;
     }
     if (reset_bootupgrade_available) {
-      boot_flag_mgr_->reset_bootupgrade_available();
+      boot_flag_mgr_->set("bootupgrade_available", "0");
     }
     client = createLiteClient(InitialVersion::kOff, app_shortlist_);
-    ASSERT_EQ(0, boot_flag_mgr_->bootcount());
+    ASSERT_EQ(0, boot_flag_mgr_->get("bootcount"));
   }
 
   /**
@@ -494,15 +494,15 @@ class ClientTest :virtual public ::testing::Test {
   }
 
   void checkBootloaderFlags(RollbackMode bootloader_mode, bool check_upgrade_available, bool expect_boot_firmware = true) {
-    ASSERT_EQ(0, boot_flag_mgr_->bootcount());
-    ASSERT_EQ(0, boot_flag_mgr_->rollback());
+    ASSERT_EQ(0, boot_flag_mgr_->get("bootcount"));
+    ASSERT_EQ(0, boot_flag_mgr_->get("rollback"));
 
     if (bootloader_mode == RollbackMode::kUbootMasked || bootloader_mode == RollbackMode::kFioVB) {
       if (check_upgrade_available) {
-        ASSERT_EQ(1, boot_flag_mgr_->upgrade_available());
+        ASSERT_EQ(1, boot_flag_mgr_->get("upgrade_available"));
       }
       if (expect_boot_firmware) {
-        ASSERT_EQ(1, boot_flag_mgr_->bootupgrade_available());
+        ASSERT_EQ(1, boot_flag_mgr_->get("bootupgrade_available"));
       }
     }
   }

--- a/tests/fixtures/liteclienttest.cc
+++ b/tests/fixtures/liteclienttest.cc
@@ -212,7 +212,9 @@ class ClientTest :virtual public ::testing::Test {
         break;
     }
     const auto boot_fw_ver{bootloader::BootloaderLite::getVersion(sys_repo_.getDeploymentPath(), client->getCurrent().sha256Hash())};
-    boot_flag_mgr_->set("bootfirmware_version", boot_fw_ver);
+    if (!boot_fw_ver.empty()) {
+      boot_flag_mgr_->set("bootfirmware_version", boot_fw_ver);
+    }
     return client;
   }
 

--- a/tests/liteclient_test.cc
+++ b/tests/liteclient_test.cc
@@ -112,8 +112,12 @@ TEST_P(LiteClientTestMultiPacman, OstreeUpdateInstalledVersionsCorrupted1) {
   // boot device with an invalid initial_version json file (ostree sha)
   auto client = createLiteClient(InitialVersion::kCorrupted1);
 
-  // verify that the initial version was corrupted
-  ASSERT_FALSE(targetsMatch(client->getCurrent(), getInitialTarget()));
+  // verify that the `installed_version` json file was corrupted,
+  // it means that the current Target should be so-called "initial" target
+  const auto current{client->getCurrent()};
+  ASSERT_EQ(current.filename(), Target::InitialTarget);
+  ASSERT_EQ(getInitialTarget().filename(), Target::InitialTarget);
+  ASSERT_TRUE(targetsMatch(current, getInitialTarget()));
 
   // Create a new Target: update rootfs and commit it into Treehub's repo
   auto new_target = createTarget();
@@ -123,8 +127,6 @@ TEST_P(LiteClientTestMultiPacman, OstreeUpdateInstalledVersionsCorrupted1) {
   ASSERT_EQ(req_headers["x-ats-target"], Target::InitialTarget);
   ASSERT_FALSE(new_target.MatchTarget(Uptane::Target::Unknown()));
 
-  // verify the install
-  ASSERT_FALSE(targetsMatch(client->getCurrent(), getInitialTarget()));
   reboot(client);
   ASSERT_FALSE(new_target.MatchTarget(Uptane::Target::Unknown()));
   ASSERT_TRUE(targetsMatch(client->getCurrent(), new_target));
@@ -135,8 +137,12 @@ TEST_P(LiteClientTestMultiPacman, OstreeUpdateInstalledVersionsCorrupted2) {
   // boot device with a corrupted json file in the filesystem
   auto client = createLiteClient(InitialVersion::kCorrupted2);
 
-  // verify that the initial version was corrupted
-  ASSERT_FALSE(targetsMatch(client->getCurrent(), getInitialTarget()));
+  // verify that the `installed_version` json file was corrupted,
+  // it means that the current Target should be so-called "initial" target
+  const auto current{client->getCurrent()};
+  ASSERT_EQ(current.filename(), Target::InitialTarget);
+  ASSERT_EQ(getInitialTarget().filename(), Target::InitialTarget);
+  ASSERT_TRUE(targetsMatch(current, getInitialTarget()));
 
   // Create a new Target: update rootfs and commit it into Treehub's repo
   auto new_target = createTarget();
@@ -146,8 +152,6 @@ TEST_P(LiteClientTestMultiPacman, OstreeUpdateInstalledVersionsCorrupted2) {
   ASSERT_EQ(req_headers["x-ats-target"], Target::InitialTarget);
   ASSERT_FALSE(new_target.MatchTarget(Uptane::Target::Unknown()));
 
-  // verify the install
-  ASSERT_FALSE(targetsMatch(client->getCurrent(), getInitialTarget()));
   reboot(client);
   ASSERT_FALSE(new_target.MatchTarget(Uptane::Target::Unknown()));
   ASSERT_TRUE(targetsMatch(client->getCurrent(), new_target));

--- a/tests/ostree_test.cc
+++ b/tests/ostree_test.cc
@@ -1,13 +1,18 @@
 #include <gtest/gtest.h>
 #include <boost/filesystem.hpp>
-#include "utilities/utils.h"
+#include <boost/algorithm/string.hpp>
 
 #include "ostree/repo.h"
+#include "test_utils.h"
+#include "utilities/utils.h"
+
+#include "fixtures/liteclient/executecmd.cc"
+#include "fixtures/liteclient/ostreerepomock.cc"
 
 
 class OSTreeTest : public ::testing::Test {
  protected:
-  OSTreeTest():path_{test_dir_.PathString()}, repo_{std::make_unique<OSTree::Repo>(path_, true)} {}
+  OSTreeTest():path_{test_dir_.PathString()}, repo_{std::make_unique<OSTree::Repo>(path_, true)}, repo_mock_{path_} {}
   bool isRepoInited() const {
     return boost::filesystem::exists(path_ + "/config") && boost::filesystem::exists(path_ + "/objects");
   }
@@ -16,6 +21,7 @@ class OSTreeTest : public ::testing::Test {
   TemporaryDirectory test_dir_;  // must be the first element in the class
   const std::string path_;
   std::unique_ptr<OSTree::Repo> repo_;
+  OSTreeRepoMock repo_mock_;
 };
 
 
@@ -37,6 +43,38 @@ TEST_F(OSTreeTest, InitNonExisting) {
 TEST_F(OSTreeTest, AddRemote) {
   ASSERT_TRUE(isRepoInited());
   repo_->addRemote("treehub", "http://localhost", "", "", "");
+}
+
+TEST_F(OSTreeTest, ReadFileFromCommit) {
+  ASSERT_TRUE(isRepoInited());
+  const std::string content_dir{"contentdir"};
+  const std::string file_content{"foobar=100"};
+  const std::string file_name{"version.txt"};
+
+  {
+    // non-existing commit hash
+    EXPECT_THROW(repo_->readFile("7b5019ad0a1021e0368226844409f5015c1101b1370af2cc56e963f8d3e4f0cd", file_name), std::runtime_error);
+  }
+  {
+    // non-existing file
+    Utils::writeFile(test_dir_ / content_dir / file_name, file_content, true);
+    const auto commit_hash{repo_mock_.commit((test_dir_ / "contentdir").string(), "lmp")};
+    EXPECT_THROW(repo_->readFile(commit_hash, "nonexistingfile"), std::runtime_error);
+  }
+
+  // positive cases for empty, small and bigger file
+  std::string big_file_content;
+  for (int ii = 0; ii < 1024; ++ii) {
+    big_file_content.append(Utils::randomUuid());
+  }
+  for (const auto& file: std::list<std::string>{file_content, "", big_file_content}) {
+    // empty file
+    Utils::writeFile(test_dir_ / "contentdir" / file_name, file, true);
+    const auto commit_hash{repo_mock_.commit((test_dir_ / "contentdir").string(), "lmp")};
+    const auto res_file_content{repo_->readFile(commit_hash, file_name)};
+    ASSERT_EQ(res_file_content.size(), file.size());
+    ASSERT_EQ(res_file_content, file);
+  }
 }
 
 // TODO: Add Treehub mock and uncomment the following tests

--- a/tests/ostree_test.cc
+++ b/tests/ostree_test.cc
@@ -4,26 +4,17 @@
 
 #include "ostree/repo.h"
 
+
 class OSTreeTest : public ::testing::Test {
  protected:
-  OSTreeTest(){
-  }
-
-  virtual void SetUp() {
-    path_ = mkdtemp(const_cast<char*>((testing::TempDir() + "OSTreeTest-repo-XXXXXX").c_str()));
-    repo_ = std::make_unique<OSTree::Repo>(path_, true);
-  }
-
-  virtual void TearDown() {
-    boost::filesystem::remove_all(path_);
-  }
-
+  OSTreeTest():path_{test_dir_.PathString()}, repo_{std::make_unique<OSTree::Repo>(path_, true)} {}
   bool isRepoInited() const {
     return boost::filesystem::exists(path_ + "/config") && boost::filesystem::exists(path_ + "/objects");
   }
 
  protected:
-  std::string path_;
+  TemporaryDirectory test_dir_;  // must be the first element in the class
+  const std::string path_;
   std::unique_ptr<OSTree::Repo> repo_;
 };
 


### PR DESCRIPTION
- Tests&Fixtures refactoring.
- Reject update if bootloader rollback is detected and rollback protection is turned on.
- Add tests for the rollback protection.