### PR TITLE
Handle egde cases of bootloader update

### DIFF
--- a/src/bootloader/bootloaderlite.cc
+++ b/src/bootloader/bootloaderlite.cc
@@ -41,9 +41,9 @@ void BootloaderLite::installNotify(const Uptane::Target& target) const {
         LOG_WARNING << "Failed to get the Target's bootloader version, skipping bootloader update";
         return;
       }
-      const VersionType target_version{std::get<0>(target_version_val)};
+      const std::string& target_version{std::get<0>(target_version_val)};
 
-      VersionType cur_version;
+      std::string cur_version;
       bool is_current_ver_valid;
       std::tie(cur_version, is_current_ver_valid) = getCurrentVersion();
       if (!is_current_ver_valid) {
@@ -58,10 +58,12 @@ void BootloaderLite::installNotify(const Uptane::Target& target) const {
         //    known and valid (checked at the method beginning).
         // or
         // 2. The current bootloader version is known and valid and
-        //   a) the given target's bootloader version is higher than the current one if the rollback protection is
-        //   enabled b) the given target's bootloader version doesn't equal to the current one if the rollback
-        //   protection is disabled
-        const auto cur_ver_str{is_current_ver_valid ? std::to_string(cur_version) : "unknown"};
+        //    the given target's bootloader version doesn't equal to the current one.
+        //    If the rollback protection is ON then the given target's bootloader version
+        //    must be higher than the current one, what is verified before this method is called;
+        //    see RootfsTreeManager::install -> RootfsTreeManager::verifyBootloaderUpdate.
+        //    Therefore, it's suffice to check whether the versions match or not at this point.
+        const auto cur_ver_str{is_current_ver_valid ? cur_version : "unknown"};
         const auto set_bu_res{setEnvVar("bootupgrade_available", "1")};
         if (std::get<1>(set_bu_res)) {
           LOG_INFO << "Bootloader will be updated from version " << cur_ver_str << " to " << target_version
@@ -83,21 +85,12 @@ void BootloaderLite::installNotify(const Uptane::Target& target) const {
   }
 }
 
-BootloaderLite::VersionNumbRes BootloaderLite::getDeploymentVersion(const std::string& hash) const {
+BootloaderLite::VersionStrRes BootloaderLite::getDeploymentVersion(const std::string& hash) const {
   const auto ver_str{getVersion(sysroot_->deployment_path(), hash)};
-  if (ver_str.empty()) {
-    return {0, false};
-  }
-  return verStrToNumber(ver_str);
+  return {ver_str, !ver_str.empty()};
 }
 
-BootloaderLite::VersionNumbRes BootloaderLite::getCurrentVersion() const {
-  const auto cur_version_str{getEnvVar("bootfirmware_version")};
-  if (!std::get<1>(cur_version_str)) {
-    return {0, false};
-  }
-  return verStrToNumber(std::get<0>(cur_version_str));
-}
+BootloaderLite::VersionStrRes BootloaderLite::getCurrentVersion() const { return getEnvVar("bootfirmware_version"); }
 
 std::string BootloaderLite::getVersion(const std::string& deployment_dir, const std::string& hash,
                                        const std::string& ver_file) {
@@ -183,9 +176,13 @@ BootFwUpdateStatus::RollbackVersionResult BootloaderLite::isRollbackVersion(cons
   if (!std::get<1>(ver_res)) {
     return {0, 0, false};
   }
-  const auto cur_ver_res{getCurrentVersion()};
+  const auto cur_ver_str_res{getCurrentVersion()};
+  if (!std::get<1>(cur_ver_str_res)) {
+    return {0, std::get<0>(ver_res), false};
+  }
+  const auto cur_ver_res{verStrToNumber(std::get<0>(cur_ver_str_res))};
   if (!std::get<1>(cur_ver_res)) {
-    return {0, 0, false};
+    return {0, std::get<0>(ver_res), false};
   }
   return {std::get<0>(cur_ver_res), std::get<0>(ver_res), std::get<0>(ver_res) < std::get<0>(cur_ver_res)};
 }

--- a/src/bootloader/bootloaderlite.h
+++ b/src/bootloader/bootloaderlite.h
@@ -13,6 +13,7 @@ class BootFwUpdateStatus {
  public:
   using VersionType = uint64_t;  // clang-tidy prefers uint64_t over unsigned long long int
   using VersionNumbRes = std::tuple<VersionType, bool>;
+  using VersionStrRes = std::tuple<std::string, bool>;
   using RollbackVersionResult = std::tuple<VersionType, VersionType, bool>;
 
   BootFwUpdateStatus(const BootFwUpdateStatus&) = delete;
@@ -36,8 +37,8 @@ class BootloaderLite : public Bootloader, public BootFwUpdateStatus {
 
   explicit BootloaderLite(BootloaderConfig config, INvStorage& storage, OSTree::Sysroot::Ptr sysroot);
 
-  VersionNumbRes getDeploymentVersion(const std::string& hash) const;
-  VersionNumbRes getCurrentVersion() const;
+  VersionStrRes getDeploymentVersion(const std::string& hash) const;
+  VersionStrRes getCurrentVersion() const;
 
   static std::string getVersion(const std::string& deployment_dir, const std::string& hash,
                                 const std::string& ver_file = VersionFile);

--- a/src/bootloader/bootloaderlite.h
+++ b/src/bootloader/bootloaderlite.h
@@ -24,7 +24,8 @@ class BootFwUpdateStatus {
   virtual bool isUpdateInProgress() const = 0;
   virtual bool isUpdateSupported() const = 0;
   virtual bool isRollbackProtectionEnabled() const = 0;
-  virtual RollbackVersionResult isRollbackVersion(const std::string& target_hash) const = 0;
+  virtual std::string getTargetVersion(const std::string& target_hash) const = 0;
+  virtual VersionStrRes getCurrentVersion() const = 0;
 
  protected:
   BootFwUpdateStatus() = default;
@@ -38,7 +39,6 @@ class BootloaderLite : public Bootloader, public BootFwUpdateStatus {
   explicit BootloaderLite(BootloaderConfig config, INvStorage& storage, OSTree::Sysroot::Ptr sysroot);
 
   VersionStrRes getDeploymentVersion(const std::string& hash) const;
-  VersionStrRes getCurrentVersion() const;
 
   static std::string getVersion(const std::string& deployment_dir, const std::string& hash,
                                 const std::string& ver_file = VersionFile);
@@ -48,7 +48,8 @@ class BootloaderLite : public Bootloader, public BootFwUpdateStatus {
   bool isUpdateInProgress() const override;
   bool isUpdateSupported() const override { return !get_env_cmd_.empty(); }
   bool isRollbackProtectionEnabled() const override;
-  RollbackVersionResult isRollbackVersion(const std::string& target_hash) const override;
+  std::string getTargetVersion(const std::string& target_hash) const override;
+  VersionStrRes getCurrentVersion() const override { return getEnvVar("bootfirmware_version"); }
 
  private:
   std::tuple<std::string, bool> setEnvVar(const std::string& var_name, const std::string& var_val) const;

--- a/tests/fixtures/liteclient/boot_flag_mgr.cc
+++ b/tests/fixtures/liteclient/boot_flag_mgr.cc
@@ -34,6 +34,10 @@ class BootFlagMgr {
     Utils::writeFile(dir_/flag, val);
   }
 
+  void remove(const std::string& flag) {
+    boost::filesystem::remove(dir_/flag);
+  }
+
  private:
   const boost::filesystem::path dir_;
 };

--- a/tests/fixtures/liteclienttest.cc
+++ b/tests/fixtures/liteclienttest.cc
@@ -248,7 +248,12 @@ class ClientTest :virtual public ::testing::Test {
     if (boot_fw_ver.empty()) {
       boot_fw_ver = "bootfirmware_version=" + next_version;
     }
-    Utils::writeFile(rootfs + bootloader::BootloaderLite::VersionFile, boot_fw_ver, true);
+    if (boot_fw_ver != "-1") {
+      Utils::writeFile(rootfs + bootloader::BootloaderLite::VersionFile, boot_fw_ver, true);
+    } else  {
+      boost::system::error_code ec;
+      boost::filesystem::remove(rootfs + bootloader::BootloaderLite::VersionFile, ec);
+    }
 
     auto hash = getOsTreeRepo().commit(rootfs, "lmp");
 


### PR DESCRIPTION
- Allow any format of a bootloader version if no rollback protection.
- Proceed with update if a version file is not found in a new target.
- Reject update if new bootloader version is malformed.
- Proceed with update if the current bootloader version is not set (env var) or is malformed provided that a new version is correct.