### PR TITLE
ostree: Exit fetch retry loop if no space while pulling deltas

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -87,9 +87,11 @@ add_aktualizr_test(NAME liteclient
 
 target_compile_definitions(t_liteclient PRIVATE ${TEST_DEFS})
 target_include_directories(t_liteclient PRIVATE ${TEST_INCS} ${AKTUALIZR_DIR}/tests/ ${AKTUALIZR_DIR}/src/)
-target_link_libraries(t_liteclient ${MAIN_TARGET_LIB} ${TEST_LIBS} uptane_generator_lib testutilities)
+target_link_libraries(t_liteclient ${MAIN_TARGET_LIB} ${TEST_LIBS} uptane_generator_lib testutilities fstatvfs-mock)
 add_dependencies(t_liteclient make_ostree_sysroot)
+set_tests_properties(test_liteclient PROPERTIES ENVIRONMENT "LD_PRELOAD=${PROJECT_BINARY_DIR}/tests/libfstatvfs-mock.so")
 set_tests_properties(test_liteclient PROPERTIES LABELS "aklite:liteclient")
+
 
 aktualizr_source_file_checks(liteclient_test.cc)
 
@@ -254,3 +256,5 @@ target_include_directories(t_cli PRIVATE ${TEST_INCS} ${AKLITE_DIR}/include ${AK
 target_link_libraries(t_cli ${MAIN_TARGET_LIB} ${TEST_LIBS} uptane_generator_lib testutilities)
 add_dependencies(t_cli make_ostree_sysroot)
 set_tests_properties(test_cli PROPERTIES LABELS "aklite:cli")
+
+add_library(fstatvfs-mock SHARED fixtures/fstatvfs-mock.cc)

--- a/tests/fixtures/fstatvfs-mock.cc
+++ b/tests/fixtures/fstatvfs-mock.cc
@@ -1,0 +1,29 @@
+#include <cstdint>
+#include <sys/statvfs.h>
+#include <dlfcn.h>
+
+#ifndef __USE_FILE_OFFSET64
+static __fsblkcnt_t free_blocks_numb;
+#else
+static __fsblkcnt64_t free_blocks_numb;
+#endif
+static bool override_blocks_numb{false};
+
+void SetFreeBlockNumb(uint64_t free_blocks_numb_in) {
+  free_blocks_numb = free_blocks_numb_in;
+  override_blocks_numb = true;
+}
+
+void UnsetFreeBlockNumb() {
+  override_blocks_numb = false;
+}
+
+int fstatvfs (int fd, struct statvfs* buf) {
+  int (*original_fstatvfs)(int, struct statvfs*);
+  original_fstatvfs = (int (*)(int, struct statvfs*))dlsym(RTLD_NEXT, "fstatvfs");
+  int res = (*original_fstatvfs)(fd, buf);
+  if (override_blocks_numb) {
+    buf->f_bfree = free_blocks_numb;
+  }
+  return res;
+}

--- a/tests/fixtures/liteclient/ostreerepomock.cc
+++ b/tests/fixtures/liteclient/ostreerepomock.cc
@@ -21,6 +21,12 @@ class OSTreeRepoMock {
     executeCmd("ostree", { "config", "--repo", path_, "set", "core.mode", mode }, "set mode for repo " + path_);
   }
 
+  void generate_delta(const std::string& from, const std::string& to) {
+    executeCmd("ostree", {"static-delta", "generate", "--repo", path_, "--from", from, "--to", to},
+               "generate static delta between " + from + " and " + to);
+    executeCmd("ostree", {"summary", "--repo", path_, "-u"}, "update summary with delta indexes");
+  }
+
   const std::string& getPath() const { return path_; }
 
  private:

--- a/tests/fixtures/liteclienttest.cc
+++ b/tests/fixtures/liteclienttest.cc
@@ -102,6 +102,7 @@ class ClientTest :virtual public ::testing::Test {
       initial_target_.updateCustom(custom_value);
       if (initial_version != InitialVersion::kOff) {
         getTufRepo().addTarget(initial_target_.filename(), initial_target_.sha256Hash(), hw_id, initial_ver);
+        getOsTreeRepo().pullLocal(sys_repo_.getRepo().getPath(), sysroot_hash_);
       }
     }
 

--- a/tests/liteclient_test.cc
+++ b/tests/liteclient_test.cc
@@ -1,5 +1,6 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <sys/statvfs.h>
 
 #include <boost/filesystem.hpp>
 #include <boost/process.hpp>
@@ -25,6 +26,10 @@
 
 using ::testing::NiceMock;
 using ::testing::Return;
+
+// Defined in fstatvfs-mock.cc
+extern void SetFreeBlockNumb(uint64_t);
+extern void UnsetFreeBlockNumb();
 
 /**
  * Class MockAppEngine
@@ -189,6 +194,30 @@ TEST_P(LiteClientTestMultiPacman, OstreeUpdateNoSpace) {
   reboot(client);
   ASSERT_TRUE(targetsMatch(client->getCurrent(), getInitialTarget()));
   checkHeaders(*client, getInitialTarget());
+}
+
+TEST_P(LiteClientTestMultiPacman, OstreeUpdateNoSpaceIfStaticDelta) {
+  auto client = createLiteClient();
+  ASSERT_TRUE(targetsMatch(client->getCurrent(), getInitialTarget()));
+
+  // We need to generate new Target content that occupies at least a few blocks
+  // in order to get delta that has a size higher than one block.
+  fixtures::executeCmd("dd", {"if=/dev/urandom", "of=" + getSysRootFs().path + "/file.img", "bs=4K", "count=3"},
+                       "generate a file with random content");
+  auto new_target = createTarget();
+  getOsTreeRepo().generate_delta(getInitialTarget().sha256Hash(), new_target.sha256Hash());
+  SetFreeBlockNumb(1);
+  update(*client, getInitialTarget(), new_target, data::ResultCode::Numeric::kDownloadFailed,
+         {DownloadResult::Status::DownloadFailed_NoSpace, "Insufficient storage available"});
+  ASSERT_TRUE(targetsMatch(client->getCurrent(), getInitialTarget()));
+  UnsetFreeBlockNumb();
+  // reboot device
+  reboot(client);
+  ASSERT_TRUE(targetsMatch(client->getCurrent(), getInitialTarget()));
+  // try again when there is enough free storage
+  update(*client, getInitialTarget(), new_target);
+  reboot(client);
+  ASSERT_TRUE(targetsMatch(client->getCurrent(), new_target));
 }
 
 TEST_P(LiteClientTestMultiPacman, OstreeUpdateRollback) {


### PR DESCRIPTION
There is no point in continuing to attempt pulling static delta files if the pull error indicates that there is not enough storage space to accommodate them.

This change detects the delta pull error caused by a lack of storage space and instructs aklite to set a state where it won't attempt to pull the current target until more space becomes available.