### PR TITLE
apps: Calculate App update size precisely

### DIFF
--- a/src/docker/restorableappengine.h
+++ b/src/docker/restorableappengine.h
@@ -156,6 +156,8 @@ class RestorableAppEngine : public AppEngine {
   static uint64_t getAppUpdateSize(const Json::Value& app_layers, const boost::filesystem::path& blob_dir);
   static uint64_t getDockerStoreSizeForAppUpdate(const uint64_t& compressed_update_size,
                                                  uint32_t average_compression_ratio);
+  static std::tuple<uint64_t, uint64_t> getPreciseAppUpdateSize(const Json::Value& app_layers,
+                                                                const boost::filesystem::path& blob_dir);
 
   void checkAvailableStorageInStores(const std::string& app_name, const uint64_t& skopeo_required_storage,
                                      const uint64_t& docker_required_storage) const;


### PR DESCRIPTION
This change enables aklite to utilize App layers metadata that contains precise disk usage information for each layer. As a result, aklite can calculate the App update size with a high level of accuracy. There are additional metadata that the docker store utilizes for each layer size/usage that are not considered by aklite. The overall size of these metadata does not depend on the layer size and is not significant.

If the App layers metadata is not found, aklite will fall back to an approximate calculation of the App update size.