### PR TITLE
Control offline update downgrade

### DIFF
--- a/apps/aklite-offline/cmds.h
+++ b/apps/aklite-offline/cmds.h
@@ -112,7 +112,8 @@ class CurrentCmd : public Cmd {
  public:
   CurrentCmd() : Cmd("current", _options) {
     _options.add_options()("help,h", "print usage")("log-level", po::value<int>()->default_value(2),
-                                                    "set log level 0-5 (trace, debug, info, warning, error, fatal)");
+                                                    "set log level 0-5 (trace, debug, info, warning, error, fatal)")(
+        "config,c", po::value<std::vector<boost::filesystem::path>>()->composing(), "Configuration file or directory");
   }
 
   int operator()(const po::variables_map& vm) const override {

--- a/apps/aklite-offline/cmds.h
+++ b/apps/aklite-offline/cmds.h
@@ -63,13 +63,15 @@ class InstallCmd : public Cmd {
     _options.add_options()("help,h", "print usage")("log-level", po::value<int>()->default_value(2),
                                                     "set log level 0-5 (trace, debug, info, warning, error, fatal)")(
         "config,c", po::value<std::vector<boost::filesystem::path>>()->composing(), "Configuration file or directory")(
-        "src-dir,s", po::value<boost::filesystem::path>()->required(), "Directory that contains an update");
+        "src-dir,s", po::value<boost::filesystem::path>()->required(), "Directory that contains an update")(
+        "force,f", po::bool_switch(&force_downgrade), "Force downgrade");
   }
 
   int operator()(const po::variables_map& vm) const override {
     try {
       Config cfg_in{vm};
-      return installUpdate(cfg_in, boost::filesystem::canonical(vm["src-dir"].as<boost::filesystem::path>()));
+      return installUpdate(cfg_in, boost::filesystem::canonical(vm["src-dir"].as<boost::filesystem::path>()),
+                           force_downgrade);
     } catch (const std::exception& exc) {
       LOG_ERROR << "Failed to list Apps: " << exc.what();
       return EXIT_FAILURE;
@@ -77,10 +79,11 @@ class InstallCmd : public Cmd {
   }
 
  private:
-  int installUpdate(const Config& cfg_in, const boost::filesystem::path& src_dir) const;
+  int installUpdate(const Config& cfg_in, const boost::filesystem::path& src_dir, bool force_downgrade) const;
 
  private:
   po::options_description _options;
+  bool force_downgrade{false};
 };
 
 class RunCmd : public Cmd {

--- a/src/offline/client.h
+++ b/src/offline/client.h
@@ -20,7 +20,14 @@ struct UpdateSrc {
   std::string TargetName;
 };
 
-enum class PostInstallAction { Undefined = -1, NeedReboot, NeedRebootForBootFw, NeedDockerRestart, AlreadyInstalled };
+enum class PostInstallAction {
+  Undefined = -1,
+  NeedReboot,
+  NeedRebootForBootFw,
+  NeedDockerRestart,
+  AlreadyInstalled,
+  DowngradeAttempt
+};
 enum class PostRunAction {
   Undefined = -1,
   Ok,
@@ -73,7 +80,8 @@ class MetaFetcher : public Uptane::IMetadataFetcher {
 namespace client {
 
 PostInstallAction install(const Config& cfg_in, const UpdateSrc& src,
-                          std::shared_ptr<HttpInterface> docker_client_http_client = nullptr);
+                          std::shared_ptr<HttpInterface> docker_client_http_client = nullptr,
+                          bool force_downgrade = false);
 PostRunAction run(const Config& cfg_in, std::shared_ptr<HttpInterface> docker_client_http_client = nullptr);
 const Uptane::Target getCurrent(const Config& cfg_in,
                                 std::shared_ptr<HttpInterface> docker_client_http_client = nullptr);

--- a/src/target.h
+++ b/src/target.h
@@ -19,6 +19,7 @@ class Target {
     explicit Version(std::string version) : raw_ver(std::move(version)) {}
 
     bool operator<(const Version& other) const { return strverscmp(raw_ver.c_str(), other.raw_ver.c_str()) < 0; }
+    bool operator>(const Version& other) const { return strverscmp(raw_ver.c_str(), other.raw_ver.c_str()) > 0; }
   };
 
   static bool hasTag(const Uptane::Target& target, const std::vector<std::string>& tags);


### PR DESCRIPTION
Prevent accidental downgrades during offline updates by disallowing them by default.
Introduce a new Command Line Interface (CLI) option `--force/-f` to enable forced downgrades, empowering users to enforce updates even if the current version is higher than the specified one.
This change ensures a more controlled update process and enhances user flexibility.
