### PR TITLE
Improve app storing and parsing

### DIFF
--- a/src/docker/restorableappengine.cc
+++ b/src/docker/restorableappengine.cc
@@ -144,17 +144,10 @@ AppEngine::Result RestorableAppEngine::verify(const App& app) {
   try {
     const Uri uri{Uri::parseUri(app.uri)};
     const auto app_dir{apps_root_ / uri.app / uri.digest.hash()};
-    const Manifest manifest{Utils::parseJSONFile(app_dir / Manifest::Filename)};
-    const auto archive_full_path{app_dir / (HashedDigest(manifest.archiveDigest()).hash() + Manifest::ArchiveExt)};
-    TemporaryDirectory app_tmp_dir;
 
-    // extract the compose file (i.e. docker-compose.yml) to a temporary directory to verify it.
-    exec(boost::format{"tar -xzf %s %s"} % archive_full_path % ComposeFile, "no compose file found in archive",
-         boost::process::start_dir = app_tmp_dir.Path());
-
-    LOG_DEBUG << app.name << ": verifying App: " << app_dir << " --> " << app_tmp_dir.Path();
+    LOG_DEBUG << app.name << ": verifying App: " << app_dir << " --> " << app_dir;
     exec(boost::format("%s config %s") % compose_cmd_ % "-q", "compose file verification failed",
-         boost::process::start_dir = app_tmp_dir.Path());
+         boost::process::start_dir = app_dir);
   } catch (const std::exception& exc) {
     LOG_ERROR << "failed to verify App; app: " + app.name + "; uri: " + app.uri + "; err: " + exc.what();
     res = {false, exc.what()};

--- a/src/docker/restorableappengine.cc
+++ b/src/docker/restorableappengine.cc
@@ -443,9 +443,9 @@ void RestorableAppEngine::pullApp(const Uri& uri, const boost::filesystem::path&
   registry_client_->downloadBlob(archive_uri, archive_full_path, manifest.archiveSize());
   Utils::writeFile(app_dir / Manifest::Filename, manifest_str);
   Utils::writeFile(app_dir / "uri", uri.registryHostname + "/" + uri.repo + "@" + uri.digest());
-  // extract docker-compose.yml, temporal hack, we don't need to extract it
-  exec(boost::format{"tar -xzf %s %s"} % archive_full_path % ComposeFile, "no compose file found in archive",
-       boost::process::start_dir = app_dir);
+  // Extract docker-compose.yml and safely persist it so the follow-up functionality doesn't need to do it again.
+  const auto compose{extractComposeFile(archive_full_path)};
+  Utils::writeFile(app_dir / ComposeFile, compose);
 }
 
 void RestorableAppEngine::checkAppUpdateSize(const Uri& uri, const boost::filesystem::path& app_dir) const {
@@ -617,18 +617,11 @@ bool RestorableAppEngine::isAppFetched(const App& app) const {
       break;
     }
 
-    // TODO: we actually should extract a compose file from the app archive, otherwise
-    // it won't be merkle tree like verification since this compose file can be hacked
-    // because it doesn't have any hash to be verified for.
-    // As an alternative we might consider adding a new attribute to an App root manifest that denotes a hash of a
-    // compose file. Or, a compose yaml should be excluded from an App's archive and considered as App config that is
-    // referenced by ["config"]["digest"] element of an App manifest. (currently this digest is equal to the hash of
-    // empty string)
-    const auto compose_file{app_dir / ComposeFile};
-    if (!boost::filesystem::exists(compose_file)) {
-      LOG_DEBUG << app.name << ": missing App compose file: " << compose_file;
-      break;
-    }
+    // Extract docker-compose.yml from the verified App archive regardless whether it has been extracted and stored on a
+    // file system before. We do it to make sure that the compose file from the verified archive is used by the
+    // follow-up functionality.
+    const auto compose{extractComposeFile(archive_full_path)};
+    Utils::writeFile(app_dir / ComposeFile, compose);
 
     // No need to check hashes of a Merkle tree of each App image since skopeo does it internally within in the `skopeo
     // copy` command. While the above statement is true there is still a need in traversing App's merkle tree at the
@@ -743,12 +736,7 @@ bool RestorableAppEngine::isAppInstalled(const App& app) const {
     const Manifest manifest{Utils::parseJSONFile(manifest_file)};
     const auto archive_manifest_hash{HashedDigest(manifest.archiveDigest()).hash()};
     const auto archive_full_path{app_dir / (archive_manifest_hash + Manifest::ArchiveExt)};
-
-    exec(boost::format{"tar -xzf %s %s"} % archive_full_path % ComposeFile,
-         app.name + ": failed to extract a compose file from the compose app archive",
-         boost::this_process::environment(), boost::process::start_dir = app_dir);
-
-    const auto compose_file_str = Utils::readFile(app_dir / ComposeFile);
+    const auto compose_file_str{extractComposeFile(archive_full_path)};
     const auto compose_file_hash =
         boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha256digest(compose_file_str)));
     const auto installed_compose_file_str = Utils::readFile(app_install_dir / ComposeFile);
@@ -1068,6 +1056,15 @@ void RestorableAppEngine::removeTmpFiles(const boost::filesystem::path& apps_roo
   } catch (const std::exception& exc) {
     LOG_ERROR << "Failed to find or remove skopeo's tmp files: " << exc.what();
   }
+}
+
+std::string RestorableAppEngine::extractComposeFile(const boost::filesystem::path& archive_path) {
+  const auto extract_compose_cmd{"tar --to-stdout -xzf " + archive_path.string() + " " + ComposeFile};
+  std::string compose;
+  if (Utils::shell(extract_compose_cmd, &compose, true) != EXIT_SUCCESS) {
+    throw std::runtime_error("Failed to extract " + ComposeFile + " from the App archive: " + compose);
+  }
+  return compose;
 }
 
 }  // namespace Docker

--- a/src/docker/restorableappengine.h
+++ b/src/docker/restorableappengine.h
@@ -165,6 +165,7 @@ class RestorableAppEngine : public AppEngine {
   static bool areDockerAndSkopeoOnTheSameVolume(const boost::filesystem::path& skopeo_path,
                                                 const boost::filesystem::path& docker_path);
   static std::tuple<uint64_t, bool> getPathVolumeID(const boost::filesystem::path& path);
+  static std::string extractComposeFile(const boost::filesystem::path& archive_path);
 
   const boost::filesystem::path store_root_;
   const boost::filesystem::path install_root_;

--- a/src/yaml2json.cc
+++ b/src/yaml2json.cc
@@ -1,15 +1,26 @@
 #include "yaml2json.h"
+
+#include <filesystem>
+
 #include <logging/logging.h>
 #include "utilities/utils.h"
 
 Yaml2Json::Yaml2Json(const std::string& yaml) {
+  if (!std::filesystem::exists(yaml)) {
+    throw std::invalid_argument("The specified `yaml` file is not found: " + yaml);
+  }
   std::string cmd = "/usr/bin/fy-tool --mode json " + yaml;
   std::string data;
-  if (Utils::shell(cmd, &data, true) == EXIT_SUCCESS) {
+  // Parse the input yaml file
+  if (Utils::shell(cmd, &data, true) != EXIT_SUCCESS) {
+    throw std::invalid_argument("Failed to parse the input `yaml` file; path: " + yaml + ", err: " + data);
+  }
+  // Parse the resultant json representation of the input yaml file
+  try {
     std::istringstream sin(data);
     sin >> root_;
-  }
-  if (root_.empty()) {
-    throw std::runtime_error(cmd.c_str());
+  } catch (const std::exception& exc) {
+    throw std::invalid_argument("Failed to parse the json representation of the input `yaml` file; path: " + yaml +
+                                ", err: " + exc.what());
   }
 }

--- a/tests/aklite_rollback_test.cc
+++ b/tests/aklite_rollback_test.cc
@@ -391,7 +391,7 @@ TEST_P(AkliteTest, OstreeAndAppRollbackIfAppsStartFails) {
 
   {
     boost::filesystem::remove(fixtures::ClientTest::test_dir_.Path() / "need_reboot");
-    device_gateway_.resetEvents();
+    device_gateway_.resetEvents(client->http_client);
     client = createLiteClient(InitialVersion::kOff, boost::none, false);
 
     ASSERT_FALSE(client->finalizeInstall());

--- a/tests/apiclient_test.cc
+++ b/tests/apiclient_test.cc
@@ -66,13 +66,16 @@ class ApiClientTest : public fixtures::ClientTest {
                                                boost::optional<std::vector<std::string>> apps = boost::none,
                                                bool finalize = true) override {
     app_engine_mock_ = std::make_shared<NiceMock<MockAppEngine>>();
-    return ClientTest::createLiteClient(app_engine_mock_, initial_version, apps);
+    lite_client_ = ClientTest::createLiteClient(app_engine_mock_, initial_version, apps);
+    return lite_client_;
   }
 
   std::shared_ptr<NiceMock<MockAppEngine>>& getAppEngine() { return app_engine_mock_; }
+  bool resetEvents() { return getDeviceGateway().resetEvents(lite_client_->http_client); }
 
  private:
   std::shared_ptr<NiceMock<MockAppEngine>> app_engine_mock_;
+  std::shared_ptr<LiteClient> lite_client_;
 };
 
 TEST_F(ApiClientTest, GetConfig) {
@@ -110,7 +113,7 @@ TEST_F(ApiClientTest, CheckIn) {
   ASSERT_EQ(1, result.Targets().size());
 
   ASSERT_TRUE(getDeviceGateway().resetSotaToml());
-  ASSERT_TRUE(getDeviceGateway().resetEvents());
+  ASSERT_TRUE(resetEvents());
 
   auto new_target = createTarget();
   result = client.CheckIn();
@@ -136,7 +139,7 @@ TEST_F(ApiClientTest, CheckInWithoutTargetImport) {
   ASSERT_EQ(0, result.Targets().size());
 
   ASSERT_TRUE(getDeviceGateway().resetSotaToml());
-  ASSERT_TRUE(getDeviceGateway().resetEvents());
+  ASSERT_TRUE(resetEvents());
 
   auto new_target = createTarget();
   result = client.CheckIn();
@@ -208,7 +211,7 @@ TEST_F(ApiClientTest, InstallWithCorrelationId) {
 
   auto latest = result.GetLatest();
 
-  getDeviceGateway().resetEvents();
+  resetEvents();
 
   auto installer = client.Installer(latest, "", "this-is-random");
   ASSERT_NE(nullptr, installer);

--- a/tests/device-gateway_fake.py
+++ b/tests/device-gateway_fake.py
@@ -136,7 +136,10 @@ class Handler(SimpleHTTPRequestHandler):
 
     def event_handler(self):
         logger.info("Device Gateway: POST /events request %s" % self.path)
-        self._dump_event()
+        if self.path.startswith(os.path.join(self.EventPrefix, "reset")):
+            self._reset_events()
+        else:
+            self._dump_event()
         self.send_response(200)
         self.send_header('Content-Length', '0')
         self.end_headers()
@@ -184,6 +187,10 @@ class Handler(SimpleHTTPRequestHandler):
                     cur_events.append(e)
                     event_ids.add(e["id"])
             json.dump(cur_events, f)
+
+    def _reset_events(self):
+        if os.path.exists(self.server.events_file):
+            os.remove(self.server.events_file)
 
 
 class FakeDeviceGateway(HTTPServer):

--- a/tests/fixtures/liteclient/devicegatewaymock.cc
+++ b/tests/fixtures/liteclient/devicegatewaymock.cc
@@ -51,7 +51,10 @@ class DeviceGatewayMock {
   const std::string& getPort() const { return port_; }
   Json::Value getReqHeaders() const { return Utils::parseJSONFile(req_headers_file_); }
   Json::Value getEvents() const { return Utils::parseJSONFile(events_file_); }
-  bool resetEvents() const { return boost::filesystem::remove(events_file_); }
+  bool resetEvents(std::shared_ptr<HttpClient> http_client) const {
+    const HttpResponse r = http_client->post(url_ + "/events/reset", Json::nullValue);
+    return r.isOk();
+  }
   std::string readSotaToml() const { return Utils::readFile(sota_toml_file_); }
   bool resetSotaToml() const { return boost::filesystem::remove(sota_toml_file_); }
 

--- a/tests/fixtures/liteclienttest.cc
+++ b/tests/fixtures/liteclienttest.cc
@@ -312,7 +312,7 @@ class ClientTest :virtual public ::testing::Test {
   void update(LiteClient& client, const Uptane::Target& from, const Uptane::Target& to,
               data::ResultCode::Numeric expected_install_code = data::ResultCode::Numeric::kNeedCompletion,
               DownloadResult expected_download_result = {DownloadResult::Status::Ok, ""}, const std::string& expected_install_err_msg = "", bool expect_boot_firmware = true) {
-    device_gateway_.resetEvents();
+    device_gateway_.resetEvents(client.http_client);
     // TODO: remove it once aklite is moved to the newer version of LiteClient that exposes update() method
     ASSERT_TRUE(client.checkForUpdatesBegin());
 
@@ -345,7 +345,7 @@ class ClientTest :virtual public ::testing::Test {
                   const std::string& download_err_msg = "",
                   data::ResultCode::Numeric expected_install_code = data::ResultCode::Numeric::kOk,
                   const std::string& install_err_msg = "") {
-    device_gateway_.resetEvents();
+    device_gateway_.resetEvents(client.http_client);
     // TODO: remove it once aklite is moved to the newer version of LiteClient that exposes update() method
     ASSERT_TRUE(client.checkForUpdatesBegin());
 


### PR DESCRIPTION
I was informed about the following error a few times:

```
Jul 11 20:01:04 stm32mp15-disco-3d00383338510b39303435 aktualizr-lite[920]: Checking Active Target status...
Jul 11 20:01:04 stm32mp15-disco-3d00383338510b39303435 aktualizr-lite[920]: App: shellhttpd, cannot check whether App is running: * Line 1, Column 1
Jul 11 20:01:04 stm32mp15-disco-3d00383338510b39303435 aktualizr-lite[920]:   Syntax error: value, object or array expected.
Jul 11 20:01:04 stm32mp15-disco-3d00383338510b39303435 aktualizr-lite[920]: shellhttpd update will be re-installed or completed
```

After investigation, I came to conclusion that that error message can appear only if `docker-compose.yml` is empty and produced by the `yaml2json` component. The `fy-tool` doesn't produce error if an input `yaml` file is empty, but the following conversion to json fails and prints the reported error message.

This change, improves error/edge cases handling in the `yaml2json` so meaningful error messages are output, as result we can understand what's going on.
Also, the question is: how come `docker-compose.yml` is empty? The only explanation is that the extraction call is not exactly save in terms of ensuring file persistence. So, this PR changes the compose file extraction logic to make sure it's safe and really persists the compose. 