### PR TITLE
apps: Improve image load to docker store

### DIFF
--- a/src/appengine.h
+++ b/src/appengine.h
@@ -26,6 +26,7 @@ class AppEngine {
     virtual Json::Value getRunningApps(const std::function<void(const std::string&, Json::Value&)>& ext_func) = 0;
     virtual void pruneImages() = 0;
     virtual void pruneContainers() = 0;
+    virtual void loadImage(const std::string&, const Json::Value&) = 0;
 
     virtual ~Client() = default;
     Client(const Client&&) = delete;

--- a/src/containerd/client.cc
+++ b/src/containerd/client.cc
@@ -71,6 +71,12 @@ void Client::pruneContainers() {
   LOG_ERROR << "Container pruning is not supported in nerdctl";
 }
 
+void Client::loadImage(const std::string& image_uri, const Json::Value& load_manifest) {
+  (void)image_uri;
+  (void)load_manifest;
+  LOG_ERROR << "Image loading is not implemented";
+}
+
 Json::Value Client::getRunningApps(const std::function<void(const std::string&, Json::Value&)>& /* ext_func */) {
   Json::Value apps;
   Json::Value containers;

--- a/src/containerd/client.h
+++ b/src/containerd/client.h
@@ -18,6 +18,7 @@ class Client : public AppEngine::Client {
   Json::Value getRunningApps(const std::function<void(const std::string&, Json::Value&)>& ext_func) override;
   void pruneImages() override;
   void pruneContainers() override;
+  void loadImage(const std::string& image_uri, const Json::Value& load_manifest) override;
 
  private:
   const std::string nerdctl_;

--- a/src/docker/docker.cc
+++ b/src/docker/docker.cc
@@ -98,6 +98,20 @@ std::vector<Descriptor> ImageManifest::layers() const {
   return res;
 }
 
+Json::Value ImageManifest::toLoadManifest(const std::string& blobs_dir, const std::vector<std::string>& refs) const {
+  Json::Value lm;
+  lm["Config"] = config().digest.hash();
+  for (int ii = 0; ii < refs.size(); ++ii) {
+    lm["RepoTags"][ii] = refs[ii];
+  }
+  const auto l{layers()};
+  for (int ii = 0; ii < l.size(); ++ii) {
+    lm["Layers"][ii] = l[ii].digest.hash();
+  }
+  lm["LayersRoot"] = blobs_dir;
+  return lm;
+}
+
 const RegistryClient::HttpClientFactory RegistryClient::DefaultHttpClientFactory =
     [](const std::vector<std::string>* headers, const std::set<std::string>* response_header_names) {
       return std::make_shared<HttpClient>(headers, response_header_names);

--- a/src/docker/docker.h
+++ b/src/docker/docker.h
@@ -146,6 +146,7 @@ struct ImageManifest : Json::Value {
   explicit ImageManifest(const Json::Value& value);
   Descriptor config() const { return Descriptor{(*this)["config"]}; }
   std::vector<Descriptor> layers() const;
+  Json::Value toLoadManifest(const std::string& blobs_dir, const std::vector<std::string>& refs) const;
 };
 
 class RegistryClient {

--- a/src/docker/dockerclient.cc
+++ b/src/docker/dockerclient.cc
@@ -1,6 +1,10 @@
 #include "dockerclient.h"
+
+#include <archive.h>
+#include <archive_entry.h>
 #include <boost/format.hpp>
 #include <boost/process.hpp>
+
 #include "http/httpclient.h"
 #include "logging/logging.h"
 #include "utilities/utils.h"
@@ -148,6 +152,36 @@ void DockerClient::pruneContainers() {
   }
 }
 
+void DockerClient::loadImage(const std::string& image_uri, const Json::Value& load_manifest) {
+  // The `/images/load` handler expects an array of load manifests in `manifest.json`
+  Json::Value lm{Json::arrayValue};
+  lm[0] = load_manifest;
+  const auto load_manifest_str{Utils::jsonToStr(lm)};
+  const auto tarred_manifest{tarString(load_manifest_str, "manifest.json")};
+  // curl --unix-socket <sock>  "http://localhost/images/load?quiet=0" --data-binary @tarred_load_manifest -H
+  // "Content-Type: application/x-tar"
+  LOG_INFO << "Loading image into docker store " << image_uri;
+  // TODO: implement support of the "not quiet" request. In this case, the response is streamed as a "chunked" stream,
+  // each "chunk" containing image load progress, so the code can output the progress to the logs.
+  // The httpclient doesn't support a HTTP response streaming and it will require some effort to implement it.
+  // The code that handle the request is located in https://github.com/moby/moby/blob/master/image/tarexport/load.go.
+  const std::string cmd{"http://localhost/images/load?quiet=1"};
+  auto resp = http_client_->post(cmd, "application/x-tar", tarred_manifest);
+  if (!resp.isOk()) {
+    throw std::runtime_error("Failed to load image: " + resp.getStatusStr());
+  }
+  const auto json_resp{resp.getJson()};
+  if (json_resp.isMember("stream")) {
+    // It prints "Image loaded; refs: <ref1>, <ref2>, ... <refN>"
+    LOG_INFO << resp.getJson()["stream"].asString();
+  } else {
+    // The load handler sends 200 to a caller before all layers are loaded and image refs are set.
+    // A presence of the `stream` field in the response assumes that the load was successful, otherwise
+    // the exception is thrown with the response payload which contains the load failure reason.
+    throw std::runtime_error("Failed to load image: " + Utils::jsonToStr(json_resp));
+  }
+}
+
 Json::Value DockerClient::getEngineInfo() {
   Json::Value info;
   const std::string cmd{"http://localhost/version"};
@@ -161,6 +195,36 @@ Json::Value DockerClient::getEngineInfo() {
     throw std::runtime_error("Request to the dockerd's /version endpoint has failed: " + cmd);
   }
   return info;
+}
+
+std::string DockerClient::tarString(const std::string& data, const std::string& file_name_in_tar) {
+  struct archive* a;
+  struct archive_entry* entry;
+  size_t archive_size;
+  std::vector<uint8_t> tar_data(2 * data.size() + 500 + 512 + 512);
+
+  a = archive_write_new();
+  archive_write_set_format_ustar(a);
+  int archive_open_status = archive_write_open_memory(a, tar_data.data(), tar_data.size(), &archive_size);
+  if (archive_open_status != ARCHIVE_OK) {
+    throw std::runtime_error("Failed to create an in-memory TAR archive: " + std::to_string(archive_open_status));
+  }
+
+  entry = archive_entry_new();
+  archive_entry_set_pathname(entry, file_name_in_tar.c_str());
+  archive_entry_set_size(entry, data.size());
+  archive_entry_set_filetype(entry, AE_IFREG);
+  archive_entry_set_perm(entry, 0644);
+  archive_write_header(a, entry);
+
+  archive_write_data(a, data.c_str(), data.size());
+  archive_write_finish_entry(a);
+  archive_entry_free(entry);
+
+  archive_write_close(a);
+  archive_write_free(a);
+
+  return {tar_data.begin(), tar_data.begin() + archive_size};
 }
 
 }  // namespace Docker

--- a/src/docker/dockerclient.h
+++ b/src/docker/dockerclient.h
@@ -27,6 +27,8 @@ class DockerClient : public AppEngine::Client {
   Json::Value getRunningApps(const std::function<void(const std::string&, Json::Value&)>& ext_func) override;
   void pruneImages() override;
   void pruneContainers() override;
+  void loadImage(const std::string& image_uri, const Json::Value& load_manifest) override;
+  static std::string tarString(const std::string& data, const std::string& file_name_in_tar);
 
  private:
   Json::Value getEngineInfo();

--- a/src/docker/restorableappengine.cc
+++ b/src/docker/restorableappengine.cc
@@ -180,21 +180,10 @@ AppEngine::Result RestorableAppEngine::installAndCreateOrRunContainers(const App
     LOG_WARNING << "Failed to install App images: " << exc.what();
   }
 
-  if (!offline_) {
+  if (!offline_ && !res) {
     try {
-      if (!res) {
-        LOG_INFO << "Falling back to pulling App images directly from Registry...";
-        // If App images installation/load fails, then let's try to pull images from Registry
-        // as the last resort.
-      } else {
-        LOG_INFO << "Verifying if App images are installed...";
-        // Even if App images are installed/loaded without failure, it would be great to check
-        // if the docker is happy about it. If not it may update image reference/manifest by
-        // fetching image manifest from Registry. This fetch may fail and we need to distinguish
-        // between the pull/fetch failures and container start/running errors.
-        // The former one shouldn't lead to the Target marking as failing,
-        // only container run/start errors should cause it.
-      }
+      LOG_INFO << "Falling back to pulling App images directly from Registry...";
+      // If App images installation/load fails, then try to pull images from Registry as the last resort.
       const auto app_install_root{install_root_ / app.name};
       pullComposeAppImages(compose_cmd_, app_install_root);
     } catch (const std::exception& exc) {

--- a/src/docker/restorableappengine.cc
+++ b/src/docker/restorableappengine.cc
@@ -446,8 +446,8 @@ void RestorableAppEngine::checkAppUpdateSize(const Uri& uri, const boost::filesy
   const auto layers_meta_desc{manifest.layersMetaDescr()};
   if (layers_meta_desc) {
     try {
-      const Docker::Uri layers_meta_uri{uri.createUri(HashedDigest(layers_meta_desc.digest))};
-      const auto layers_meta_path{app_dir / layers_meta_desc.digest};
+      const Docker::Uri layers_meta_uri{uri.createUri(layers_meta_desc.digest)};
+      const auto layers_meta_path{app_dir / layers_meta_desc.digest.hash()};
       registry_client_->downloadBlob(layers_meta_uri, layers_meta_path, layers_meta_desc.size);
       const auto layers_meta{Utils::parseJSONFile(layers_meta_path)};
       if (!layers_meta.isMember(arch)) {

--- a/src/docker/restorableappengine.h
+++ b/src/docker/restorableappengine.h
@@ -111,6 +111,10 @@ class RestorableAppEngine : public AppEngine {
                                                 const boost::filesystem::path& docker_path);
 
  private:
+  class LoadImageException : public std::runtime_error {
+   public:
+    explicit LoadImageException(const std::string& err) : std::runtime_error(err) {}
+  };
   // pull App&Images
   void pullApp(const Uri& uri, const boost::filesystem::path& app_dir);
   void checkAppUpdateSize(const Uri& uri, const boost::filesystem::path& app_dir) const;
@@ -120,7 +124,7 @@ class RestorableAppEngine : public AppEngine {
   // install App&Images
   Result installAndCreateOrRunContainers(const App& app, bool run = false);
   Result installContainerless(const App& app);
-  boost::filesystem::path installAppAndImages(const App& app);
+  void installAppAndImages(const App& app);
   static void installApp(const boost::filesystem::path& app_dir, const boost::filesystem::path& dst_dir);
   void installAppImages(const boost::filesystem::path& app_dir);
 

--- a/src/docker/restorableappengine.h
+++ b/src/docker/restorableappengine.h
@@ -145,6 +145,10 @@ class RestorableAppEngine : public AppEngine {
   static void installImage(const std::string& client, const boost::filesystem::path& image_dir,
                            const boost::filesystem::path& shared_blob_dir, const std::string& docker_host,
                            const std::string& tag, const std::string& format = "v2s2");
+  static void loadImageToDockerStore(Docker::DockerClient::Ptr& docker_client_,
+                                     const boost::filesystem::path& shared_blob_dir,
+                                     const boost::filesystem::path& image_dir, const std::string& uri,
+                                     const std::string& tag);
 
   static void verifyComposeApp(const std::string& compose_cmd, const boost::filesystem::path& app_dir);
   static void pullComposeAppImages(const std::string& compose_cmd, const boost::filesystem::path& app_dir,

--- a/src/liteclient.cc
+++ b/src/liteclient.cc
@@ -660,7 +660,7 @@ data::ResultCode::Numeric LiteClient::install(const Uptane::Target& target) {
     writeCurrentTarget(target);
     updateRequestHeaders();
   } else if (iresult.result_code.num_code == data::ResultCode::Numeric::kDownloadFailed) {
-    LOG_INFO << "Apps installation failed while the install process was trying to fetch App images data,"
+    LOG_INFO << "Apps installation failed while the install process was trying to load App images to docker store,"
                 " will try the install again at the next update cycle.";
   } else {
     LOG_ERROR << "Unable to install update: " << iresult.description;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -212,7 +212,7 @@ add_aktualizr_test(NAME docker
   PROJECT_WORKING_DIRECTORY
 )
 aktualizr_source_file_checks(docker_test.cc)
-target_include_directories(t_docker PRIVATE ${TEST_INCS} ${AKTUALIZR_DIR}/tests/)
+target_include_directories(t_docker PRIVATE ${TEST_INCS} ${AKTUALIZR_DIR}/tests/ ${AKTUALIZR_DIR}/src)
 set_tests_properties(test_docker PROPERTIES LABELS "aklite:docker")
 target_link_libraries(t_docker ${MAIN_TARGET_LIB} testutilities)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -212,9 +212,9 @@ add_aktualizr_test(NAME docker
   PROJECT_WORKING_DIRECTORY
 )
 aktualizr_source_file_checks(docker_test.cc)
-target_include_directories(t_docker PRIVATE ${TEST_INCS})
+target_include_directories(t_docker PRIVATE ${TEST_INCS} ${AKTUALIZR_DIR}/tests/)
 set_tests_properties(test_docker PROPERTIES LABELS "aklite:docker")
-target_link_libraries(t_docker ${MAIN_TARGET_LIB})
+target_link_libraries(t_docker ${MAIN_TARGET_LIB} testutilities)
 
 add_aktualizr_test(NAME aklite_offline
   SOURCES aklite_offline_test.cc

--- a/tests/docker-compose_fake.py
+++ b/tests/docker-compose_fake.py
@@ -51,6 +51,7 @@ def up(out_dir, app_name, compose, flags):
         images = {}
 
     logger.info("Run services...")
+    logger.info("Run services...")
     with open(os.path.join(out_dir, "containers.json"), "r") as f:
         containers = json.load(f)
 

--- a/tests/docker_test.cc
+++ b/tests/docker_test.cc
@@ -219,6 +219,25 @@ TEST_F(ImageTest, ImageManifestNegative) {
   }
 }
 
+TEST_F(ImageTest, LoadManifest) {
+  const auto man{Docker::ImageManifest{img_man_}};
+  const std::vector<std::string>& refs = {
+      "factory/image@sha256:692f29ee68fa6bab04aa6a1c6d8db0ad44e287e5ff5c7e1d5794c3aabc55884d",
+      "factory/image@sha256:692f29e",
+  };
+  const std::string blobs_dir{"reset-apps/blobs/sha256"};
+  const auto lm{man.toLoadManifest(blobs_dir, refs)};
+  ASSERT_EQ(man.config().digest.hash(), lm["Config"].asString());
+  ASSERT_EQ(blobs_dir, lm["LayersRoot"].asString());
+  for (int ii = 0; ii << refs.size(); ++ii) {
+    ASSERT_EQ(refs[ii], lm["RepoTags"][ii].asString());
+  }
+  const auto l{man.layers()};
+  for (int ii = 0; ii << l.size(); ++ii) {
+    ASSERT_EQ(l[ii].digest.hash(), lm["Layers"][ii].asString());
+  }
+}
+
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/tests/docker_test.cc
+++ b/tests/docker_test.cc
@@ -169,6 +169,56 @@ TEST(Docker, BearerAuthNegative) {
   }
 }
 
+class ImageTest : virtual public ::testing::Test {
+ protected:
+  void SetUp() override {
+    img_man_["mediaType"] = Docker::ImageManifest::Format;
+    img_man_["schemaVersion"] = Docker::ImageManifest::Version;
+    img_man_["config"]["mediaType"] = "application/vnd.docker.container.image.v1+json";
+    img_man_["config"]["size"] = 6541;
+    img_man_["config"]["digest"] = "sha256:99ae753c80968a7d7846dfbd06f0f0f7a425575955a275c7db01d0e9e34cab70";
+
+    img_layers_[0]["mediaType"] = "application/vnd.docker.image.rootfs.diff.tar.gzip";
+    img_layers_[0]["size"] = 1342;
+    img_layers_[0]["digest"] = "sha256:48ecbb6b270eb481cb6df2a5b0332de294ec729e1968e92d725f1329637ce01b";
+    img_layers_[1]["mediaType"] = "application/vnd.docker.image.rootfs.diff.tar.gzip";
+    img_layers_[1]["size"] = 308482;
+    img_layers_[1]["digest"] = "sha256:692f29ee68fa6bab04aa6a1c6d8db0ad44e287e5ff5c7e1d5794c3aabc55884d";
+    img_man_["layers"] = img_layers_;
+  }
+
+  Json::Value img_man_;
+  Json::Value img_layers_;
+};
+
+TEST_F(ImageTest, ImageManifest) {
+  ASSERT_NO_THROW(const auto man{Docker::ImageManifest{img_man_}};
+                  EXPECT_EQ(Docker::Descriptor{img_man_["config"]}, man.config()); const auto man_layers{man.layers()};
+                  int indx{0}; for (const auto& l
+                                    : man.layers()) { EXPECT_EQ(Docker::Descriptor{img_layers_[indx++]}, l); };);
+}
+
+TEST_F(ImageTest, ImageManifestNegative) {
+  {
+    // missing field
+    Json::Value image_manifest;
+    image_manifest["schemaVersion"] = Docker::ImageManifest::Version;
+    ASSERT_THROW(Docker::ImageManifest{image_manifest}, std::runtime_error);
+  }
+  {
+    // invalid config digest
+    Json::Value image_manifest{img_man_};
+    image_manifest["config"]["digest"] = "0968a7d7846dfbd06f0f0f7a425575955a275c7db01d0e9e34cab70";
+    ASSERT_THROW(Docker::ImageManifest{image_manifest}.config(), std::invalid_argument);
+  }
+  {
+    // invalid layer size
+    Json::Value image_manifest{img_man_};
+    image_manifest["layers"][0]["size"] = "foobar";
+    ASSERT_THROW(Docker::ImageManifest{image_manifest}.layers(), Json::LogicError);
+  }
+}
+
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/tests/fixtures/composeapp.cc
+++ b/tests/fixtures/composeapp.cc
@@ -190,6 +190,7 @@ class ComposeApp {
         manifest["layers"][1]["size"] = layers_meta_.size();
       }
       manifest["layers"][1]["annotations"]["layers-meta"] = "v1";
+      manifest["layers"][1]["mediaType"] = "application/octet-stream";
     }
     // emulate compose-publish work, i.e. calculate hash on a manifest json as it is,
     // no need to normalize it to a canonical representation


### PR DESCRIPTION
Replace the `skopeo copy` command with the functionality that makes `HTTP POST /images/load` request to the docker daemon.
The `skopeo copy` command has two issues:
1. It implies copying layers from the skopeo store to the docker's temporal directory prior to starting layer exporting/load process.
2. It does the layer copy to the temporal directly even if those layers are already present in the docker store (because it sends the load manifest after copying all image layers...).

By extending the image load manifest with addition field that refers to the image layers blob/root directory it makes the docker loader/tarexporter to pull layer blobs directly from the skopeo/OCI store. See this PR https://github.com/foundriesio/meta-lmp/pull/1288 for details. Also, this approach automatically fixes the second issue.

In addition to that, this change allows us setting a digest/hashed reference for the uploaded image. Thus, we can skip unnecessary request to Registry for an image manifest during installation process.
Also, we can set any image tag if needed.