### PR TITLE
Use usage stat to controll pull attempts

### DIFF
--- a/src/api.cc
+++ b/src/api.cc
@@ -239,7 +239,7 @@ class LiteInstall : public InstallContext {
 
     auto download_res{client_->download(*target_, reason)};
     if (!download_res) {
-      return download_res;
+      return DownloadResult{download_res.status, download_res.description, download_res.destination_path};
     }
 
     if (client_->VerifyTarget(*target_) != TargetStatus::kGood) {

--- a/src/composeappmanager.cc
+++ b/src/composeappmanager.cc
@@ -242,13 +242,13 @@ bool ComposeAppManager::checkForAppsToUpdate(const Uptane::Target& target) {
   return cur_apps_to_fetch_and_update_.empty() && cur_apps_to_fetch_.empty();
 }
 
-DownloadResult ComposeAppManager::Download(const TufTarget& target) {
+DownloadResultWithStat ComposeAppManager::Download(const TufTarget& target) {
   auto ostree_download_res{RootfsTreeManager::Download(target)};
   if (!ostree_download_res) {
     return ostree_download_res;
   }
 
-  DownloadResult res{ostree_download_res};
+  DownloadResultWithStat res{ostree_download_res};
   const Uptane::Target uptane_target{Target::fromTufTarget(target)};
 
   if (cfg_.force_update) {

--- a/src/composeappmanager.h
+++ b/src/composeappmanager.h
@@ -43,7 +43,7 @@ class ComposeAppManager : public RootfsTreeManager {
                     AppEngine::Ptr app_engine = nullptr);
 
   std::string name() const override { return Name; }
-  DownloadResult Download(const TufTarget& target) override;
+  DownloadResultWithStat Download(const TufTarget& target) override;
   bool fetchTarget(const Uptane::Target& target, Uptane::Fetcher& fetcher, const KeyManager& keys,
                    const FetcherProgressCb& progress_cb, const api::FlowControlToken* token) override;
 

--- a/src/downloader.h
+++ b/src/downloader.h
@@ -2,10 +2,16 @@
 #define AKTUALIZR_LITE_DOWNLOADER_H_
 
 #include "aktualizr-lite/api.h"
+#include "storage/stat.h"
+
+class DownloadResultWithStat : public DownloadResult {
+ public:
+  storage::Volume::UsageInfo stat;
+};
 
 class Downloader {
  public:
-  virtual DownloadResult Download(const TufTarget& target) = 0;
+  virtual DownloadResultWithStat Download(const TufTarget& target) = 0;
 
   virtual ~Downloader() = default;
   Downloader(const Downloader&) = delete;

--- a/src/liteclient.cc
+++ b/src/liteclient.cc
@@ -513,10 +513,10 @@ bool LiteClient::checkImageMetaOffline() {
   return true;
 }
 
-DownloadResult LiteClient::downloadImage(const Uptane::Target& target, const api::FlowControlToken* token) {
+DownloadResultWithStat LiteClient::downloadImage(const Uptane::Target& target, const api::FlowControlToken* token) {
   key_manager_->loadKeys();
 
-  DownloadResult download_result{DownloadResult::Status::DownloadFailed, ""};
+  DownloadResultWithStat download_result{DownloadResult::Status::DownloadFailed, ""};
   {
     const int max_tries = 3;
     int tries = 0;
@@ -632,7 +632,7 @@ void LiteClient::reportAppsState() {
   }
 }
 
-DownloadResult LiteClient::download(const Uptane::Target& target, const std::string& reason) {
+DownloadResultWithStat LiteClient::download(const Uptane::Target& target, const std::string& reason) {
   notifyDownloadStarted(target, reason);
   auto download_result{downloadImage(target)};
   notifyDownloadFinished(target, download_result, download_result.description);

--- a/src/liteclient.h
+++ b/src/liteclient.h
@@ -1,6 +1,7 @@
 #ifndef AKTUALIZR_LITE_CLIENT_H_
 #define AKTUALIZR_LITE_CLIENT_H_
 
+#include "downloader.h"
 #include "gtest/gtest_prod.h"
 #include "libaktualizr/config.h"
 #include "libaktualizr/packagemanagerinterface.h"
@@ -41,7 +42,7 @@ class LiteClient {
   void checkForUpdatesEndWithFailure(const std::string& err);
   bool finalizeInstall(data::InstallationResult* ir = nullptr);
   Uptane::Target getRollbackTarget();
-  DownloadResult download(const Uptane::Target& target, const std::string& reason);
+  DownloadResultWithStat download(const Uptane::Target& target, const std::string& reason);
   data::ResultCode::Numeric install(const Uptane::Target& target);
   void notifyInstallFinished(const Uptane::Target& t, data::InstallationResult& ir);
   std::pair<bool, std::string> isRebootRequired() const {
@@ -91,7 +92,7 @@ class LiteClient {
   void writeCurrentTarget(const Uptane::Target& t) const;
 
   data::InstallationResult installPackage(const Uptane::Target& target);
-  DownloadResult downloadImage(const Uptane::Target& target, const api::FlowControlToken* token = nullptr);
+  DownloadResultWithStat downloadImage(const Uptane::Target& target, const api::FlowControlToken* token = nullptr);
   static void add_apps_header(std::vector<std::string>& headers, PackageConfig& config);
   data::InstallationResult finalizePendingUpdate(boost::optional<Uptane::Target>& target);
   void initRequestHeaders(std::vector<std::string>& headers) const;

--- a/src/rootfstreemanager.h
+++ b/src/rootfstreemanager.h
@@ -34,7 +34,7 @@ class RootfsTreeManager : public OstreeManager, public Downloader {
                     const std::shared_ptr<INvStorage>& storage, const std::shared_ptr<HttpInterface>& http,
                     std::shared_ptr<OSTree::Sysroot> sysroot, const KeyManager& keys);
 
-  DownloadResult Download(const TufTarget& target) override;
+  DownloadResultWithStat Download(const TufTarget& target) override;
 
   bool fetchTarget(const Uptane::Target& target, Uptane::Fetcher& fetcher, const KeyManager& keys,
                    const FetcherProgressCb& progress_cb, const api::FlowControlToken* token) override;

--- a/src/storage/stat.cc
+++ b/src/storage/stat.cc
@@ -42,9 +42,8 @@ Volume::UsageInfo Volume::getUsageInfo(const std::string& path, unsigned int res
     return UsageInfo{.err = err};
   }
 
-  UsageInfo::Type free{
-      stat.blockSize * stat.freeBlockNumber,
-      static_cast<unsigned int>(std::floor((static_cast<double>(stat.freeBlockNumber) / stat.blockNumb) * 100))};
+  UsageInfo::Type free{stat.blockSize * stat.freeBlockNumber,
+                       (static_cast<double>(stat.freeBlockNumber) / stat.blockNumb) * 100};
   UsageInfo::Type reserved{
       stat.blockSize * static_cast<uint64_t>(std::ceil(stat.blockNumb * (reserved_percentage / 100.0))),
       reserved_percentage};
@@ -64,7 +63,7 @@ Volume::UsageInfo Volume::getUsageInfo(const std::string& path, unsigned int res
 
 Volume::UsageInfo& Volume::UsageInfo::withRequired(const uint64_t& val) {
   if (isOk() && size.first > 0) {
-    required = {val, std::ceil((static_cast<double>(val) / size.first) * 100)};
+    required = {val, (static_cast<double>(val) / size.first) * 100};
   } else {
     required = {val, 0};
   }

--- a/src/storage/stat.h
+++ b/src/storage/stat.h
@@ -9,7 +9,7 @@ namespace storage {
 struct Volume {
   struct UsageInfo {
     // <bytes, percentage of overall volume capacity>
-    using Type = std::pair<uint64_t, unsigned int>;
+    using Type = std::pair<uint64_t, float>;
 
     std::string path;
     Type size;

--- a/tests/nospace_test.cc
+++ b/tests/nospace_test.cc
@@ -170,6 +170,8 @@ TEST(StorageStat, UsageInfo) {
     SetBlockSize(block_size);
     SetFreeBlockNumb(std::ceil(block_numb * (free_percentage / 100.0)), block_numb);
     storage::Volume::UsageInfo usage_info{storage::Volume::getUsageInfo("./", reserved_percentage)};
+    usage_info.free.second = std::round(usage_info.free.second);
+    usage_info.available.second = std::round(usage_info.available.second);
     ASSERT_TRUE(usage_info.isOk());
     ASSERT_EQ(free, usage_info.free) << usage_info.free.first;
     ASSERT_EQ(reserved, usage_info.reserved) << usage_info.reserved.first;
@@ -194,6 +196,7 @@ TEST(StorageStat, UsageInfo) {
     SetBlockSize(block_size);
     SetFreeBlockNumb(std::ceil(block_numb * (free_percentage / 100.0)), block_numb);
     storage::Volume::UsageInfo usage_info{storage::Volume::getUsageInfo("./", reserved_percentage)};
+    usage_info.free.second = std::round(usage_info.free.second);
     ASSERT_TRUE(usage_info.isOk());
     ASSERT_EQ(free, usage_info.free) << usage_info.free.first;
     ASSERT_EQ(reserved, usage_info.reserved) << usage_info.reserved.first;


### PR DESCRIPTION
Extend the download result context to include storage usage information
and the amount of free space required for an ostree update.

Utilize the storage usage info and the required space value obtained in
the "no space" download result to determine whether to attempt another
pull. If there is still insufficient free storage space to accommodate
the specified ostree update, then skip the update attempt.    
