### PR TITLE
offline: Fix --log-level option

### DIFF
--- a/apps/aklite-offline/main.cpp
+++ b/apps/aklite-offline/main.cpp
@@ -70,6 +70,9 @@ int main(int argc, char** argv) {
 
   logger_init(isatty(1) == 1);
   logger_set_threshold(static_cast<boost::log::trivial::severity_level>(vm["log-level"].as<int>()));
+  // libaktualizr assumes that the log level is set using a "loglevel" cmd line option, so we need
+  // to set that option as well, otherwise libaktualizr overrides the log level with the default value
+  vm.insert(std::pair<std::string, boost::program_options::variable_value>("loglevel", vm["log-level"]));
 
   return cmd(vm);
 }


### PR DESCRIPTION
The command line  option for log level in aklite-offline does not match the one used in aktualizr ("log-level" vs "loglevel"). Libaktualizr sets the log level regardless of the running application, and assumes a "loglevel" option is set in the program options map. This patch adds a "loglevel" entry to the map, copying the "log-level" value.