### PR TITLE
offline: Add "current" subcommand

### DIFF
--- a/apps/aklite-offline/cmds.cpp
+++ b/apps/aklite-offline/cmds.cpp
@@ -1,4 +1,6 @@
 #include "cmds.h"
+#include "composeappmanager.h"
+#include "target.h"
 
 #include "offline/client.h"
 
@@ -110,6 +112,25 @@ int RunCmd::runUpdate(const Config& cfg_in) const {
   } catch (const std::exception& exc) {
     std::cerr << "Failed to run the offline update; err: " << exc.what();
   }
+  return ret_code;
+}
+
+int CurrentCmd::current(const Config& cfg_in) const {
+  int ret_code{EXIT_FAILURE};
+
+  auto target = offline::client::getCurrent(cfg_in, nullptr);
+
+  ComposeAppManager::Config pc{cfg_in.pacman};
+
+  std::cout << "Target: " << target.filename() << std::endl;
+  std::cout << "Ostree hash: " << target.sha256Hash() << std::endl;
+  std::cout << "Apps:" << std::endl;
+  for (const auto& app : Target::Apps(target)) {
+    if (!pc.apps || (*pc.apps).end() != std::find((*pc.apps).begin(), (*pc.apps).end(), app.name)) {
+      std::cout << "    " << app.name + " -> " + app.uri << std::endl;
+    }
+  }
+
   return ret_code;
 }
 

--- a/apps/aklite-offline/cmds.h
+++ b/apps/aklite-offline/cmds.h
@@ -82,6 +82,30 @@ class RunCmd : public Cmd {
   po::options_description _options;
 };
 
+class CurrentCmd : public Cmd {
+ public:
+  CurrentCmd() : Cmd("current", _options) {
+    _options.add_options()("help,h", "print usage")("log-level", po::value<int>()->default_value(2),
+                                                    "set log level 0-5 (trace, debug, info, warning, error, fatal)");
+  }
+
+  int operator()(const po::variables_map& vm) const override {
+    try {
+      Config cfg_in{vm};
+      return current(cfg_in);
+    } catch (const std::exception& exc) {
+      LOG_ERROR << "Failed to get current status information: " << exc.what();
+      return EXIT_FAILURE;
+    }
+  }
+
+ private:
+  int current(const Config& cfg_in) const;
+
+ private:
+  po::options_description _options;
+};
+
 }  // namespace aklite_offline
 }  // namespace apps
 

--- a/apps/aklite-offline/main.cpp
+++ b/apps/aklite-offline/main.cpp
@@ -12,6 +12,7 @@ namespace po = boost::program_options;
 static std::vector<apps::aklite_offline::Cmd::Ptr> cmds{
     std::make_shared<apps::aklite_offline::InstallCmd>(),
     std::make_shared<apps::aklite_offline::RunCmd>(),
+    std::make_shared<apps::aklite_offline::CurrentCmd>(),
 };
 
 static void print_usage() {


### PR DESCRIPTION
This new command prints the current target, ostree hash and list of enabled applications, using the following format:

Target: <target>
Ostree hash: <hash>
Apps:
    <app1_name> -> <app1_uri>
    <app2_name> -> <app2_uri>