### PR TITLE
Delta stat application: check update size before fetching update data

### DIFF
--- a/src/rootfstreemanager.cc
+++ b/src/rootfstreemanager.cc
@@ -14,10 +14,34 @@
 #include "storage/invstorage.h"
 #include "target.h"
 
+const unsigned int RootfsTreeManager::Config::DefaultSysrootStorageWatermark{90};
+const unsigned int RootfsTreeManager::Config::MinSysrootStorageWatermark{50};
+const unsigned int RootfsTreeManager::Config::MaxSysrootStorageWatermark{95};
+
 RootfsTreeManager::Config::Config(const PackageConfig& pconfig) {
   if (pconfig.extra.count(UpdateBlockParamName) == 1) {
     std::string val{pconfig.extra.at(UpdateBlockParamName)};
     UpdateBlock = val != "0" && val != "false";
+  }
+  if (pconfig.extra.count(SysrootStorageWatermarkParamName) == 1) {
+    const std::string val_str{pconfig.extra.at(SysrootStorageWatermarkParamName)};
+    try {
+      const auto val{boost::lexical_cast<unsigned int>(val_str)};
+      if (val < MinSysrootStorageWatermark) {
+        LOG_ERROR << "Value of `" << SysrootStorageWatermarkParamName << "` parameter is too low: " << val_str
+                  << "; setting it the minimum allowed: " << MinSysrootStorageWatermark;
+        SysrootStorageWatermark = MinSysrootStorageWatermark;
+      } else if (val > MaxSysrootStorageWatermark) {
+        LOG_ERROR << "Value of `" << SysrootStorageWatermarkParamName << "` parameter is too high: " << val_str
+                  << "; setting it the maximum allowed: " << MaxSysrootStorageWatermark;
+        SysrootStorageWatermark = MaxSysrootStorageWatermark;
+      } else {
+        SysrootStorageWatermark = val;
+      }
+    } catch (const std::exception& exc) {
+      LOG_ERROR << "Invalid value of `" << SysrootStorageWatermarkParamName << "` parameter: " << val_str
+                << "; setting it the default value: " << DefaultSysrootStorageWatermark;
+    }
   }
 }
 

--- a/src/rootfstreemanager.cc
+++ b/src/rootfstreemanager.cc
@@ -1,7 +1,15 @@
 #include "rootfstreemanager.h"
 
-#include <boost/algorithm/string.hpp>
+#include <fcntl.h>
+#include <sys/statvfs.h>
+#include <cstdio>
 
+#include <boost/algorithm/hex.hpp>
+#include <boost/algorithm/string.hpp>
+#include <boost/format.hpp>
+
+#include "crypto/crypto.h"
+#include "http/httpclient.h"
 #include "ostree/repo.h"
 #include "storage/invstorage.h"
 #include "target.h"
@@ -43,10 +51,29 @@ DownloadResult RootfsTreeManager::Download(const TufTarget& target) {
   data::InstallationResult pull_err{data::ResultCode::Numeric::kUnknown, ""};
   std::string error_desc;
   for (const auto& remote : remotes) {
-    LOG_INFO << "Fetching ostree commit " + target.Sha256Hash() + " from " + remote.baseUrl;
     if (!remote.isRemoteSet) {
       setRemote(remote.name, remote.baseUrl, remote.keys);
     }
+
+    DeltaStat delta_stat{};
+    if (getDeltaStatIfAvailable(target, remote, delta_stat)) {
+      LOG_INFO << "Found and pulled delta stats, checking if update can fit on a disk...";
+      UpdateStat update_stat{};
+      bool ok{canDeltaFitOnDisk(delta_stat, update_stat)};
+      const auto stat_msg{boost::format{"required %u, available %u out of %u(%u%% of the volume capacity %u)"} %
+                          update_stat.deltaSize % update_stat.available % update_stat.maxAvailable %
+                          update_stat.highWatermark % update_stat.storageCapacity};
+
+      if (!ok) {
+        return {DownloadResult::Status::DownloadFailed_NoSpace,
+                "Insufficient storage available; err: " + stat_msg.str(), sysroot_->path()};
+      }
+      LOG_INFO << "Fetching static delta; " + stat_msg.str();
+    } else {
+      LOG_INFO << "No static delta or static delta stats are found, skipping the update size check...";
+      LOG_INFO << "Fetching ostree commit " + target.Sha256Hash() + " from " + remote.baseUrl;
+    }
+
     pull_err = OstreeManager::pull(config.sysroot, remote.baseUrl, keys_, Target::fromTufTarget(target), nullptr,
                                    prog_cb, remote.isRemoteSet ? nullptr : remote.name.c_str(), remote.headers);
     if (pull_err.isSuccess()) {
@@ -249,4 +276,152 @@ data::InstallationResult RootfsTreeManager::verifyBootloaderUpdate(const Uptane:
   }
 
   return data::InstallationResult(data::ResultCode::Numeric::kOk, "");
+}
+
+bool RootfsTreeManager::getDeltaStatIfAvailable(const TufTarget& target, const Remote& remote,
+                                                DeltaStat& delta_stat) const {
+  try {
+    DeltaStatsRef delta_stats_ref;
+    if (!getDeltaStatsRef(target.Custom(), delta_stats_ref)) {
+      LOG_INFO << "No reference to static delta stats found in Target";
+      return false;
+    }
+    LOG_INFO << "Found reference to a file with static delta stats, downloading it...";
+    Json::Value delta_stats_json{downloadDeltaStats(delta_stats_ref, remote)};
+    if (delta_stats_json.isNull()) {
+      return false;
+    }
+    LOG_INFO << "File with static delta stats has been downloaded, parsing it...";
+    if (!findDeltaStatForUpdate(delta_stats_json, getCurrentHash(), target.Sha256Hash(), delta_stat)) {
+      LOG_ERROR << "No delta stat found between " << getCurrentHash() << " and " << target.Sha256Hash();
+      return false;
+    }
+    return true;
+  } catch (const std::exception& exc) {
+    LOG_ERROR << "Error occurred while getting static delta stats: " << exc.what();
+  }
+  return false;
+}
+
+bool RootfsTreeManager::canDeltaFitOnDisk(const DeltaStat& delta_stat, UpdateStat& update_stat) const {
+  StorageStat storage{};
+  getStorageStat(sysroot_->path(), storage);
+  const auto highWatermark{getStorageHighWatermark()};
+
+  const uint64_t max_blocks_available = std::floor(storage.blockNumb * (static_cast<double>(highWatermark) / 100));
+  const uint64_t blocks_in_use = storage.blockNumb - storage.freeBlockNumb;
+  const uint64_t max_blocks_available_for_update =
+      (max_blocks_available > blocks_in_use) ? (max_blocks_available - blocks_in_use) : 0;
+  const uint64_t blocks_required_by_delta = (delta_stat.uncompressedSize / storage.blockSize) +
+                                            ((delta_stat.uncompressedSize % storage.blockSize != 0) ? 1 : 0);
+
+  update_stat.storageCapacity = storage.blockSize * storage.blockNumb;
+  update_stat.highWatermark = highWatermark;
+  update_stat.maxAvailable = max_blocks_available * storage.blockSize;
+  update_stat.available = max_blocks_available_for_update * storage.blockSize;
+  update_stat.deltaSize = delta_stat.uncompressedSize;
+
+  return blocks_required_by_delta <= max_blocks_available_for_update;
+}
+
+bool RootfsTreeManager::getDeltaStatsRef(const Json::Value& json, DeltaStatsRef& ref) {
+  if (!json.isMember("delta-stats")) {
+    return false;
+  }
+  const auto delta_stats_ref{json["delta-stats"]};
+  if (!delta_stats_ref.isMember("sha256") || !delta_stats_ref["sha256"].isString()) {
+    LOG_ERROR << "Incorrect metadata about static delta statistics are found in Target;"
+              << " err: missing `sha256` field or it's not a string";
+    return false;
+  }
+  if (!delta_stats_ref.isMember("size") || !delta_stats_ref["size"].isUInt()) {
+    LOG_ERROR << "Incorrect metadata about static delta statistics are found in Target;"
+              << " err: missing `size` field or it's not an integer";
+    return false;
+  }
+  ref = {delta_stats_ref["sha256"].asString(), delta_stats_ref["size"].asUInt()};
+  return true;
+}
+
+Json::Value RootfsTreeManager::downloadDeltaStats(const DeltaStatsRef& ref, const Remote& remote) {
+  static const uint64_t DeltaStatsMaxSize{1024 * 1024};
+  const std::string uri = remote.baseUrl + "/delta-stats/" + ref.sha256;
+
+  if (ref.size > DeltaStatsMaxSize) {
+    LOG_ERROR << "Requested delta stat file has higher size than maximum allowed; "
+                 " requested size: "
+              << ref.size << ", maximum allowed: " << DeltaStatsMaxSize;
+    return Json::nullValue;
+  }
+  std::vector<std::string> extra_headers;
+  for (const auto& header : remote.headers) {
+    extra_headers.emplace_back(header.first + ": " + header.second);
+  }
+  auto client{HttpClient(&extra_headers)};
+
+  LOG_INFO << "Fetching delta stats -> " << uri;
+  const auto resp = client.get(uri, ref.size);
+  if (!resp.isOk()) {
+    LOG_ERROR << "Failed to fetch static delta stats; status: " << resp.getStatusStr() << ", err: " << resp.body;
+    return Json::nullValue;
+  }
+  if (resp.body.size() != ref.size) {
+    LOG_ERROR << "Fetched invalid static delta stats, size mismatch; "
+              << " expected: " << ref.size << ", got: " << resp.body.size();
+    return Json::nullValue;
+  }
+  const auto received_data_hash{
+      boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha256digest(resp.body)))};
+  if (received_data_hash != ref.sha256) {
+    LOG_ERROR << "Fetched invalid static delta stats, hash mismatch; "
+              << " expected: " << ref.sha256 << ", got: " << received_data_hash;
+    return Json::nullValue;
+  }
+  return resp.getJson();
+}
+
+bool RootfsTreeManager::findDeltaStatForUpdate(const Json::Value& delta_stats, const std::string& from,
+                                               const std::string& to, DeltaStat& found_delta_stat) {
+  if (!delta_stats.isMember(to)) {
+    LOG_ERROR << "Invalid delta stats received; no `to` hash is found: " << to;
+    return false;
+  }
+  const auto& to_json{delta_stats[to]};
+  Json::Value found_delta;
+  for (Json::ValueConstIterator it = to_json.begin(); it != to_json.end(); ++it) {
+    if (it.key().asString() == from) {
+      found_delta = *it;
+      break;
+    }
+  }
+  if (!found_delta) {
+    return false;
+  }
+  if (!found_delta.isMember("size") || !found_delta["size"].isUInt64()) {
+    LOG_ERROR << "Invalid delta stat has been found; `size` field is missing or is not `uint64`, " << found_delta;
+    return false;
+  }
+  if (!found_delta.isMember("u_size") || !found_delta["u_size"].isUInt64()) {
+    LOG_ERROR << "Invalid delta stat has been found; `u_size` field is missing or is not `uint64`, " << found_delta;
+    return false;
+  }
+  found_delta_stat = {found_delta["size"].asUInt64(), found_delta["u_size"].asUInt64()};
+  return true;
+}
+
+void RootfsTreeManager::getStorageStat(const std::string& path, StorageStat& stat_out) {
+  int fd{-1};
+  if ((fd = open(path.c_str(), O_DIRECTORY | O_RDONLY)) == -1) {
+    throw std::runtime_error(std::string("Failed to obtain a sysroot directory file descriptor; err: ") +
+                             std::strerror(errno));
+  }
+  struct statvfs fs_stat {};
+  if (-1 == fstatvfs(fd, &fs_stat)) {
+    throw std::runtime_error(std::string("Failed to obtain statistic about the sysroot directory; err: ") +
+                             std::strerror(errno));
+  }
+
+  stat_out.freeBlockNumb = (getuid() != 0 ? fs_stat.f_bavail : fs_stat.f_bfree);
+  stat_out.blockNumb = fs_stat.f_blocks;
+  stat_out.blockSize = fs_stat.f_bsize;  // f_frsize == f_bsize on the linux-based systems
 }

--- a/src/rootfstreemanager.h
+++ b/src/rootfstreemanager.h
@@ -10,6 +10,16 @@
 class RootfsTreeManager : public OstreeManager, public Downloader {
  public:
   static constexpr const char* const Name{"ostree"};
+  struct Config {
+   public:
+    explicit Config(const PackageConfig& pconfig);
+
+    static constexpr const char* const UpdateBlockParamName{"ostree_update_block"};
+
+    // A flag enabling/disabling ostree update blocking if there is ongoing boot firmware update
+    // that requires confirmation by means of reboot.
+    bool UpdateBlock{true};
+  };
   using RequestHeaders = std::unordered_map<std::string, std::string>;
   struct Remote {
     std::string name;
@@ -81,9 +91,7 @@ class RootfsTreeManager : public OstreeManager, public Downloader {
   std::unique_ptr<bootloader::BootFwUpdateStatus> boot_fw_update_status_;
   std::shared_ptr<HttpInterface> http_client_;
   const std::string gateway_url_;
-  // A flag enabling/disabling ostree update blocking if there is ongoing boot firmware update
-  // that requires confirmation by means of reboot.
-  bool update_block_{true};
+  const Config cfg_;
 };
 
 #endif  // AKTUALIZR_LITE_ROOTFS_TREE_MANAGER_H_

--- a/src/rootfstreemanager.h
+++ b/src/rootfstreemanager.h
@@ -15,10 +15,19 @@ class RootfsTreeManager : public OstreeManager, public Downloader {
     explicit Config(const PackageConfig& pconfig);
 
     static constexpr const char* const UpdateBlockParamName{"ostree_update_block"};
+    static constexpr const char* const SysrootStorageWatermarkParamName{"sysroot_storage_watermark"};
+    static const unsigned int DefaultSysrootStorageWatermark;
+    static const unsigned int MinSysrootStorageWatermark;
+    static const unsigned int MaxSysrootStorageWatermark;
 
     // A flag enabling/disabling ostree update blocking if there is ongoing boot firmware update
     // that requires confirmation by means of reboot.
     bool UpdateBlock{true};
+
+    // A high watermark for storage usage, expressed as a percentage,
+    // in other words, up to X% of the overall volume capacity can be used.
+    // The volume on which the sysroot is persisted is what is meant in this context.
+    unsigned int SysrootStorageWatermark{DefaultSysrootStorageWatermark};
   };
   using RequestHeaders = std::unordered_map<std::string, std::string>;
   struct Remote {
@@ -78,7 +87,7 @@ class RootfsTreeManager : public OstreeManager, public Downloader {
   data::InstallationResult verifyBootloaderUpdate(const Uptane::Target& target) const;
   bool getDeltaStatIfAvailable(const TufTarget& target, const Remote& remote, DeltaStat& delta_stat) const;
   bool canDeltaFitOnDisk(const DeltaStat& delta_stat, UpdateStat& update_stat) const;
-  static unsigned int getStorageHighWatermark() { return 90; /* TODO */ };
+  unsigned int getStorageHighWatermark() const { return cfg_.SysrootStorageWatermark; };
 
   static bool getDeltaStatsRef(const Json::Value& json, DeltaStatsRef& ref);
   static Json::Value downloadDeltaStats(const DeltaStatsRef& ref, const Remote& remote);

--- a/tests/boot_flag_mgmt_test.cc
+++ b/tests/boot_flag_mgmt_test.cc
@@ -84,7 +84,7 @@ class BootFlagMgmtTestSuite : public BootFlagMgmtTest,
     std::tie(pacman_type, bootloader_mode) = GetParam();
     conf.pacman.type = pacman_type;
     conf.bootloader.rollback_mode = bootloader_mode;
-    conf.pacman.extra["ostree_update_block"] = "1";
+    conf.pacman.extra[RootfsTreeManager::Config::UpdateBlockParamName] = "1";
     bootloader_type_ = bootloader_mode;
   };
 };

--- a/tests/cli_test.cc
+++ b/tests/cli_test.cc
@@ -43,7 +43,7 @@ class CliClient : public AkliteTest {
   void tweakConf(Config& conf) override {
     conf.pacman.ostree_server = ostree_server_uri_;
     conf.uptane.repo_server = tuf_repo_server_;
-    conf.pacman.extra["ostree_update_block"] = "1";
+    conf.pacman.extra[RootfsTreeManager::Config::UpdateBlockParamName] = "1";
   }
 
  protected:

--- a/tests/fixtures/liteclient/sysostreerepomock.cc
+++ b/tests/fixtures/liteclient/sysostreerepomock.cc
@@ -20,6 +20,10 @@ class SysOSTreeRepoMock {
     executeCmd("ostree", { "--repo=" + path_ + "/ostree/repo", "config", "set", "core.min-free-space-size", size }, "set config " + size);
   }
 
+  void setMinFreeSpacePercent(const std::string& size_in_percents) {
+    executeCmd("ostree", { "--repo=" + path_ + "/ostree/repo", "config", "set", "core.min-free-space-percent", size_in_percents }, "set config " + size_in_percents);
+  }
+
   std::string getDeploymentPath() const { return path_ + "/ostree/deploy/" + os_ + "/deploy"; }
 
  private:

--- a/tests/nospace_test.cc
+++ b/tests/nospace_test.cc
@@ -67,6 +67,45 @@ class NoSpaceTest : public fixtures::ClientTest {
   std::shared_ptr<NiceMock<MockAppEngine>> app_engine_mock_;
 };
 
+TEST_F(NoSpaceTest, SysrootStorageWatermarkParam) {
+  {
+    // check default value
+    const auto cfg{RootfsTreeManager::Config(PackageConfig{})};
+    ASSERT_EQ(RootfsTreeManager::Config::DefaultSysrootStorageWatermark, cfg.SysrootStorageWatermark);
+  }
+  {
+    // check if set to the default value if the specified param value is ivalid
+    PackageConfig pacmancfg;
+    pacmancfg.extra[RootfsTreeManager::Config::SysrootStorageWatermarkParamName] = "10foo";
+    const auto cfg{RootfsTreeManager::Config(pacmancfg)};
+    ASSERT_EQ(RootfsTreeManager::Config::DefaultSysrootStorageWatermark, cfg.SysrootStorageWatermark);
+  }
+  {
+    // check if set to the min allowed value if the specified param value is lower than the one
+    PackageConfig pacmancfg;
+    pacmancfg.extra[RootfsTreeManager::Config::SysrootStorageWatermarkParamName] =
+        std::to_string(RootfsTreeManager::Config::MinSysrootStorageWatermark - 1);
+    const auto cfg{RootfsTreeManager::Config(pacmancfg)};
+    ASSERT_EQ(RootfsTreeManager::Config::MinSysrootStorageWatermark, cfg.SysrootStorageWatermark);
+  }
+  {
+    // check if set to the max allowed value if the specified param value is higher than the one
+    PackageConfig pacmancfg;
+    pacmancfg.extra[RootfsTreeManager::Config::SysrootStorageWatermarkParamName] =
+        std::to_string(RootfsTreeManager::Config::MaxSysrootStorageWatermark + 1);
+    const auto cfg{RootfsTreeManager::Config(pacmancfg)};
+    ASSERT_EQ(RootfsTreeManager::Config::MaxSysrootStorageWatermark, cfg.SysrootStorageWatermark);
+  }
+  {
+    // check if a custom valid value can be set
+    PackageConfig pacmancfg;
+    const unsigned int my_watermark{93};
+    pacmancfg.extra[RootfsTreeManager::Config::SysrootStorageWatermarkParamName] = std::to_string(my_watermark);
+    const auto cfg{RootfsTreeManager::Config(pacmancfg)};
+    ASSERT_EQ(my_watermark, cfg.SysrootStorageWatermark);
+  }
+}
+
 TEST_F(NoSpaceTest, OstreeUpdateNoSpace) {
   // boot device
   auto client = createLiteClient();


### PR DESCRIPTION
- Pull delta statistics for a given update if available.
  
- If available, then check if there is enough free storage available
  taking into account the storage watermark.
    
- Don't pull update/ostree if there is not enough free storage available
  and exit with the corresponding error.
    
- Add unit tests for the given use-case.
