### PR TITLE
offline: Use absolute path to source dir

### DIFF
--- a/apps/aklite-offline/cmds.h
+++ b/apps/aklite-offline/cmds.h
@@ -43,7 +43,7 @@ class InstallCmd : public Cmd {
   int operator()(const po::variables_map& vm) const override {
     try {
       Config cfg_in{vm};
-      return installUpdate(cfg_in, vm["src-dir"].as<boost::filesystem::path>());
+      return installUpdate(cfg_in, boost::filesystem::canonical(vm["src-dir"].as<boost::filesystem::path>()));
     } catch (const std::exception& exc) {
       LOG_ERROR << "Failed to list Apps: " << exc.what();
       return EXIT_FAILURE;


### PR DESCRIPTION
Translate the input source path into the absolute path because the ostree won't be able to pull if a path is relative.