### PR TITLE
sysroot: Remove redundant conf param

### DIFF
--- a/src/ostree/sysroot.h
+++ b/src/ostree/sysroot.h
@@ -14,24 +14,10 @@ class Sysroot {
    public:
     explicit Config(const PackageConfig& pconfig);
 
-    static constexpr const char* const ReservedStorageSpacePercentageDeltaParamName{
-        "sysroot_delta_reserved_space_percentage"};
-    static const unsigned int DefaultReservedStorageSpacePercentageDelta;
-    static const unsigned int MinReservedStorageSpacePercentageDelta;
-    static const unsigned int MaxReservedStorageSpacePercentageDelta;
-
     static constexpr const char* const ReservedStorageSpacePercentageOstreeParamName{
         "sysroot_ostree_reserved_space_percentage"};
     static const unsigned int MinReservedStorageSpacePercentageOstree;
     static const unsigned int MaxReservedStorageSpacePercentageOstree;
-
-    // This variable represents the reserved amount of storage, expressed as a percentage
-    // of the overall capacity of the volume where the sysroot/ostree repo is located.
-    // The reserved percentage is only considered when performing a delta-based ostree pull.
-    // The downloader verifies that the reserved storage will remain untouched prior to initiating a delta-based ostree
-    // pull. If the available free space, in addition to the reserved space, is insufficient to fit delta files, then
-    // the downloader will reject the download and exit with an error.
-    unsigned int ReservedStorageSpacePercentageDelta{DefaultReservedStorageSpacePercentageDelta};
 
     // This variable represents the reserved amount of storage, expressed as a percentage
     // of the overall capacity of the volume where the sysroot/ostree repo is located.
@@ -59,7 +45,6 @@ class Sysroot {
 
   virtual std::string getDeploymentHash(Deployment deployment_type) const;
   bool reload();
-  unsigned int reservedStorageSpacePercentageDelta() const { return cfg_.ReservedStorageSpacePercentageDelta; }
   unsigned int reservedStorageSpacePercentageOstree() const;
 
  private:

--- a/src/rootfstreemanager.h
+++ b/src/rootfstreemanager.h
@@ -71,7 +71,7 @@ class RootfsTreeManager : public OstreeManager, public Downloader {
   void setRemote(const std::string& name, const std::string& url, const boost::optional<const KeyManager*>& keys);
   data::InstallationResult verifyBootloaderUpdate(const Uptane::Target& target) const;
   bool getDeltaStatIfAvailable(const TufTarget& target, const Remote& remote, DeltaStat& delta_stat) const;
-  storage::Volume::UsageInfo getUsageInfo(bool just_reserved_by_ostree) const;
+  storage::Volume::UsageInfo getUsageInfo() const;
 
   static bool getDeltaStatsRef(const Json::Value& json, DeltaStatsRef& ref);
   static Json::Value downloadDeltaStats(const DeltaStatsRef& ref, const Remote& remote);

--- a/tests/liteclient_test.cc
+++ b/tests/liteclient_test.cc
@@ -352,13 +352,13 @@ TEST_F(LiteClientTest, OstreeAndAppUpdateIfOstreeDownloadFailureAndStaticDeltaSt
   setGenerateStaticDelta(2, true);
   auto new_target = createTarget(&apps);
   const auto delta_size{getDeltaSize(getInitialTarget(), new_target)};
-  const auto expected_available{15 - 5};
+  const auto expected_available{10};
   storage::Volume::UsageInfo usage_info{.size = {100 * 4096, 100},
                                         .available = {expected_available * 4096, expected_available}};
   std::stringstream expected_msg;
   expected_msg << "before ostree pull; required: " << usage_info.withRequired(delta_size).required
                << ", available: " << usage_info.available;
-  SetFreeBlockNumb(10 + 5 /* default reserved for delta case */, 100);
+  SetFreeBlockNumb(10 + OSTree::Repo::MinFreeSpacePercentDefaultValue, 100);
 
   getOsTreeRepo().removeDeltas();
   getOsTreeRepo().removeCommitObject(new_target.sha256Hash());


### PR DESCRIPTION
Remove the knob to configure the reserved amount of storage for the delta-based update. Instead, use the `min-free-space-percent` value set in ostree repo config. This param value can be overridden in the sota toml configuration -
`[pacman]:sysroot_ostree_reserved_space_percentage`.