### PR TITLE
Custom client target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CC ?= clang
 GTEST_FILTER ?= "*"
 
 
-TASKS = config build format tidy garage-tools
+TASKS = config build format tidy garage-tools custom-client
 .PHONY: $(TASKS) test
 
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ The make environment variables are:
 If `-f dev-flow.mk` is specified, then the `make` command is executed on a host, otherwise the `foundries/aklite-dev` container is used.
 A user can specify their own container to run the commands in by overriding `CONTAINER` environment variable.
 
+#### Build Custom Client Example
+
+[The example of the custom client](./examples/custom-client-cxx/main.cc) depends on the `libaktualizr` and `libaktualizr_lite` libraries,
+therefore they should be built prior to building of the example. Then, run:
+```
+make [-f dev-flow.mk] custom-client
+```
+
 ### Test
 
 ```
@@ -54,3 +62,19 @@ The make environment variables are:
 ### Usage
 
 [Run aktualizr-lite locally against your Factory](./how-to-run-locally.md)
+
+#### Run Custom Client Example
+
+Prior to running of the custom client example, a user should execute all steps listed in [the how to run locally guide](./how-to-run-locally.md).
+Then, the following command will start the custom client:
+```
+LD_LIBRARY_PATH="$LD_LIBRARY_PATH:./build/aktualizr/src/libaktualizr/:./build/src"  \
+            AKLITE_CONFIG_DIR=<device config dir | sota.toml> ./build-custom/custom-sota-client
+```
+or in the dev container:
+
+```
+docker run --rm -v $PWD:$PWD -w $PWD \
+    -e LD_LIBRARY_PATH="$LD_LIBRARY_PATH:./build-cont/aktualizr/src/libaktualizr/:./build-cont/src" \
+    -e AKLITE_CONFIG_DIR="<device config dir | sota.toml>"  foundries/aklite-dev ./build-cont-custom/custom-sota-client
+```

--- a/dev-flow.mk
+++ b/dev-flow.mk
@@ -32,9 +32,8 @@ install:
 	cmake --build ${BUILD_DIR} --target $@
 	cp -r aktualizr/third_party/jsoncpp/include/json /usr/include
 
-# requires `install` to be executed as `root`
 custom-client:
-	cmake -S examples/custom-client-cxx -B ${BUILD_DIR}-custom -GNinja -DCMAKE_CXX_COMPILER=${CXX} -DCMAKE_C_COMPILER=${CC}
+	cmake -S examples/custom-client-cxx -B ${BUILD_DIR}-custom -GNinja -DCMAKE_CXX_COMPILER=${CXX} -DCMAKE_C_COMPILER=${CC} -DCMAKE_CXX_FLAGS="-I $(CURDIR)/include -I $(CURDIR)/aktualizr/third_party/jsoncpp/include/ -L "$(CURDIR)/${BUILD_DIR}/aktualizr/src/libaktualizr/" -L $(CURDIR)/${BUILD_DIR}/src"
 	cmake --build ${BUILD_DIR}-custom --target all
 
 garage-tools:

--- a/examples/custom-client-cxx/main.cc
+++ b/examples/custom-client-cxx/main.cc
@@ -1,5 +1,6 @@
 #include <thread>
 
+#include <boost/process.hpp>
 #include <boost/log/core.hpp>
 #include <boost/log/trivial.hpp>
 #include <boost/log/expressions.hpp>
@@ -41,7 +42,15 @@ static std::string get_reboot_cmd(const AkliteClient &client) {
 int main(int argc, char **argv) {
   boost::log::core::get()->set_filter(boost::log::trivial::severity >= boost::log::trivial::info);
 
-  AkliteClient client(AkliteClient::CONFIG_DIRS);
+  std::vector<boost::filesystem::path> cfg_dirs;
+  auto env{boost::this_process::environment()};
+  if (env.end() != env.find("AKLITE_CONFIG_DIR")) {
+    cfg_dirs.emplace_back(env.get("AKLITE_CONFIG_DIR"));
+  } else {
+    cfg_dirs = AkliteClient::CONFIG_DIRS;
+  }
+
+  AkliteClient client(cfg_dirs);
   auto interval = client.GetConfig().get("uptane.polling_sec", 600);
   auto reboot_cmd = get_reboot_cmd(client);
 


### PR DESCRIPTION
- Add the custom client target.
- Add env var to specify config dir for the custom client.
- Add info to `README` on building and running the custom client example.