### PR TITLE
Unify and improve free space verification

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@ set(TARGET_EXE aktualizr-lite)
 set(TARGET_LIB ${MAIN_TARGET_LIB})
 
 set(SRC helpers.cc
+        storage/stat.cc
         composeappmanager.cc
         rootfstreemanager.cc
         docker/restorableappengine.cc
@@ -20,6 +21,7 @@ set(SRC helpers.cc
         api.cc)
 
 set(HEADERS helpers.h
+        storage/stat.h
         composeappmanager.h
         rootfstreemanager.h
         docker/restorableappengine.h

--- a/src/composeappmanager.cc
+++ b/src/composeappmanager.cc
@@ -248,7 +248,7 @@ DownloadResult ComposeAppManager::Download(const TufTarget& target) {
     return ostree_download_res;
   }
 
-  DownloadResult res{DownloadResult::Status::Ok, ""};
+  DownloadResult res{ostree_download_res};
   const Uptane::Target uptane_target{Target::fromTufTarget(target)};
 
   if (cfg_.force_update) {

--- a/src/ostree/sysroot.cc
+++ b/src/ostree/sysroot.cc
@@ -7,54 +7,56 @@
 
 namespace OSTree {
 
-const unsigned int Sysroot::Config::DefaultStorageWatermark{90};
-const unsigned int Sysroot::Config::MinStorageWatermark{50};
-const unsigned int Sysroot::Config::MaxStorageWatermark{95};
+const unsigned int Sysroot::Config::DefaultReservedStorageSpacePercentageDelta{5};
+const unsigned int Sysroot::Config::MinReservedStorageSpacePercentageDelta{3};
+const unsigned int Sysroot::Config::MaxReservedStorageSpacePercentageDelta{50};
 
-const unsigned int Sysroot::Config::MinFreeSpacePercent{3};
-const unsigned int Sysroot::Config::MaxFreeSpacePercent{50};
+const unsigned int Sysroot::Config::MinReservedStorageSpacePercentageOstree{3};
+const unsigned int Sysroot::Config::MaxReservedStorageSpacePercentageOstree{50};
 
 Sysroot::Config::Config(const PackageConfig& pconfig) {
-  Path = pconfig.sysroot.string();
-  Type = pconfig.booted;
-  OsName = pconfig.os.empty() ? "lmp" : pconfig.os;
+  path = pconfig.sysroot.string();
+  type = pconfig.booted;
+  osname = pconfig.os.empty() ? "lmp" : pconfig.os;
 
-  if (pconfig.extra.count(StorageWatermarkParamName) == 1) {
-    const std::string val_str{pconfig.extra.at(StorageWatermarkParamName)};
+  if (pconfig.extra.count(ReservedStorageSpacePercentageDeltaParamName) == 1) {
+    const std::string val_str{pconfig.extra.at(ReservedStorageSpacePercentageDeltaParamName)};
     try {
       const auto val{boost::lexical_cast<unsigned int>(val_str)};
-      if (val < MinStorageWatermark) {
-        LOG_ERROR << "Value of `" << StorageWatermarkParamName << "` parameter is too low: " << val_str
-                  << "; setting it the minimum allowed: " << MinStorageWatermark;
-        StorageWatermark = MinStorageWatermark;
-      } else if (val > MaxStorageWatermark) {
-        LOG_ERROR << "Value of `" << StorageWatermarkParamName << "` parameter is too high: " << val_str
-                  << "; setting it the maximum allowed: " << MaxStorageWatermark;
-        StorageWatermark = MaxStorageWatermark;
+      if (val < MinReservedStorageSpacePercentageDelta) {
+        LOG_ERROR << "Value of `" << ReservedStorageSpacePercentageDeltaParamName
+                  << "` parameter is too low: " << val_str
+                  << "; setting it the minimum allowed: " << MinReservedStorageSpacePercentageDelta;
+        ReservedStorageSpacePercentageDelta = MinReservedStorageSpacePercentageDelta;
+      } else if (val > MaxReservedStorageSpacePercentageDelta) {
+        LOG_ERROR << "Value of `" << ReservedStorageSpacePercentageDeltaParamName
+                  << "` parameter is too high: " << val_str
+                  << "; setting it the maximum allowed: " << MaxReservedStorageSpacePercentageDelta;
+        ReservedStorageSpacePercentageDelta = MaxReservedStorageSpacePercentageDelta;
       } else {
-        StorageWatermark = val;
+        ReservedStorageSpacePercentageDelta = val;
       }
     } catch (const std::exception& exc) {
-      LOG_ERROR << "Invalid value of `" << StorageWatermarkParamName << "` parameter: " << val_str
-                << "; setting it the default value: " << DefaultStorageWatermark;
+      LOG_ERROR << "Invalid value of `" << ReservedStorageSpacePercentageDeltaParamName << "` parameter: " << val_str
+                << "; setting it the default value: " << DefaultReservedStorageSpacePercentageDelta;
     }
   }
 
-  if (pconfig.extra.count(StorageFreeSpacePercentParamName) == 1) {
-    const std::string val_str{pconfig.extra.at(StorageFreeSpacePercentParamName)};
+  if (pconfig.extra.count(ReservedStorageSpacePercentageOstreeParamName) == 1) {
+    const std::string val_str{pconfig.extra.at(ReservedStorageSpacePercentageOstreeParamName)};
     try {
       const auto val{boost::lexical_cast<unsigned int>(val_str)};
-      if (val < MinFreeSpacePercent) {
-        LOG_ERROR << "Value of `" << StorageFreeSpacePercentParamName << "` parameter is too low: " << val_str
-                  << "; won't override the value set in the ostree config";
-      } else if (val > MaxFreeSpacePercent) {
-        LOG_ERROR << "Value of `" << StorageFreeSpacePercentParamName << "` parameter is too high: " << val_str
-                  << "; won't override the value set in the ostree config";
+      if (val < MinReservedStorageSpacePercentageOstree) {
+        LOG_ERROR << "Value of `" << ReservedStorageSpacePercentageOstreeParamName
+                  << "` parameter is too low: " << val_str << "; won't override the value set in the ostree config";
+      } else if (val > MaxReservedStorageSpacePercentageOstree) {
+        LOG_ERROR << "Value of `" << ReservedStorageSpacePercentageOstreeParamName
+                  << "` parameter is too high: " << val_str << "; won't override the value set in the ostree config";
       } else {
-        StorageFreeSpacePercent = val;
+        ReservedStorageSpacePercentageOstree = val;
       }
     } catch (const std::exception& exc) {
-      LOG_ERROR << "Invalid value of `" << StorageFreeSpacePercentParamName << "` parameter: " << val_str
+      LOG_ERROR << "Invalid value of `" << ReservedStorageSpacePercentageOstreeParamName << "` parameter: " << val_str
                 << "; won't override the value set in the ostree config";
     }
   }
@@ -62,36 +64,41 @@ Sysroot::Config::Config(const PackageConfig& pconfig) {
 
 Sysroot::Sysroot(const PackageConfig& pconfig)
     : cfg_{pconfig},
-      repo_path_{cfg_.Path + "/ostree/repo"},
-      deployment_path_{cfg_.Path + "/ostree/deploy/" + cfg_.OsName + "/deploy"} {
+      repo_path_{cfg_.path + "/ostree/repo"},
+      deployment_path_{cfg_.path + "/ostree/deploy/" + cfg_.osname + "/deploy"} {
   Repo repo{repo_path_};
   const auto ostree_min_free_space{repo.getFreeSpacePercent()};
-  if (-1 == cfg_.StorageFreeSpacePercent) {
+  if (-1 == cfg_.ReservedStorageSpacePercentageOstree) {
     LOG_DEBUG
         << "Minimum free space percentage is not overridden, applying the one that is configured in the ostree config: "
         << ostree_min_free_space;
   } else {
     try {
-      repo.setFreeSpacePercent(cfg_.StorageFreeSpacePercent);
+      repo.setFreeSpacePercent(cfg_.ReservedStorageSpacePercentageOstree);
       LOG_DEBUG << "Minimum free space percentage is overridden; "
-                << "from " << ostree_min_free_space << " to  " << cfg_.StorageFreeSpacePercent;
+                << "from " << ostree_min_free_space << " to  " << cfg_.ReservedStorageSpacePercentageOstree;
     } catch (const std::exception& exc) {
       LOG_ERROR << "Failed to override `min-free-space-percent` value in the ostree config, applying the one that is "
                    "configured in the ostree config: "
                 << ostree_min_free_space << "; err: " << exc.what();
     }
   }
-  sysroot_ = OstreeManager::LoadSysroot(cfg_.Path);
+  sysroot_ = OstreeManager::LoadSysroot(cfg_.path);
 }
 
 bool Sysroot::reload() {
   // Just reload for the booted env. In non-booted env "pending" deployment becomes "current" just after installation
   // without a need to reboot. It in turns invalidates "getCurrent" value for tests at the stage after installation and
   // before reboot.
-  if (cfg_.Type == BootedType::kBooted) {
+  if (cfg_.type == BootedType::kBooted) {
     return static_cast<bool>(ostree_sysroot_load_if_changed(sysroot_.get(), nullptr, nullptr, nullptr));
   }
   return true;
+}
+
+unsigned int Sysroot::reservedStorageSpacePercentageOstree() const {
+  OSTree::Repo repo{repoPath()};
+  return repo.getFreeSpacePercent();
 }
 
 std::string Sysroot::getDeploymentHash(Deployment deployment_type) const {
@@ -99,28 +106,28 @@ std::string Sysroot::getDeploymentHash(Deployment deployment_type) const {
   g_autoptr(GPtrArray) deployments = nullptr;
   OstreeDeployment* deployment = nullptr;
 
-  switch (cfg_.Type) {
+  switch (cfg_.type) {
     case BootedType::kBooted:
-      deployment = getDeploymentIfBooted(sysroot_.get(), cfg_.OsName.c_str(), deployment_type);
+      deployment = getDeploymentIfBooted(sysroot_.get(), cfg_.osname.c_str(), deployment_type);
       break;
     case BootedType::kStaged:
       if (deployment_type == Deployment::kPending) {
-        OstreeDeployment* cur_deployment = getDeploymentIfStaged(sysroot_.get(), cfg_.OsName.c_str(), deployment_type);
+        OstreeDeployment* cur_deployment = getDeploymentIfStaged(sysroot_.get(), cfg_.osname.c_str(), deployment_type);
         // Load the sysroot to make sure we get its latest state, so we can get real "pending" deployment caused by
         // successful installation
-        GObjectUniquePtr<OstreeSysroot> changed_sysroot = OstreeManager::LoadSysroot(cfg_.Path);
+        GObjectUniquePtr<OstreeSysroot> changed_sysroot = OstreeManager::LoadSysroot(cfg_.path);
         OstreeDeployment* pend_deployment =
-            getDeploymentIfStaged(changed_sysroot.get(), cfg_.OsName.c_str(), deployment_type);
+            getDeploymentIfStaged(changed_sysroot.get(), cfg_.osname.c_str(), deployment_type);
         deployment =
             (strcmp(ostree_deployment_get_csum(pend_deployment), ostree_deployment_get_csum(cur_deployment)) == 0)
                 ? nullptr
                 : pend_deployment;
       } else {
-        deployment = getDeploymentIfStaged(sysroot_.get(), cfg_.OsName.c_str(), deployment_type);
+        deployment = getDeploymentIfStaged(sysroot_.get(), cfg_.osname.c_str(), deployment_type);
       }
       break;
     default:
-      throw std::runtime_error("Invalid boot type: " + std::to_string(static_cast<int>(cfg_.Type)));
+      throw std::runtime_error("Invalid boot type: " + std::to_string(static_cast<int>(cfg_.type)));
   }
 
   if (deployment != nullptr) {

--- a/src/ostree/sysroot.h
+++ b/src/ostree/sysroot.h
@@ -14,30 +14,38 @@ class Sysroot {
    public:
     explicit Config(const PackageConfig& pconfig);
 
-    static constexpr const char* const StorageWatermarkParamName{"sysroot_storage_watermark"};
-    static const unsigned int DefaultStorageWatermark;
-    static const unsigned int MinStorageWatermark;
-    static const unsigned int MaxStorageWatermark;
+    static constexpr const char* const ReservedStorageSpacePercentageDeltaParamName{
+        "sysroot_delta_reserved_space_percentage"};
+    static const unsigned int DefaultReservedStorageSpacePercentageDelta;
+    static const unsigned int MinReservedStorageSpacePercentageDelta;
+    static const unsigned int MaxReservedStorageSpacePercentageDelta;
 
-    static constexpr const char* const StorageFreeSpacePercentParamName{"min_free_space_percent"};
-    static const unsigned int MinFreeSpacePercent;
-    static const unsigned int MaxFreeSpacePercent;
+    static constexpr const char* const ReservedStorageSpacePercentageOstreeParamName{
+        "sysroot_ostree_reserved_space_percentage"};
+    static const unsigned int MinReservedStorageSpacePercentageOstree;
+    static const unsigned int MaxReservedStorageSpacePercentageOstree;
 
-    // A high watermark for storage usage, expressed as a percentage,
-    // in other words, up to X% of the overall volume capacity can be used.
-    // The volume on which the sysroot is persisted is what is meant in this context.
-    unsigned int StorageWatermark{DefaultStorageWatermark};
+    // This variable represents the reserved amount of storage, expressed as a percentage
+    // of the overall capacity of the volume where the sysroot/ostree repo is located.
+    // The reserved percentage is only considered when performing a delta-based ostree pull.
+    // The downloader verifies that the reserved storage will remain untouched prior to initiating a delta-based ostree
+    // pull. If the available free space, in addition to the reserved space, is insufficient to fit delta files, then
+    // the downloader will reject the download and exit with an error.
+    unsigned int ReservedStorageSpacePercentageDelta{DefaultReservedStorageSpacePercentageDelta};
 
-    // A low watermark for storage free space expressed as a percentage.
-    // In other words, at least X% of the overall volume capacity must be free, or
-    // up to (100 - X%) of the overall volume capacity can be used.
-    // This parameter is intended solely for the non-delta case.
+    // This variable represents the reserved amount of storage, expressed as a percentage
+    // of the overall capacity of the volume where the sysroot/ostree repo is located.
+    // The reserved percentage is considered in the both cases, during performing
+    // an object-based ostree pull and delta-based ostree pull.
+    // The downloader guarantees that the reserved storage is untouched when ostree objects are being committed to an
+    // ostree repo. If the available free space, in addition to the reserved space, is insufficient to fit object files,
+    // then the downloader will reject the download and exit with an error.
     // Effectively, it enforces setting of the ostree repo config param `core.min-free-space-percent`.
-    int StorageFreeSpacePercent{-1};
+    int ReservedStorageSpacePercentageOstree{-1};
 
-    std::string Path;
-    BootedType Type;
-    std::string OsName;
+    std::string path;
+    BootedType type;
+    std::string osname;
   };
 
   enum class Deployment { kCurrent = 0, kPending, kRollback };
@@ -45,13 +53,14 @@ class Sysroot {
 
   explicit Sysroot(const PackageConfig& pconfig);
 
-  const std::string& path() const { return cfg_.Path; }
+  const std::string& path() const { return cfg_.path; }
   const std::string& repoPath() const { return repo_path_; }
   const std::string& deployment_path() const { return deployment_path_; }
 
   virtual std::string getDeploymentHash(Deployment deployment_type) const;
   bool reload();
-  unsigned int storageWatermark() const { return cfg_.StorageWatermark; }
+  unsigned int reservedStorageSpacePercentageDelta() const { return cfg_.ReservedStorageSpacePercentageDelta; }
+  unsigned int reservedStorageSpacePercentageOstree() const;
 
  private:
   static OstreeDeployment* getDeploymentIfBooted(OstreeSysroot* sysroot, const char* os_name,

--- a/src/rootfstreemanager.cc
+++ b/src/rootfstreemanager.cc
@@ -114,8 +114,9 @@ DownloadResult RootfsTreeManager::Download(const TufTarget& target) {
              sysroot_->repoPath()};
       break;
     }
-    error_desc += pull_err.description + "\n";
-    res = {DownloadResult::Status::DownloadFailed, error_desc};
+    error_desc += pull_err.description + "\nbefore ostree pull; " + pre_pull_usage_info.str() +
+                  "\nafter ostree pull; " + post_pull_usage_info.str();
+    res = {DownloadResult::Status::DownloadFailed, error_desc, sysroot_->repoPath()};
   }
 
   return res;

--- a/src/rootfstreemanager.cc
+++ b/src/rootfstreemanager.cc
@@ -314,7 +314,7 @@ bool RootfsTreeManager::getDeltaStatIfAvailable(const TufTarget& target, const R
 bool RootfsTreeManager::canDeltaFitOnDisk(const DeltaStat& delta_stat, UpdateStat& update_stat) const {
   StorageStat storage{};
   getStorageStat(sysroot_->repoPath(), storage);
-  const auto highWatermark{getStorageHighWatermark()};
+  const auto highWatermark{100 - sysroot_->reservedStorageSpacePercentageDelta()};
 
   const uint64_t max_blocks_available = std::floor(storage.blockNumb * (static_cast<double>(highWatermark) / 100));
   const uint64_t blocks_in_use = storage.blockNumb - storage.freeBlockNumb;

--- a/src/rootfstreemanager.h
+++ b/src/rootfstreemanager.h
@@ -78,7 +78,6 @@ class RootfsTreeManager : public OstreeManager, public Downloader {
   data::InstallationResult verifyBootloaderUpdate(const Uptane::Target& target) const;
   bool getDeltaStatIfAvailable(const TufTarget& target, const Remote& remote, DeltaStat& delta_stat) const;
   bool canDeltaFitOnDisk(const DeltaStat& delta_stat, UpdateStat& update_stat) const;
-  unsigned int getStorageHighWatermark() const { return sysroot_->storageWatermark(); };
 
   static bool getDeltaStatsRef(const Json::Value& json, DeltaStatsRef& ref);
   static Json::Value downloadDeltaStats(const DeltaStatsRef& ref, const Remote& remote);

--- a/src/rootfstreemanager.h
+++ b/src/rootfstreemanager.h
@@ -61,13 +61,6 @@ class RootfsTreeManager : public OstreeManager, public Downloader {
     uint64_t freeBlockNumb;
     uint64_t blockNumb;
   };
-  struct UpdateStat {
-    uint64_t storageCapacity;
-    unsigned int highWatermark;
-    uint64_t maxAvailable;
-    uint64_t available;
-    uint64_t deltaSize;
-  };
 
   std::string getCurrentHash() const override {
     return sysroot_->getDeploymentHash(OSTree::Sysroot::Deployment::kCurrent);
@@ -77,13 +70,11 @@ class RootfsTreeManager : public OstreeManager, public Downloader {
   void setRemote(const std::string& name, const std::string& url, const boost::optional<const KeyManager*>& keys);
   data::InstallationResult verifyBootloaderUpdate(const Uptane::Target& target) const;
   bool getDeltaStatIfAvailable(const TufTarget& target, const Remote& remote, DeltaStat& delta_stat) const;
-  bool canDeltaFitOnDisk(const DeltaStat& delta_stat, UpdateStat& update_stat) const;
 
   static bool getDeltaStatsRef(const Json::Value& json, DeltaStatsRef& ref);
   static Json::Value downloadDeltaStats(const DeltaStatsRef& ref, const Remote& remote);
   static bool findDeltaStatForUpdate(const Json::Value& delta_stats, const std::string& from, const std::string& to,
                                      DeltaStat& found_delta_stat);
-  static void getStorageStat(const std::string& path, StorageStat& stat_out);
 
   const KeyManager& keys_;
   std::shared_ptr<OSTree::Sysroot> sysroot_;

--- a/src/rootfstreemanager.h
+++ b/src/rootfstreemanager.h
@@ -71,7 +71,7 @@ class RootfsTreeManager : public OstreeManager, public Downloader {
   void setRemote(const std::string& name, const std::string& url, const boost::optional<const KeyManager*>& keys);
   data::InstallationResult verifyBootloaderUpdate(const Uptane::Target& target) const;
   bool getDeltaStatIfAvailable(const TufTarget& target, const Remote& remote, DeltaStat& delta_stat) const;
-  storage::Volume::UsageInfo getUsageInfo() const;
+  storage::Volume::UsageInfo getUsageInfo(bool just_reserved_by_ostree) const;
 
   static bool getDeltaStatsRef(const Json::Value& json, DeltaStatsRef& ref);
   static Json::Value downloadDeltaStats(const DeltaStatsRef& ref, const Remote& remote);

--- a/src/rootfstreemanager.h
+++ b/src/rootfstreemanager.h
@@ -6,6 +6,7 @@
 #include "http/httpinterface.h"
 #include "ostree/sysroot.h"
 #include "package_manager/ostreemanager.h"
+#include "storage/stat.h"
 
 class RootfsTreeManager : public OstreeManager, public Downloader {
  public:
@@ -70,6 +71,7 @@ class RootfsTreeManager : public OstreeManager, public Downloader {
   void setRemote(const std::string& name, const std::string& url, const boost::optional<const KeyManager*>& keys);
   data::InstallationResult verifyBootloaderUpdate(const Uptane::Target& target) const;
   bool getDeltaStatIfAvailable(const TufTarget& target, const Remote& remote, DeltaStat& delta_stat) const;
+  storage::Volume::UsageInfo getUsageInfo() const;
 
   static bool getDeltaStatsRef(const Json::Value& json, DeltaStatsRef& ref);
   static Json::Value downloadDeltaStats(const DeltaStatsRef& ref, const Remote& remote);

--- a/src/storage/stat.cc
+++ b/src/storage/stat.cc
@@ -92,6 +92,7 @@ ostream& operator<<(ostream& os, const storage::Volume::UsageInfo& t) {
     if (t.required.first > 0) {
       os << "required: " << t.required.first << "B unknown%";
     }
+    os << "; fstatvfs err: " << t.err;
     return os;
   }
 

--- a/src/storage/stat.cc
+++ b/src/storage/stat.cc
@@ -1,0 +1,106 @@
+#include "stat.h"
+
+#include <fcntl.h>
+#include <sys/statvfs.h>
+#include <unistd.h>
+#include <cmath>
+#include <cstring>
+#include <sstream>
+#include <stdexcept>
+#include <tuple>
+
+namespace storage {
+
+struct Stat {
+  uint64_t blockSize;
+  uint64_t freeBlockNumber;
+  uint64_t blockNumb;
+};
+
+static std::string getStat(const std::string& path, Stat& stat) {
+  int fd{-1};
+  if (-1 == (fd = open(path.c_str(), O_DIRECTORY | O_RDONLY))) {
+    return std::string("Failed to open a file/directory; path: ") + path + ", err: " + std::strerror(errno);
+  }
+  struct statvfs fs_stat {};
+  const auto stat_res = fstatvfs(fd, &fs_stat);
+  close(fd);
+  if (-1 == stat_res) {
+    return std::string("Failed to obtain statistic about the path volume; path: ") + path +
+           ", err: " + std::strerror(errno);
+  }
+  stat.blockNumb = fs_stat.f_blocks;
+  stat.freeBlockNumber = (getuid() != 0 ? fs_stat.f_bavail : fs_stat.f_bfree);
+  stat.blockSize = fs_stat.f_bsize;  // f_frsize == f_bsize on the linux-based systems
+  return "";
+}
+
+Volume::UsageInfo Volume::getUsageInfo(const std::string& path, unsigned int reserved_percentage,
+                                       const std::string& reserved_by) {
+  Stat stat{};
+  if (std::string err = getStat(path, stat); !err.empty()) {
+    return UsageInfo{.err = err};
+  }
+
+  UsageInfo::Type free{
+      stat.blockSize * stat.freeBlockNumber,
+      static_cast<unsigned int>(std::floor((static_cast<double>(stat.freeBlockNumber) / stat.blockNumb) * 100))};
+  UsageInfo::Type reserved{
+      stat.blockSize * static_cast<uint64_t>(std::ceil(stat.blockNumb * (reserved_percentage / 100.0))),
+      reserved_percentage};
+  UsageInfo::Type available{(free.first > reserved.first) ? (free.first - reserved.first) : 0,
+                            (free.second > reserved.second) ? (free.second - reserved.second) : 0};
+  return {
+      .path = path,
+      .size = {stat.blockSize * stat.blockNumb, 100},
+      .free = free,
+      .reserved = reserved,
+      .reserved_by = reserved_by,
+      .available = available,
+      .required = {},
+      .err = "",
+  };
+}
+
+Volume::UsageInfo& Volume::UsageInfo::withRequired(const uint64_t& val) {
+  if (isOk() && size.first > 0) {
+    required = {val, std::ceil((static_cast<double>(val) / size.first) * 100)};
+  } else {
+    required = {val, 0};
+  }
+  return *this;
+}
+
+std::string Volume::UsageInfo::str() const {
+  std::stringstream ss;
+  ss << *this;
+  return ss.str();
+}
+
+}  // namespace storage
+
+// NOLINTNEXTLINE(cert-dcl58-cpp,-warnings-as-errors)
+namespace std {
+
+ostream& operator<<(ostream& os, const storage::Volume::UsageInfo::Type& t) {
+  os << t.first << "B " << t.second << "%";
+  return os;
+}
+
+ostream& operator<<(ostream& os, const storage::Volume::UsageInfo& t) {
+  if (!t.isOk()) {
+    if (t.required.first > 0) {
+      os << "required: " << t.required.first << "B unknown%";
+    }
+    return os;
+  }
+
+  if (t.required.first > 0) {
+    os << "required: " << t.required << ", ";
+  }
+  os << "available: " << t.available << " at " << t.path << ", size: " << t.size << ", free: " << t.free
+     << ", reserved: " << t.reserved << "(by `" << t.reserved_by << "`)";
+  return os;
+}
+
+}  // namespace std

--- a/src/storage/stat.h
+++ b/src/storage/stat.h
@@ -1,0 +1,44 @@
+#ifndef AKTUALIZR_LITE_STORAGE_STAT_H_
+#define AKTUALIZR_LITE_STORAGE_STAT_H_
+
+#include <cstdint>
+#include <string>
+
+namespace storage {
+
+struct Volume {
+  struct UsageInfo {
+    // <bytes, percentage of overall volume capacity>
+    using Type = std::pair<uint64_t, unsigned int>;
+
+    std::string path;
+    Type size;
+    Type free;
+    Type reserved;
+    std::string reserved_by;
+    Type available;
+
+    Type required;
+
+    std::string err;
+    bool isOk() const { return err.empty(); }
+
+    UsageInfo& withRequired(const uint64_t& val);
+    std::string str() const;
+  };
+
+  static UsageInfo getUsageInfo(const std::string& path, unsigned int reserved_percentage,
+                                const std::string& reserved_by = "");
+};
+
+}  // namespace storage
+
+// NOLINTNEXTLINE(cert-dcl58-cpp,-warnings-as-errors)
+namespace std {
+
+ostream& operator<<(ostream& os, const storage::Volume::UsageInfo& t);
+ostream& operator<<(ostream& os, const storage::Volume::UsageInfo::Type& t);
+
+}  // namespace std
+
+#endif  // AKTUALIZR_LITE_STORAGE_STAT_H_

--- a/tests/fixtures/fstatvfs-mock.cc
+++ b/tests/fixtures/fstatvfs-mock.cc
@@ -9,7 +9,13 @@ static __fsblkcnt_t blocks_numb;
 static __fsblkcnt64_t free_blocks_numb;
 static __fsblkcnt64_t blocks_numb;
 #endif
+static unsigned long int block_size{0};
 static bool override_blocks_numb{false};
+
+void SetBlockSize(unsigned long int block_size_in)
+ {
+  block_size = block_size_in;
+}
 
 void SetFreeBlockNumb(uint64_t free_blocks_numb_in, uint64_t blocks_numb_in) {
   free_blocks_numb = free_blocks_numb_in;
@@ -19,6 +25,7 @@ void SetFreeBlockNumb(uint64_t free_blocks_numb_in, uint64_t blocks_numb_in) {
 
 void UnsetFreeBlockNumb() {
   override_blocks_numb = false;
+  block_size = 0;
 }
 
 int fstatvfs (int fd, struct statvfs* buf) {
@@ -31,6 +38,9 @@ int fstatvfs (int fd, struct statvfs* buf) {
     if (blocks_numb > 0) {
       // override the total number of blocks if set, otherwise the underlying system storage block number is used
       buf->f_blocks = blocks_numb;
+    }
+    if (block_size > 0) {
+      buf->f_frsize = buf->f_bsize = block_size;
     }
   }
   return res;

--- a/tests/fixtures/liteclient/ostreerepomock.cc
+++ b/tests/fixtures/liteclient/ostreerepomock.cc
@@ -78,6 +78,19 @@ class OSTreeRepoMock {
 
   const std::string& getPath() const { return path_; }
 
+  void removeCommitObject(const std::string& hash) {
+    const auto commit_object_path{path_ + "/objects/" + hash.substr(0, 2) + "/" + hash.substr(2) + ".commit"};
+    boost::filesystem::remove(commit_object_path);
+  }
+  void removeDeltas() {
+    const auto deltas_path{path_ + "/deltas/"};
+    boost::filesystem::remove_all(deltas_path);
+  }
+  void removeDeltaStats() {
+    const auto deltas_path{path_ + "/delta-stats/"};
+    boost::filesystem::remove_all(deltas_path);
+  }
+
  private:
   const std::string path_;
 };

--- a/tests/fixtures/liteclient/ostreerepomock.cc
+++ b/tests/fixtures/liteclient/ostreerepomock.cc
@@ -61,6 +61,21 @@ class OSTreeRepoMock {
     return delta_stat_ref;
   }
 
+  uint64_t getDeltaSize(const std::string& delta_file_name, const std::string& from, const std::string& to) const {
+    const auto delta_file_path{path_ + "/delta-stats/" + delta_file_name};
+    if (!boost::filesystem::exists(delta_file_path)) {
+     return 0;
+    }
+    Json::Value delta_json = Utils::parseJSONFile(delta_file_path);
+    if (!delta_json.isMember(to)) {
+      return 0;
+    }
+    if (!delta_json[to].isMember(from)) {
+      return 0;
+    }
+    return boost::lexical_cast<uint64_t>(delta_json[to][from]["u_size"]);
+  }
+
   const std::string& getPath() const { return path_; }
 
  private:

--- a/tests/fixtures/liteclienttest.cc
+++ b/tests/fixtures/liteclienttest.cc
@@ -335,7 +335,7 @@ class ClientTest :virtual public ::testing::Test {
     ASSERT_EQ(download_result.status, expected_download_result.status);
     ASSERT_TRUE(download_result.description.find(expected_download_result.description) != std::string::npos) << "Actuall error message: " << download_result.description;
     if (expected_download_result.noSpace()) {
-      ASSERT_EQ(download_result.destination_path, sys_repo_.getPath());
+      ASSERT_EQ(download_result.destination_path, sys_repo_.getRepo().getPath());
     }
     if (download_result) {
       ASSERT_EQ(client.install(to), expected_install_code);

--- a/tests/fixtures/liteclienttest.cc
+++ b/tests/fixtures/liteclienttest.cc
@@ -545,6 +545,15 @@ class ClientTest :virtual public ::testing::Test {
     return ostree_repo_.getDeltaSize(to.custom_data()["delta-stats"]["sha256"].asString(), from.sha256Hash(), to.sha256Hash());
   }
 
+  std::string getEventContext(const std::string& ev_id) {
+    for (const auto& ev: device_gateway_.getEvents()) {
+      if (ev_id == ev["eventType"]["id"].asString()) {
+        return ev["event"]["details"].asString();
+      }
+    }
+    return "";
+  }
+
  protected:
   static const std::string branch;
   static const std::string hw_id;

--- a/tests/fixtures/liteclienttest.cc
+++ b/tests/fixtures/liteclienttest.cc
@@ -541,6 +541,9 @@ class ClientTest :virtual public ::testing::Test {
     static_delta_size_bn_ = min_size_in_blocks;
     static_delta_stat_ = add_delta_stat;
   }
+  uint64_t getDeltaSize(const Uptane::Target& from, const Uptane::Target& to) const {
+    return ostree_repo_.getDeltaSize(to.custom_data()["delta-stats"]["sha256"].asString(), from.sha256Hash(), to.sha256Hash());
+  }
 
  protected:
   static const std::string branch;

--- a/tests/nospace_test.cc
+++ b/tests/nospace_test.cc
@@ -307,15 +307,13 @@ TEST_F(NoSpaceTest, OstreeUpdateNoSpaceIfStaticDeltaStats) {
     ASSERT_TRUE(targetsMatch(client->getCurrent(), getInitialTarget()));
   }
   {
-    // not enough free blocks taking into account the default reserved 5%,
-    // (15 - 11 = 4) - 4% of blocks will be free after the update, we need 5%
+    // required 11%, free 15%, reserved 5% (default) -> available 10% < 11%
     SetFreeBlockNumb(15, 100);
     update(*client, getInitialTarget(), new_target, data::ResultCode::Numeric::kDownloadFailed,
            {DownloadResult::Status::DownloadFailed_NoSpace, "Insufficient storage available"});
     const auto events{device_gateway_.getEvents()};
     const std::string event_err_msg{events[events.size() - 1]["event"]["details"].asString()};
-    ASSERT_TRUE(std::string::npos !=
-                event_err_msg.find("available 40960 out of 389120(95% of the volume capacity 409600)"))
+    ASSERT_TRUE(std::string::npos != event_err_msg.find("required: 42397B 11%, available: 40960B 10%"))
         << event_err_msg;
     ASSERT_TRUE(targetsMatch(client->getCurrent(), getInitialTarget()));
   }

--- a/tests/nospace_test.cc
+++ b/tests/nospace_test.cc
@@ -127,7 +127,7 @@ TEST(StorageStat, UsageInfo) {
     usage_info.withRequired(7);
     ASSERT_EQ(7, usage_info.required.first);
     ASSERT_EQ(0, usage_info.required.second);
-    ASSERT_EQ("required: 7B unknown%", usage_info.str());
+    ASSERT_TRUE(std::string::npos != usage_info.str().find("required: 7B unknown%")) << usage_info;
   }
   {
     unsigned int block_size{4096};
@@ -213,6 +213,11 @@ TEST_F(NoSpaceTest, OstreeUpdateNoSpace) {
   update(*client, getInitialTarget(), new_target, data::ResultCode::Numeric::kDownloadFailed,
          {DownloadResult::Status::DownloadFailed_NoSpace, "Insufficient storage available"});
   ASSERT_TRUE(targetsMatch(client->getCurrent(), getInitialTarget()));
+  const auto event_err_msg{getEventContext("EcuDownloadCompleted")};
+  ASSERT_TRUE(std::string::npos != event_err_msg.find("min-free-space-size 1048576MB would be exceeded"))
+      << event_err_msg;
+  ASSERT_TRUE(std::string::npos != event_err_msg.find("before ostree pull; available:")) << event_err_msg;
+  ASSERT_TRUE(std::string::npos != event_err_msg.find("after ostree pull; available:")) << event_err_msg;
 
   // reboot device
   reboot(client);
@@ -230,62 +235,109 @@ TEST_F(NoSpaceTest, OstreeUpdateNoSpaceIfWatermarkParamIsSet) {
   ASSERT_TRUE(targetsMatch(client->getCurrent(), getInitialTarget()));
 
   auto new_target = createTarget();
-  update(*client, getInitialTarget(), new_target, data::ResultCode::Numeric::kDownloadFailed,
-         {DownloadResult::Status::DownloadFailed_NoSpace, "Insufficient storage available"});
-  ASSERT_TRUE(targetsMatch(client->getCurrent(), getInitialTarget()));
 
-  // Now, let's decrease the required minimum space to 40%, since the update size is < 9 blocks,
-  // then the libostree should be happy.
-  // We need to "reboot" in order to recreate the client instance so the new watermark is applied.
-  setMinFreeSpace("40");
-  reboot(client);
-  ASSERT_TRUE(targetsMatch(client->getCurrent(), getInitialTarget()));
-  update(*client, getInitialTarget(), new_target);
-  reboot(client);
-  ASSERT_TRUE(targetsMatch(client->getCurrent(), new_target));
+  {
+    update(*client, getInitialTarget(), new_target, data::ResultCode::Numeric::kDownloadFailed,
+           {DownloadResult::Status::DownloadFailed_NoSpace, "Insufficient storage available"});
+    ASSERT_TRUE(targetsMatch(client->getCurrent(), getInitialTarget()));
+    const auto event_err_msg{getEventContext("EcuDownloadCompleted")};
+    ASSERT_TRUE(std::string::npos != event_err_msg.find("min-free-space-percent '50%' would be exceeded"))
+        << event_err_msg;
+    ASSERT_TRUE(std::string::npos != event_err_msg.find("available: 4096B 1%")) << event_err_msg;
+  }
+  {
+    // Now, let's decrease the required minimum space to 40%, since the update size is < 9 blocks,
+    // then the libostree should be happy.
+    // We need to "reboot" in order to recreate the client instance so the new watermark is applied.
+    setMinFreeSpace("40");
+    reboot(client);
+    ASSERT_TRUE(targetsMatch(client->getCurrent(), getInitialTarget()));
+    update(*client, getInitialTarget(), new_target);
+    reboot(client);
+    ASSERT_TRUE(targetsMatch(client->getCurrent(), new_target));
+  }
   UnsetFreeBlockNumb();
 }
 
 TEST_F(NoSpaceTest, OstreeUpdateNoSpaceIfStaticDelta) {
   auto client = createLiteClient();
   ASSERT_TRUE(targetsMatch(client->getCurrent(), getInitialTarget()));
+  // Delta size is 3 + 1 = 4 blocks
   setGenerateStaticDelta(3);
   auto new_target = createTarget();
   {
-    // Not enough space/block, 3 is required, we got only 1.
+    // The delta-based update if there is no stat/info about the delta, so the pre-pull verification
+    // of the update size is not possible. Thus, the error originates in libostree; libostree does NOT
+    // apply any threshold/reserved when checking if there is enough storage to store a delta file,
+    // it just checks for the overall storage capacity.
+    //
+    // required 4%, free 2%, available 0%, no pre-pull check -> libostree generates the error "Delta requires..."
     // The expected libostree error:
     //    "Error while pulling image: 0 Delta requires 13.8 kB free space, but only 4.1 kB available"
-    SetFreeBlockNumb(1, 10);
+    SetFreeBlockNumb(2, 100);
     update(*client, getInitialTarget(), new_target, data::ResultCode::Numeric::kDownloadFailed,
            {DownloadResult::Status::DownloadFailed_NoSpace, "Insufficient storage available"});
     ASSERT_TRUE(targetsMatch(client->getCurrent(), getInitialTarget()));
+    const auto event_err_msg{getEventContext("EcuDownloadCompleted")};
+    ASSERT_TRUE(std::string::npos != event_err_msg.find("Delta requires")) << event_err_msg;
+    // libostree converts 2*4096=8192B by dividing it to 1000 not 1024.
+    ASSERT_TRUE(std::string::npos != event_err_msg.find("free space, but only 8.2 kB available")) << event_err_msg;
+    ASSERT_TRUE(std::string::npos != event_err_msg.find("available: 0B 0%")) << event_err_msg;
+    ASSERT_TRUE(std::string::npos !=
+                event_err_msg.find(OSTree::Sysroot::Config::ReservedStorageSpacePercentageOstreeParamName))
+        << event_err_msg;
   }
   {
-    // There is enough space to accommodate the 3-block delta since we have 3 free blocks.
-    // But, at the last step of the delta processing libostree calls dispatch_close() ->
-    // _ostree_repo_bare_content_commit(). And, the _ostree_repo_bare_content_commit() checks the
-    // `min-free-space-percent`/`min-free-space-size` watermark. In our case we have 3 out of 100 blocks free,
-    // which is enough to fit the delta, but less than the `min-free-space-percent` of overall storage
-    // becomes free after the update, so libostree rejects it.
-    // It  doesn't make sense to reject the update after its content is pulled and already written to a disk,
-    // but this is the way libostree works, so we have to adjust...(we bypass this issue by using the delta stats)
-    // Expected error message is:
+    // The delta-based update if there is no stat/info about the delta, so the pre-pull verification
+    // of the update size is not possible. Thus, the error originates in libostree; libostree does NOT
+    // apply any threshold/reserved when checking if there is enough storage to store a delta file,
+    // it just checks for the overall storage capacity.
+    // In this case, there is enough free storage to accommodate the delta file.
+    // But, during committing the ostree objects extracted from the delta file, libostree checks
+    // if there is enough free storage is available taking into account the
+    // `min-free-space-percent`/`min-free-space-size` threshold -> reserved storage. By default, the libostree sets it
+    // to 3%.
+    //
+    // required 4%, free 5%, reserved 3%, available 2%, no pre-pull check -> libostree generates the error "would be
+    // exceeded, at least..." Expected error message is:
     //    "Error while pulling image: 0 opcode close: min-free-space-percent '3%' would be exceeded, at least 13 bytes
     //    requested"
-    SetFreeBlockNumb(3, 100);
+    SetFreeBlockNumb(5, 100);
     update(*client, getInitialTarget(), new_target, data::ResultCode::Numeric::kDownloadFailed,
            {DownloadResult::Status::DownloadFailed_NoSpace, "Insufficient storage available"});
     ASSERT_TRUE(targetsMatch(client->getCurrent(), getInitialTarget()));
+    const auto event_err_msg{getEventContext("EcuDownloadCompleted")};
+    ASSERT_TRUE(std::string::npos != event_err_msg.find("min-free-space-percent '3%' would be exceeded, at least"))
+        << event_err_msg;
+    ASSERT_TRUE(std::string::npos != event_err_msg.find("available: 8192B 2%")) << event_err_msg;
+    ASSERT_TRUE(std::string::npos !=
+                event_err_msg.find(OSTree::Sysroot::Config::ReservedStorageSpacePercentageOstreeParamName));
   }
   {
-    // Now, we have 15 blocks out of 100 free, so 15-3 = 12 - 12% of storage will be free after the update,
-    // so libostree should be happy.
-    // NOTE: 7 blocks (7%) should suffice, but for some reason libostree requires 15%.
-    // TODO: Check the following assumption.
-    //       Most likely there is a moment during download at which 2x of the update/delta size is required.
-    //       Specifically, in this case, 3% for downloaded delta and then 3% to commit it to the repo - hence > 6% is
-    //       needed.
-    SetFreeBlockNumb(15, 100);
+    // required 4%, free 7%, reserved 3%, available 7% - 3% = 4% -> should be ok,
+    // but there is a moment during the delta-based pull when libostree has the delta file
+    // on a file system + extracted files while it commits the extracted files to the repo.
+    // So, it takes into account the delta file size + extracted objects during ostree objects committing,
+    // therefore we need 4% + <some additional space> ~ 5% (required)+ 3% (reserved) ~ 8% (at least 8 free blocks
+    // is required, but just 7 is available)
+    //
+    storage::Volume::UsageInfo usage_info{.size = {100 * 4096, 100}, .available = {(7 - 3) * 4096, 7 - 3}};
+    std::stringstream expected_available;
+    expected_available << usage_info.available;
+    SetFreeBlockNumb(7, 100);
+    update(*client, getInitialTarget(), new_target, data::ResultCode::Numeric::kDownloadFailed,
+           {DownloadResult::Status::DownloadFailed_NoSpace, "Insufficient storage available"});
+    ASSERT_TRUE(targetsMatch(client->getCurrent(), getInitialTarget()));
+    const auto event_err_msg{getEventContext("EcuDownloadCompleted")};
+    ASSERT_TRUE(std::string::npos != event_err_msg.find("min-free-space-percent '3%' would be exceeded, at least"))
+        << event_err_msg;
+    ASSERT_TRUE(std::string::npos != event_err_msg.find(expected_available.str())) << event_err_msg;
+    ASSERT_TRUE(std::string::npos !=
+                event_err_msg.find(OSTree::Sysroot::Config::ReservedStorageSpacePercentageOstreeParamName));
+  }
+  {
+    // required 4%, free 15%, reserved 3%, available 15% - 3% = 12% -> ok
+    SetFreeBlockNumb(14, 100);
     update(*client, getInitialTarget(), new_target);
     reboot(client);
     ASSERT_TRUE(targetsMatch(client->getCurrent(), new_target));

--- a/tests/nospace_test.cc
+++ b/tests/nospace_test.cc
@@ -320,8 +320,7 @@ TEST_F(NoSpaceTest, OstreeUpdateNoSpaceIfStaticDeltaStats) {
                  << ", available: " << usage_info.available;
     update(*client, getInitialTarget(), new_target, data::ResultCode::Numeric::kDownloadFailed,
            {DownloadResult::Status::DownloadFailed_NoSpace, "Insufficient storage available"});
-    const auto events{device_gateway_.getEvents()};
-    const std::string event_err_msg{events[events.size() - 1]["event"]["details"].asString()};
+    const std::string event_err_msg{getEventContext("EcuDownloadCompleted")};
     ASSERT_TRUE(std::string::npos != event_err_msg.find(expected_msg.str())) << event_err_msg;
     ASSERT_TRUE(std::string::npos !=
                 event_err_msg.find(OSTree::Sysroot::Config::ReservedStorageSpacePercentageDeltaParamName))
@@ -341,8 +340,7 @@ TEST_F(NoSpaceTest, OstreeUpdateNoSpaceIfStaticDeltaStats) {
                  << ", available: " << usage_info.available;
     update(*client, getInitialTarget(), new_target, data::ResultCode::Numeric::kDownloadFailed,
            {DownloadResult::Status::DownloadFailed_NoSpace, "Insufficient storage available"});
-    const auto events{device_gateway_.getEvents()};
-    const std::string event_err_msg{events[events.size() - 1]["event"]["details"].asString()};
+    const std::string event_err_msg{getEventContext("EcuDownloadCompleted")};
     ASSERT_TRUE(std::string::npos != event_err_msg.find(expected_msg.str())) << event_err_msg;
     ASSERT_TRUE(std::string::npos !=
                 event_err_msg.find(OSTree::Sysroot::Config::ReservedStorageSpacePercentageOstreeParamName))
@@ -355,6 +353,9 @@ TEST_F(NoSpaceTest, OstreeUpdateNoSpaceIfStaticDeltaStats) {
     update(*client, getInitialTarget(), new_target);
     reboot(client);
     ASSERT_TRUE(targetsMatch(client->getCurrent(), new_target));
+    const std::string msg{getEventContext("EcuDownloadCompleted")};
+    ASSERT_TRUE(std::string::npos != msg.find("before ostree pull")) << msg;
+    ASSERT_TRUE(std::string::npos != msg.find("after ostree pull")) << msg;
   }
   UnsetFreeBlockNumb();
 }


### PR DESCRIPTION
- Add functionality to obtain storage usage that can be used across all use-cases.
- Apply the new storage usage obtaining functionality to all ostree pull use-cases, with and without delta, negative and positive cases.
- Extend and improve the unit tests to verify the new and modified functionality.