### PR TITLE
api: POC: add installation modes

### DIFF
--- a/include/aktualizr-lite/api.h
+++ b/include/aktualizr-lite/api.h
@@ -106,6 +106,7 @@ class InstallResult {
     Ok = 0,
     OkBootFwNeedsCompletion,
     NeedsCompletion,
+    AppsNeedCompletion,
     BootFwNeedsCompletion,
     Failed,
     DownloadFailed,
@@ -116,7 +117,8 @@ class InstallResult {
 
   // NOLINTNEXTLINE(hicpp-explicit-conversions,google-explicit-constructor)
   operator bool() const {
-    return status == Status::Ok || status == Status::OkBootFwNeedsCompletion || status == Status::NeedsCompletion;
+    return status == Status::Ok || status == Status::OkBootFwNeedsCompletion || status == Status::NeedsCompletion ||
+           status == Status::AppsNeedCompletion;
   }
 };
 

--- a/include/aktualizr-lite/api.h
+++ b/include/aktualizr-lite/api.h
@@ -143,6 +143,23 @@ class DownloadResult {
 std::ostream &operator<<(std::ostream &os, const InstallResult &res);
 std::ostream &operator<<(std::ostream &os, const DownloadResult &res);
 
+/**
+ * The installation mode to be applied. Specified during InstallContext context initialization.
+ */
+enum class InstallMode {
+  /**
+   * A default install mode. Both Target's components ostree and Apps are fetched and installed
+   * within InstallContext::Install() call.
+   */
+  All = 0,
+  /**
+   * Fetch both ostree and Apps, but only install ostree if it has been updated.
+   * The fetched Apps are installed and started during the finalization phase,
+   * which is executed by the AkliteClient::CompleteInstallation() call.
+   */
+  OstreeOnly
+};
+
 class InstallContext {
  public:
   InstallContext(const InstallContext &) = delete;
@@ -306,7 +323,7 @@ class AkliteClient {
    * Create an InstallContext object to help drive an update.
    */
   std::unique_ptr<InstallContext> Installer(const TufTarget &t, std::string reason = "",
-                                            std::string correlation_id = "") const;
+                                            std::string correlation_id = "", InstallMode = InstallMode::All) const;
 
   /**
    * @brief Complete a pending installation

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,6 +37,7 @@ set(HEADERS helpers.h
         yaml2json.h
         target.h
         downloader.h
+        installer.h
         exec.h
         cli/cli.h
         ../include/aktualizr-lite/api.h)

--- a/src/cli/cli.h
+++ b/src/cli/cli.h
@@ -22,12 +22,14 @@ enum class StatusCode {
   InstallAppPullFailure = 80,
   InstallNeedsRebootForBootFw = 90,
   InstallNeedsReboot = 100,
+  InstallAppsNeedFinalization = 105,
   InstallRollbackOk = 110,
   InstallRollbackNeedsReboot = 120,
   InstallRollbackFailed = 130,
 };
 
-StatusCode Install(AkliteClient &client, int version = -1, const std::string &target_name = "");
+StatusCode Install(AkliteClient &client, int version = -1, const std::string &target_name = "",
+                   const std::string &install_mode = "");
 StatusCode CompleteInstall(AkliteClient &client);
 
 }  // namespace cli

--- a/src/composeappmanager.h
+++ b/src/composeappmanager.h
@@ -44,6 +44,7 @@ class ComposeAppManager : public RootfsTreeManager {
 
   std::string name() const override { return Name; }
   DownloadResultWithStat Download(const TufTarget& target) override;
+  data::InstallationResult Install(const TufTarget& target, InstallMode mode) override;
   bool fetchTarget(const Uptane::Target& target, Uptane::Fetcher& fetcher, const KeyManager& keys,
                    const FetcherProgressCb& progress_cb, const api::FlowControlToken* token) override;
 

--- a/src/installer.h
+++ b/src/installer.h
@@ -1,0 +1,22 @@
+#ifndef AKTUALIZR_LITE_INSTALLER_H_
+#define AKTUALIZR_LITE_INSTALLER_H_
+
+#include "aktualizr-lite/api.h"
+#include "libaktualizr/types.h"
+
+class Installer {
+ public:
+  // TODO: use the API's return type - InstallResult
+  virtual data::InstallationResult Install(const TufTarget& target, InstallMode mode) = 0;
+
+  virtual ~Installer() = default;
+  Installer(const Installer&) = delete;
+  Installer(const Installer&&) = delete;
+  Installer& operator=(const Installer&) = delete;
+  Installer& operator=(const Installer&&) = delete;
+
+ protected:
+  explicit Installer() = default;
+};
+
+#endif  // AKTUALIZR_LITE_DOWNLOADER_H_

--- a/src/liteclient.h
+++ b/src/liteclient.h
@@ -18,6 +18,7 @@ class ReportEvent;
 class ReportQueue;
 class DownloadResult;
 class Downloader;
+class Installer;
 
 class LiteClient {
  public:
@@ -43,7 +44,7 @@ class LiteClient {
   bool finalizeInstall(data::InstallationResult* ir = nullptr);
   Uptane::Target getRollbackTarget();
   DownloadResultWithStat download(const Uptane::Target& target, const std::string& reason);
-  data::ResultCode::Numeric install(const Uptane::Target& target);
+  data::ResultCode::Numeric install(const Uptane::Target& target, InstallMode install_mode = InstallMode::All);
   void notifyInstallFinished(const Uptane::Target& t, data::InstallationResult& ir);
   std::pair<bool, std::string> isRebootRequired() const {
     return {is_reboot_required_, config.bootloader.reboot_command};
@@ -91,7 +92,7 @@ class LiteClient {
   void notifyInstallStarted(const Uptane::Target& t);
   void writeCurrentTarget(const Uptane::Target& t) const;
 
-  data::InstallationResult installPackage(const Uptane::Target& target);
+  data::InstallationResult installPackage(const Uptane::Target& target, InstallMode install_mode = InstallMode::All);
   DownloadResultWithStat downloadImage(const Uptane::Target& target, const api::FlowControlToken* token = nullptr);
   static void add_apps_header(std::vector<std::string>& headers, PackageConfig& config);
   data::InstallationResult finalizePendingUpdate(boost::optional<Uptane::Target>& target);
@@ -113,6 +114,7 @@ class LiteClient {
   std::vector<Uptane::Target> no_targets_;
 
   std::shared_ptr<Downloader> downloader_;
+  std::shared_ptr<Installer> installer_;
   Json::Value apps_state_;
   const int report_queue_run_pause_s_{10};
   const int report_queue_event_limit_{6};

--- a/src/main.cc
+++ b/src/main.cc
@@ -435,11 +435,15 @@ static int cli_install(LiteClient& client, const bpo::variables_map& params) {
       target_name = version_str;
     }
   }
+  std::string install_mode;
+  if (params.count("install-mode") > 0) {
+    install_mode = params.at("install-mode").as<std::string>();
+  }
 
   std::shared_ptr<LiteClient> client_ptr{&client, [](LiteClient* /*unused*/) {}};
   AkliteClient akclient{client_ptr, false, true};
 
-  return static_cast<int>(cli::Install(akclient, version, target_name));
+  return static_cast<int>(cli::Install(akclient, version, target_name, install_mode));
 }
 
 static int cli_complete_install(LiteClient& client, const bpo::variables_map& params) {
@@ -498,6 +502,7 @@ bpo::variables_map parse_options(int argc, char** argv) {
       ("ostree-server", bpo::value<std::string>(), "URL of the Ostree repository")
       ("primary-ecu-hardware-id", bpo::value<std::string>(), "hardware ID of primary ecu")
       ("update-name", bpo::value<std::string>(), "optional name of the update when running \"update\". default=latest")
+      ("install-mode", bpo::value<std::string>(), "Optional install mode. Supported modes: [delay-app-install]. By default both ostree and apps are installed before reboot")
 #ifdef ALLOW_MANUAL_ROLLBACK
       ("clear-installed-versions", "DANGER - clear the history of installed updates before applying the given update. This is handy when doing test/debug and you need to rollback to an old version manually.")
 #endif

--- a/src/rootfstreemanager.cc
+++ b/src/rootfstreemanager.cc
@@ -168,6 +168,10 @@ void RootfsTreeManager::installNotify(const Uptane::Target& target) {
   OstreeManager::installNotify(target);
 }
 
+data::InstallationResult RootfsTreeManager::Install(const TufTarget& target, InstallMode /*mode*/) {
+  return RootfsTreeManager::install(Target::fromTufTarget(target));
+}
+
 data::InstallationResult RootfsTreeManager::install(const Uptane::Target& target) const {
   data::InstallationResult res;
   Uptane::Target current = OstreeManager::getCurrent();

--- a/src/rootfstreemanager.h
+++ b/src/rootfstreemanager.h
@@ -4,11 +4,12 @@
 #include "bootloader/bootloaderlite.h"
 #include "downloader.h"
 #include "http/httpinterface.h"
+#include "installer.h"
 #include "ostree/sysroot.h"
 #include "package_manager/ostreemanager.h"
 #include "storage/stat.h"
 
-class RootfsTreeManager : public OstreeManager, public Downloader {
+class RootfsTreeManager : public OstreeManager, public Downloader, public Installer {
  public:
   static constexpr const char* const Name{"ostree"};
   struct Config {
@@ -35,17 +36,18 @@ class RootfsTreeManager : public OstreeManager, public Downloader {
                     std::shared_ptr<OSTree::Sysroot> sysroot, const KeyManager& keys);
 
   DownloadResultWithStat Download(const TufTarget& target) override;
+  data::InstallationResult Install(const TufTarget& target, InstallMode mode) override;
 
   bool fetchTarget(const Uptane::Target& target, Uptane::Fetcher& fetcher, const KeyManager& keys,
                    const FetcherProgressCb& progress_cb, const api::FlowControlToken* token) override;
 
   const bootloader::BootFwUpdateStatus& bootFwUpdateStatus() const { return *boot_fw_update_status_; }
   void setInitialTargetIfNeeded(const std::string& hw_id);
+  data::InstallationResult install(const Uptane::Target& target) const override;
 
  protected:
   virtual void completeInitialTarget(Uptane::Target& init_target){};
   void installNotify(const Uptane::Target& target) override;
-  data::InstallationResult install(const Uptane::Target& target) const override;
   const std::shared_ptr<OSTree::Sysroot>& sysroot() const { return sysroot_; }
 
  private:

--- a/tests/apiclient_test.cc
+++ b/tests/apiclient_test.cc
@@ -287,10 +287,14 @@ TEST_F(ApiClientTest, InstallModeOstreeOnlyIfJustApps) {
   ASSERT_EQ(DownloadResult::Status::Ok, dresult.status);
 
   auto iresult = installer->Install();
-  ASSERT_EQ(InstallResult::Status::NeedsCompletion, iresult.status);
+  ASSERT_EQ(InstallResult::Status::AppsNeedCompletion, iresult.status);
 
-  auto ciresult = client.CompleteInstallation();
-  ASSERT_EQ(InstallResult::Status::Ok, ciresult.status);
+  {
+    liteclient = createLiteClient();
+    AkliteClient client(liteclient);
+    auto ciresult = client.CompleteInstallation();
+    ASSERT_EQ(InstallResult::Status::Ok, ciresult.status);
+  }
 }
 
 TEST_F(ApiClientTest, Secondaries) {


### PR DESCRIPTION
- Add a generic mechanism to support different installation modes. It includes adding a new `Installer` interface which along with the `Downloader` interface will eventually help to get rid of dependency on the aktualizr's PackageManager interface.
- Added "ostree only"/"delayed App installation" installation mode support.
- Added a new CLI parameter to the CLI command to turn on the delayed app installation mode.