### PR TITLE
rootfsmanager: Don't pull delta stat if offline update

### DIFF
--- a/src/rootfstreemanager.cc
+++ b/src/rootfstreemanager.cc
@@ -306,6 +306,10 @@ data::InstallationResult RootfsTreeManager::verifyBootloaderUpdate(const Uptane:
 
 bool RootfsTreeManager::getDeltaStatIfAvailable(const TufTarget& target, const Remote& remote,
                                                 DeltaStat& delta_stat) const {
+  if (0 == remote.baseUrl.find_first_of("file://")) {
+    // Delta stat file download is not supported in the offline update case.
+    return false;
+  }
   try {
     DeltaStatsRef delta_stats_ref;
     if (!getDeltaStatsRef(target.Custom(), delta_stats_ref)) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -224,7 +224,8 @@ add_aktualizr_test(NAME aklite_offline
 )
 aktualizr_source_file_checks(aklite_offline_test.cc)
 target_include_directories(t_aklite_offline PRIVATE ${TEST_INCS} ${AKTUALIZR_DIR}/tests/ ${AKTUALIZR_DIR}/src/)
-target_link_libraries(t_aklite_offline ${MAIN_TARGET_LIB} ${TEST_LIBS} testutilities uptane_generator_lib ${AKLITE_OFFLINE_LIB})
+target_link_libraries(t_aklite_offline ${MAIN_TARGET_LIB} ${TEST_LIBS} testutilities uptane_generator_lib ${AKLITE_OFFLINE_LIB} fstatvfs-mock)
+set_tests_properties(test_aklite_offline PROPERTIES ENVIRONMENT "LD_PRELOAD=${PROJECT_BINARY_DIR}/tests/libfstatvfs-mock.so")
 set_tests_properties(test_aklite_offline PROPERTIES LABELS "aklite:offline")
 
 

--- a/tests/aklite_offline_test.cc
+++ b/tests/aklite_offline_test.cc
@@ -24,6 +24,10 @@
 #include "fixtures/liteclient/sysrootfs.cc"
 #include "fixtures/liteclient/tufrepomock.cc"
 
+// Defined in fstatvfs-mock.cc
+extern void SetFreeBlockNumb(uint64_t, uint64_t);
+extern void UnsetFreeBlockNumb();
+
 class AppStore {
  public:
   AppStore(const boost::filesystem::path& root_dir, const std::string& hostname = "hub.foundries.io")
@@ -123,7 +127,10 @@ class AkliteOffline : public ::testing::Test {
   void SetUp() {
     auto env{boost::this_process::environment()};
     env.set("DOCKER_HOST", daemon_.getUrl());
+    SetFreeBlockNumb(90, 100);
   }
+
+  void TearDown() { UnsetFreeBlockNumb(); }
 
   offline::PostInstallAction install() { return offline::client::install(cfg_, src(), daemon_.getClient()); }
 


### PR DESCRIPTION
The fioctl command that downloads content for offline update does not fetch the delta stat if the one is present for a given target. Therefore, the offline update client should not attempt to fetch the delta stat file.