### PR TITLE
Cleanup skopeo's tmp files

### DIFF
--- a/src/docker/restorableappengine.h
+++ b/src/docker/restorableappengine.h
@@ -106,6 +106,8 @@ class RestorableAppEngine : public AppEngine {
   Json::Value getRunningAppsInfo() const override;
   void prune(const Apps& app_shortlist) override;
 
+  static void removeTmpFiles(const boost::filesystem::path& apps_root);
+
  private:
   // pull App&Images
   void pullApp(const Uri& uri, const boost::filesystem::path& app_dir);


### PR DESCRIPTION
Remove tmp files created by skopeo during image layer pulling that are not cleaned up if `skopeo copy` is interrupted. 
The cleanup function is called only at the aklite initialization since tmp files are not removed by skopeo only if an overall process is interrupted/killed/device is rebooted.
