### PR TITLE
Add a TUF API to aklite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ option(ALLOW_MANUAL_ROLLBACK "Set to ON to build with support of manual rollback
 option(BUILD_AKLITE_OFFLINE "Set to ON to build cli command for an offline update" OFF)
 option(BUILD_AKLITE_WITH_NERDCTL "Set to ON to build with support of nerdctl/containerd" OFF)
 option(BUILD_AKLITE_APPS "Set to ON to build cli command for Apps management" ON)
+option(BUILD_TUFCTL "Set to ON to build sample tuf control application" OFF)
 
 # If we build the sota tools we don't need aklite (???) and vice versa
 # if we build aklite we don't need the sota tools
@@ -61,7 +62,9 @@ if(BUILD_AKLITE)
   if(BUILD_AKLITE_OFFLINE)
     add_subdirectory(apps/aklite-offline)
   endif(BUILD_AKLITE_OFFLINE)
-
+  if(BUILD_TUFCTL)
+    add_subdirectory(apps/tufctl)
+  endif(BUILD_TUFCTL)
 endif(BUILD_AKLITE)
 
 # Use `-LH` options (cmake <args> -LH) to output all variables
@@ -72,3 +75,4 @@ message(STATUS "ALLOW_MANUAL_ROLLBACK: ${ALLOW_MANUAL_ROLLBACK}")
 message(STATUS "BUILD_AKLITE_OFFLINE: ${BUILD_AKLITE_OFFLINE}")
 message(STATUS "BUILD_AKLITE_WITH_NERDCTL: ${BUILD_AKLITE_WITH_NERDCTL}")
 message(STATUS "BUILD_AKLITE_APPS: ${BUILD_AKLITE_APPS}")
+message(STATUS "BUILD_TUFCTL: ${BUILD_TUFCTL}")

--- a/apps/tufctl/CMakeLists.txt
+++ b/apps/tufctl/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required (VERSION 3.5)
+
+set(TARGET tufctl)
+project(${TARGET})
+
+set(SRC main.cpp)
+# set(HEADERS cmds.h)
+
+add_executable(${TARGET} ${SRC})
+add_dependencies(aktualizr-lite ${TARGET})
+set_property(TARGET ${TARGET} PROPERTY CXX_STANDARD 17)
+
+set(INCS
+  ${AKLITE_DIR}/include/
+  ${AKLITE_DIR}/src/
+  ${AKTUALIZR_DIR}/src/libaktualizr
+  ${AKTUALIZR_DIR}/include
+  ${AKTUALIZR_DIR}/third_party/jsoncpp/include
+  # odd dependency of libaktualizr/http/httpclient.h
+  ${AKTUALIZR_DIR}/third_party/googletest/googletest/include
+  ${LIBOSTREE_INCLUDE_DIRS}
+)
+
+target_include_directories(${TARGET} PRIVATE ${INCS})
+
+target_link_libraries(${TARGET} aktualizr_lite ${AKLITE_OFFLINE_LIB})
+
+install(TARGETS ${TARGET} RUNTIME DESTINATION bin)
+
+# enable creating clang-tidy targets for each source file (see aktualizr/CMakeLists.txt for details)
+aktualizr_source_file_checks(${SRC} ${HEADERS})

--- a/apps/tufctl/main.cpp
+++ b/apps/tufctl/main.cpp
@@ -1,0 +1,106 @@
+#include <boost/property_tree/ini_parser.hpp>
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/ptree_fwd.hpp>
+#include "aktualizr-lite/tuf/tuf.h"
+#include "tuf/akhttpsreposource.h"
+#include "tuf/akrepo.h"
+#include "tuf/localreposource.h"
+
+// Strip leading and trailing quotes
+std::string strip_quotes(const std::string& value) {
+  std::string res = value;
+  res.erase(std::remove(res.begin(), res.end(), '\"'), res.end());
+  return res;
+}
+
+int main(int argc, char** argv) {
+  if (argc < 2) {
+    std::cerr << "Usage example: " << argv[0] << " repo_sources.toml" << std::endl;
+    exit(1);
+  }
+
+  boost::filesystem::path storage_path;
+
+  std::vector<std::shared_ptr<aklite::tuf::RepoSource>> sources;
+  // Set up
+  {
+    boost::property_tree::ptree pt;
+    boost::property_tree::ini_parser::read_ini(argv[1], pt);
+
+    std::ostringstream oss;
+    boost::property_tree::write_json(oss, pt);
+    std::cout << oss.str();
+
+    for (boost::property_tree::ptree::iterator pos = pt.begin(); pos != pt.end();) {
+      std::cout << pos->first << std::endl;
+
+      if (pos->first.rfind("source ") == 0) {
+        std::cout << "got repo " << pos->first.substr(7) << std::endl;
+        std::string uri = pos->second.get<std::string>("uri");
+        std::cout << "uri " << uri << " " << uri.rfind("\"file://", 0) << std::endl;
+
+        std::shared_ptr<aklite::tuf::RepoSource> source;
+        if (uri.rfind("\"file://", 0) == 0) {
+          auto local_path = Utils::stripQuotes(uri).erase(0, strlen("file://"));
+          source = std::make_shared<aklite::tuf::LocalRepoSource>(pos->first, local_path);
+        } else {
+          source = std::make_shared<aklite::tuf::AkHttpsRepoSource>(pos->first, pos->second);
+        }
+        sources.push_back(source);
+      }
+
+      if (pos->first == "storage") {
+        storage_path = strip_quotes(pos->second.get<std::string>("path"));
+      }
+
+      ++pos;
+    }
+  }
+
+  // Try individual fetch operations. sota.toml is not used
+  {
+    for (auto const& source : sources) {
+      Json::StreamWriterBuilder builder;
+      builder["indentation"] = "  ";
+      try {
+        auto json = source->fetchRoot(1);
+        std::cout << json << std::endl;
+      } catch (std::runtime_error e) {
+        std::cout << e.what() << std::endl;
+      }
+      try {
+        auto json = source->fetchTimestamp();
+        std::cout << json << std::endl;
+      } catch (std::runtime_error e) {
+        std::cout << e.what() << std::endl;
+      }
+
+      try {
+        auto json = source->fetchSnapshot();
+        std::cout << json << std::endl;
+      } catch (std::runtime_error e) {
+        std::cout << e.what() << std::endl;
+      }
+      try {
+        auto json = source->fetchTargets();
+        // std::cout << json << std::endl;
+      } catch (std::runtime_error e) {
+        std::cout << e.what() << std::endl;
+      }
+    }
+  }
+
+  // Perform TUF refresh for each repo source, using libaktualizr implementation of Repo
+  {
+    aklite::tuf::AkRepo repo(storage_path);
+    for (auto const& source : sources) {
+      repo.updateMeta(source);
+    }
+
+    auto targets = repo.GetTargets();
+    for (auto const& target : targets) {
+      std::cout << target.Name() << " " << target.Sha256Hash() << std::endl;
+    }
+  }
+}

--- a/include/aktualizr-lite/api.h
+++ b/include/aktualizr-lite/api.h
@@ -12,65 +12,12 @@
 
 #include "json/json.h"
 
+#include "tuf/tuf.h"
+
 class Config;
 class LiteClient;
 
-/**
- * A high-level representation of a TUF Target in terms applicable to a
- * FoundriesFactory.
- */
-class TufTarget {
- public:
-  explicit TufTarget() : name_{"unknown"} {}
-  TufTarget(std::string name, std::string sha256, int version, Json::Value custom)
-      : name_(std::move(name)), sha256_(std::move(sha256)), version_(version), custom_(std::move(custom)) {}
-
-  /**
-   * Return the TUF Target name. This is the key in the targets.json key/value
-   * singed.metadata dictionary.
-   */
-  const std::string &Name() const { return name_; }
-  /**
-   * Return the sha256 OStree hash of the Target.
-   */
-  const std::string &Sha256Hash() const { return sha256_; }
-  /**
-   * Return the FoundriesFactory CI build number or in TUF, custom.version.
-   */
-  int Version() const { return version_; }
-
-  /**
-   * Return TUF custom data for a Target.
-   */
-  const Json::Value &Custom() const { return custom_; }
-
-  /**
-   * Is this a known target in the Tuf manifest? There are two common causes
-   * to this situation:
-   *  1) A device has been re-registered (sql.db got wiped out) and the
-   *     /var/sota/installed_versions file is missing. The device might
-   *     running the correct target but the system isn't sure.
-   *  2) A device might be running a Target from a different tag it's not
-   *     configured for. This means the Target isn't present in the targets.json
-   *     this device is getting from the device-gateway.
-   */
-  bool IsUnknown() const { return name_ == "unknown"; }
-
-  /**
-   * @brief Compares the given target with the other target
-   * @param other - the other target to compare with
-   * @return true if the targets match, otherwise false
-   */
-  bool operator==(const TufTarget &other) const {
-    return other.name_ == name_ && other.sha256_ == sha256_ && other.version_ == version_;
-  }
-
- private:
-  std::string name_;
-  std::string sha256_;
-  int version_{-1};
-  Json::Value custom_;
-};
+using aklite::tuf::TufTarget;
 
 /**
  * The response from an AkliteClient call to CheckIn()

--- a/include/aktualizr-lite/api.h
+++ b/include/aktualizr-lite/api.h
@@ -241,6 +241,18 @@ class AkliteClient {
   CheckInResult CheckIn() const;
 
   /**
+   * Performs a simplified "check-in" accessing locally available TUF metadata files.
+   * No communication is done with the device gateway. It consists of:
+   *  1) attempt to read a new new root.json - normally not found.
+   *  2) read timestamp and snapshot metadata.
+   *  3) read a new targets.json if needed
+   *
+   * This is an EXPERIMENTAL implementation. If there is Target data to be updated
+   * later on, it will still be fetched from the remote servers (ostree, app registry).
+   */
+  CheckInResult CheckInLocal(const std::string &path) const;
+
+  /**
    * Return the active aktualizr-lite configuration.
    */
   boost::property_tree::ptree GetConfig() const;
@@ -313,9 +325,11 @@ class AkliteClient {
 
  private:
   void Init(Config &config, bool finalize = true, bool apply_lock = true);
+  CheckInResult UpdateMetaAndGetTargets(std::shared_ptr<aklite::tuf::RepoSource> repo_src) const;
 
   bool read_only_{false};
   std::shared_ptr<LiteClient> client_;
+  std::shared_ptr<aklite::tuf::Repo> tuf_repo_;
   std::vector<std::string> secondary_hwids_;
   mutable bool configUploaded_{false};
 };

--- a/include/aktualizr-lite/tuf/tuf.h
+++ b/include/aktualizr-lite/tuf/tuf.h
@@ -1,0 +1,118 @@
+// Copyright (c) 2023 Foundries.io
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef AKLITE_TUF_TUF_H_
+#define AKLITE_TUF_TUF_H_
+
+#include <string>
+
+#include "json/json.h"
+
+/**
+ * This header contains the definition of an EXPERIMENTAL API for accessing TUF
+ * functionality. It allows for better isolation between Aktualizr-lite and
+ * libaktualizr, and better handling of multiple metadata sources for a same
+ * TUF repository (for example, mirrors or pre-fetched metadata files).
+ */
+
+namespace aklite::tuf {
+
+/**
+ * Interface for a TUF repository metadata source.
+ */
+class RepoSource {
+ public:
+  virtual ~RepoSource() = default;
+  RepoSource(const RepoSource&) = delete;
+  RepoSource(const RepoSource&&) = delete;
+  RepoSource& operator=(const RepoSource&) = delete;
+  RepoSource& operator=(const RepoSource&&) = delete;
+
+  virtual std::string fetchRoot(int version) = 0;
+  virtual std::string fetchTimestamp() = 0;
+  virtual std::string fetchSnapshot() = 0;
+  virtual std::string fetchTargets() = 0;
+
+ protected:
+  RepoSource() = default;
+};
+
+/**
+ * A high-level representation of a TUF Target in terms applicable to a
+ * FoundriesFactory.
+ */
+class TufTarget {
+ public:
+  explicit TufTarget() : name_{"unknown"} {}
+  TufTarget(std::string name, std::string sha256, int version, Json::Value custom)
+      : name_(std::move(name)), sha256_(std::move(sha256)), version_(version), custom_(std::move(custom)) {}
+
+  /**
+   * Return the TUF Target name. This is the key in the targets.json key/value
+   * singed.metadata dictionary.
+   */
+  const std::string& Name() const { return name_; }
+  /**
+   * Return the sha256 OStree hash of the Target.
+   */
+  const std::string& Sha256Hash() const { return sha256_; }
+  /**
+   * Return the FoundriesFactory CI build number or in TUF, custom.version.
+   */
+  int Version() const { return version_; }
+
+  /**
+   * Return TUF custom data for a Target.
+   */
+  const Json::Value& Custom() const { return custom_; }
+
+  /**
+   * Is this a known target in the Tuf manifest? There are two common causes
+   * to this situation:
+   *  1) A device has been re-registered (sql.db got wiped out) and the
+   *     /var/sota/installed_versions file is missing. The device might
+   *     running the correct target but the system isn't sure.
+   *  2) A device might be running a Target from a different tag it's not
+   *     configured for. This means the Target isn't present in the targets.json
+   *     this device is getting from the device-gateway.
+   */
+  bool IsUnknown() const { return name_ == "unknown"; }
+
+  /**
+   * @brief Compares the given target with the other target
+   * @param other - the other target to compare with
+   * @return true if the targets match, otherwise false
+   */
+  bool operator==(const TufTarget& other) const {
+    return other.name_ == name_ && other.sha256_ == sha256_ && other.version_ == version_;
+  }
+
+ private:
+  std::string name_;
+  std::string sha256_;
+  int version_{-1};
+  Json::Value custom_;
+};
+
+/**
+ * Interface for a TUF specification engine, handling a single repository,
+ * fed through one or more consistent RepoSource instances.
+ */
+class Repo {
+ public:
+  virtual ~Repo() = default;
+  Repo(const Repo&) = delete;
+  Repo(const Repo&&) = delete;
+  Repo& operator=(const Repo&) = delete;
+  Repo& operator=(const Repo&&) = delete;
+
+  virtual std::vector<TufTarget> GetTargets() = 0;
+  virtual void updateMeta(std::shared_ptr<RepoSource> repo_src) = 0;
+
+ protected:
+  Repo() = default;
+};
+
+}  // namespace aklite::tuf
+
+#endif

--- a/include/aktualizr-lite/tuf/tuf.h
+++ b/include/aktualizr-lite/tuf/tuf.h
@@ -108,6 +108,7 @@ class Repo {
 
   virtual std::vector<TufTarget> GetTargets() = 0;
   virtual void updateMeta(std::shared_ptr<RepoSource> repo_src) = 0;
+  virtual void checkMeta() = 0;
 
  protected:
   Repo() = default;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,10 @@ set(SRC helpers.cc
         target.cc
         appengine.cc
         cli/cli.cc
-        api.cc)
+        api.cc
+        tuf/akhttpsreposource.cc
+        tuf/localreposource.cc
+        tuf/akrepo.cc)
 
 set(HEADERS helpers.h
         storage/stat.h
@@ -40,7 +43,11 @@ set(HEADERS helpers.h
         installer.h
         exec.h
         cli/cli.h
-        ../include/aktualizr-lite/api.h)
+        tuf/akhttpsreposource.h
+        tuf/localreposource.h
+        tuf/akrepo.h
+        ../include/aktualizr-lite/api.h
+        ../include/aktualizr-lite/tuf/tuf.h)
 
 if (BUILD_AKLITE_WITH_NERDCTL)
   set(SRC ${SRC} containerd/client.cc containerd/engine.cc)

--- a/src/tuf/akhttpsreposource.cc
+++ b/src/tuf/akhttpsreposource.cc
@@ -1,0 +1,113 @@
+#include <boost/filesystem.hpp>
+#include <boost/property_tree/ptree.hpp>
+
+#include "http/httpclient.h"
+#include "uptane/imagerepository.h"
+
+#include "akhttpsreposource.h"
+#include "crypto/p11engine.h"
+
+namespace aklite::tuf {
+
+AkHttpsRepoSource::AkHttpsRepoSource(const std::string& name_in, boost::property_tree::ptree& pt) { init(name_in, pt); }
+
+static std::string readFileIfExists(const utils::BasedPath& based_path) {
+  if (based_path.empty()) {
+    return "";
+  }
+  boost::filesystem::path path = based_path.get("");
+  if (boost::filesystem::exists(path)) {
+    return Utils::readFile(path);
+  } else {
+    return "";
+  }
+}
+
+void AkHttpsRepoSource::init(const std::string& name_in, boost::property_tree::ptree& pt) {
+  name_ = name_in;
+
+  std::vector<std::string> headers;
+  headers.emplace_back("x-ats-tags: " + Utils::stripQuotes(pt.get<std::string>("tag")));
+  for (const auto& key : {"dockerapps", "target", "ostreehash"}) {
+    headers.emplace_back("x-ats-" + std::string(key) + ": " + Utils::stripQuotes(pt.get<std::string>(key, "")));
+  }
+  auto http_client = std::make_shared<HttpClientWithShare>(&headers);
+
+  boost::program_options::variables_map m;
+  Config config(m);
+  fillConfig(config, pt);
+
+  P11EngineGuard p11(config.p11.module, config.p11.pass, config.p11.label);
+  http_client->setCerts(config.tls.ca_source == CryptoSource::kFile ? readFileIfExists(config.import.tls_cacert_path)
+                                                                    : p11->getItemFullId(config.p11.tls_cacert_id),
+                        config.tls.ca_source,
+                        config.tls.cert_source == CryptoSource::kFile
+                            ? readFileIfExists(config.import.tls_clientcert_path)
+                            : p11->getItemFullId(config.p11.tls_clientcert_id),
+                        config.tls.cert_source,
+                        config.tls.pkey_source == CryptoSource::kFile ? readFileIfExists(config.import.tls_pkey_path)
+                                                                      : p11->getItemFullId(config.p11.tls_pkey_id),
+                        config.tls.pkey_source);
+
+  meta_fetcher_ = std::make_shared<Uptane::Fetcher>(config, http_client);
+}
+
+void AkHttpsRepoSource::fillConfig(Config& config, boost::property_tree::ptree& pt) {
+  bool enable_hsm = pt.count("p11_module") > 0;
+  if (enable_hsm) {
+    config.p11.module = Utils::stripQuotes(pt.get<std::string>("p11_module"));
+    config.p11.pass = Utils::stripQuotes(pt.get<std::string>("p11_pass"));
+    config.p11.label = Utils::stripQuotes(pt.get<std::string>("p11_label"));
+  }
+
+  if (enable_hsm && pt.count("tls_pkey_id") > 0) {
+    config.tls.pkey_source = CryptoSource::kPkcs11;
+    config.p11.tls_pkey_id = Utils::stripQuotes(pt.get<std::string>("tls_pkey_id"));
+  } else {
+    config.tls.pkey_source = CryptoSource::kFile;
+    config.import.tls_pkey_path = utils::BasedPath(Utils::stripQuotes(pt.get<std::string>("tls_pkey_path")));
+  }
+
+  if (enable_hsm && pt.count("tls_cacert_id") > 0) {
+    config.tls.ca_source = CryptoSource::kPkcs11;
+    config.p11.tls_cacert_id = Utils::stripQuotes(pt.get<std::string>("tls_cacert_id"));
+  } else {
+    config.tls.ca_source = CryptoSource::kFile;
+    config.import.tls_cacert_path = utils::BasedPath(Utils::stripQuotes(pt.get<std::string>("tls_cacert_path")));
+  }
+
+  if (enable_hsm && pt.count("tls_clientcert_id") > 0) {
+    config.tls.cert_source = CryptoSource::kPkcs11;
+    config.p11.tls_clientcert_id = Utils::stripQuotes(pt.get<std::string>("tls_clientcert_id"));
+  } else {
+    config.tls.cert_source = CryptoSource::kFile;
+    config.import.tls_clientcert_path =
+        utils::BasedPath(Utils::stripQuotes(pt.get<std::string>("tls_clientcert_path")));
+  }
+
+  config.uptane.repo_server = Utils::stripQuotes(pt.get<std::string>("uri"));
+}
+
+std::string AkHttpsRepoSource::fetchRole(const Uptane::Role& role, int64_t maxsize, Uptane::Version version) {
+  std::string reply;
+  meta_fetcher_->fetchRole(&reply, maxsize, Uptane::RepositoryType::Image(), role, version);
+  return reply;
+}
+
+std::string AkHttpsRepoSource::fetchRoot(int version) {
+  return fetchRole(Uptane::Role::Root(), Uptane::kMaxRootSize, Uptane::Version(version));
+}
+
+std::string AkHttpsRepoSource::fetchTimestamp() {
+  return fetchRole(Uptane::Role::Timestamp(), Uptane::kMaxTimestampSize, Uptane::Version());
+}
+
+std::string AkHttpsRepoSource::fetchSnapshot() {
+  return fetchRole(Uptane::Role::Snapshot(), Uptane::kMaxSnapshotSize, Uptane::Version());
+}
+
+std::string AkHttpsRepoSource::fetchTargets() {
+  return fetchRole(Uptane::Role::Targets(), Uptane::kMaxImageTargetsSize, Uptane::Version());
+}
+
+}  // namespace aklite::tuf

--- a/src/tuf/akhttpsreposource.h
+++ b/src/tuf/akhttpsreposource.h
@@ -16,7 +16,7 @@ class AkHttpsRepoSource : public RepoSource {
   std::string fetchTargets() override;
 
  private:
-  void init(const std::string& name_in, boost::property_tree::ptree& pt);
+  void init(const std::string& name_in, boost::property_tree::ptree& pt, Config& config);
   static void fillConfig(Config& config, boost::property_tree::ptree& pt);
   std::string fetchRole(const Uptane::Role& role, int64_t maxsize, Uptane::Version version);
 

--- a/src/tuf/akhttpsreposource.h
+++ b/src/tuf/akhttpsreposource.h
@@ -1,0 +1,27 @@
+#include "uptane/fetcher.h"
+
+#include "aktualizr-lite/tuf/tuf.h"
+
+namespace aklite::tuf {
+
+// TufRepoSource implementation for fetching remote meta-data via https using libaktualizr
+class AkHttpsRepoSource : public RepoSource {
+ public:
+  AkHttpsRepoSource(const std::string& name_in, boost::property_tree::ptree& pt);
+  AkHttpsRepoSource(const std::string& name_in, boost::property_tree::ptree& pt, Config& config);
+
+  std::string fetchRoot(int version) override;
+  std::string fetchTimestamp() override;
+  std::string fetchSnapshot() override;
+  std::string fetchTargets() override;
+
+ private:
+  void init(const std::string& name_in, boost::property_tree::ptree& pt);
+  static void fillConfig(Config& config, boost::property_tree::ptree& pt);
+  std::string fetchRole(const Uptane::Role& role, int64_t maxsize, Uptane::Version version);
+
+  std::string name_;
+  std::shared_ptr<Uptane::IMetadataFetcher> meta_fetcher_;
+};
+
+}  // namespace aklite::tuf

--- a/src/tuf/akrepo.cc
+++ b/src/tuf/akrepo.cc
@@ -62,4 +62,6 @@ void AkRepo::FetcherWrapper::fetchLatestRole(std::string* result, int64_t maxsiz
   fetchRole(result, maxsize, repo, role, Uptane::Version());
 }
 
+void AkRepo::checkMeta() { image_repo_.checkMetaOffline(*storage_); }
+
 }  // namespace aklite::tuf

--- a/src/tuf/akrepo.cc
+++ b/src/tuf/akrepo.cc
@@ -1,0 +1,65 @@
+#include "akrepo.h"
+#include "target.h"
+
+namespace aklite::tuf {
+
+// AkRepo
+AkRepo::AkRepo(const boost::filesystem::path& storage_path) { init(storage_path); }
+
+AkRepo::AkRepo(const Config& config) {
+  storage_ = INvStorage::newStorage(config.storage, false, StorageClient::kTUF);
+  storage_->importData(config.import);
+}
+
+std::vector<TufTarget> AkRepo::GetTargets() {
+  std::shared_ptr<const Uptane::Targets> targets{image_repo_.getTargets()};
+  if (targets) {
+    auto ret = std::vector<TufTarget>();
+    for (const auto& up_target : image_repo_.getTargets()->targets) {
+      ret.emplace_back(Target::toTufTarget(up_target));
+    }
+    return ret;
+  } else {
+    return std::vector<TufTarget>();
+  }
+}
+
+void AkRepo::updateMeta(std::shared_ptr<RepoSource> repo_src) {
+  FetcherWrapper wrapper(repo_src);
+  image_repo_.updateMeta(*storage_, wrapper);
+}
+
+void AkRepo::init(const boost::filesystem::path& storage_path) {
+  StorageConfig sc;
+  sc.path = storage_path;
+  storage_ = INvStorage::newStorage(sc, false, StorageClient::kTUF);
+}
+
+// FetcherWrapper
+AkRepo::FetcherWrapper::FetcherWrapper(std::shared_ptr<RepoSource> src) { repo_src = std::move(src); }
+
+void AkRepo::FetcherWrapper::fetchRole(std::string* result, int64_t maxsize, Uptane::RepositoryType repo,
+                                       const Uptane::Role& role, Uptane::Version version) const {
+  (void)maxsize;
+  (void)repo;
+  std::string json;
+  if (role == Uptane::Role::Root()) {
+    json = repo_src->fetchRoot(version.version());
+  } else if (role == Uptane::Role::Timestamp()) {
+    json = repo_src->fetchTimestamp();
+  } else if (role == Uptane::Role::Snapshot()) {
+    json = repo_src->fetchSnapshot();
+  } else if (role == Uptane::Role::Targets()) {
+    json = repo_src->fetchTargets();
+  } else {
+    throw std::runtime_error("Invalid TUF Role " + role.ToString());
+  }
+  *result = json;
+}
+
+void AkRepo::FetcherWrapper::fetchLatestRole(std::string* result, int64_t maxsize, Uptane::RepositoryType repo,
+                                             const Uptane::Role& role) const {
+  fetchRole(result, maxsize, repo, role, Uptane::Version());
+}
+
+}  // namespace aklite::tuf

--- a/src/tuf/akrepo.h
+++ b/src/tuf/akrepo.h
@@ -15,6 +15,7 @@ class AkRepo : public Repo {
   explicit AkRepo(const Config& config);
   std::vector<TufTarget> GetTargets() override;
   void updateMeta(std::shared_ptr<RepoSource> repo_src) override;
+  void checkMeta() override;
 
  private:
   void init(const boost::filesystem::path& storage_path);

--- a/src/tuf/akrepo.h
+++ b/src/tuf/akrepo.h
@@ -1,0 +1,41 @@
+#include "libaktualizr/config.h"
+#include "storage/invstorage.h"
+#include "uptane/fetcher.h"
+#include "uptane/imagerepository.h"
+
+#include "aktualizr-lite/tuf/tuf.h"
+#include "target.h"
+
+namespace aklite::tuf {
+
+// Repo implementation that uses libaktualizr to provide TUF metadata handling and storage
+class AkRepo : public Repo {
+ public:
+  explicit AkRepo(const boost::filesystem::path& storage_path);
+  explicit AkRepo(const Config& config);
+  std::vector<TufTarget> GetTargets() override;
+  void updateMeta(std::shared_ptr<RepoSource> repo_src) override;
+
+ private:
+  void init(const boost::filesystem::path& storage_path);
+
+  Uptane::ImageRepository image_repo_;
+  std::shared_ptr<INvStorage> storage_;
+
+  // Wrapper around any TufRepoSource implementation to make it usable directly by libaktualizr,
+  // by implementing Uptane::IMetadataFetcher interface
+  class FetcherWrapper : public Uptane::IMetadataFetcher {
+   public:
+    explicit FetcherWrapper(std::shared_ptr<RepoSource> src);
+    void fetchRole(std::string* result, int64_t maxsize, Uptane::RepositoryType repo, const Uptane::Role& role,
+                   Uptane::Version version) const override;
+
+    void fetchLatestRole(std::string* result, int64_t maxsize, Uptane::RepositoryType repo,
+                         const Uptane::Role& role) const override;
+
+   private:
+    std::shared_ptr<RepoSource> repo_src;
+  };
+};
+
+}  // namespace aklite::tuf

--- a/src/tuf/localreposource.cc
+++ b/src/tuf/localreposource.cc
@@ -1,0 +1,32 @@
+#include <boost/filesystem.hpp>
+
+#include "utilities/utils.h"
+
+#include "localreposource.h"
+
+namespace aklite::tuf {
+
+LocalRepoSource::LocalRepoSource(const std::string &name_in, const std::string &local_path) {
+  name = name_in;
+  src_dir_ = boost::filesystem::path(local_path);
+}
+
+std::string LocalRepoSource::fetchFile(const boost::filesystem::path &meta_file_path) {
+  if (!boost::filesystem::exists(meta_file_path)) {
+    throw NotFoundException(meta_file_path.string());
+  }
+
+  return Utils::readFile(meta_file_path);
+}
+
+std::string LocalRepoSource::fetchRoot(int version) {
+  return fetchFile(src_dir_ / (std::to_string(version) + ".root.json"));
+}
+
+std::string LocalRepoSource::fetchTimestamp() { return fetchFile(src_dir_ / "timestamp.json"); }
+
+std::string LocalRepoSource::fetchSnapshot() { return fetchFile(src_dir_ / "snapshot.json"); }
+
+std::string LocalRepoSource::fetchTargets() { return fetchFile(src_dir_ / "targets.json"); }
+
+}  // namespace aklite::tuf

--- a/src/tuf/localreposource.h
+++ b/src/tuf/localreposource.h
@@ -1,0 +1,30 @@
+#include "boost/filesystem.hpp"
+
+#include "aktualizr-lite/tuf/tuf.h"
+
+namespace aklite::tuf {
+
+// TufRepoSource implementation for fetching local meta-dat
+class LocalRepoSource : public RepoSource {
+ public:
+  class NotFoundException : public std::runtime_error {
+   public:
+    explicit NotFoundException(const std::string &path)
+        : std::runtime_error("Metadata hasn't been found; file path: " + path) {}
+  };
+
+  LocalRepoSource(const std::string &name_in, const std::string &local_path);
+
+  std::string fetchRoot(int version) override;
+  std::string fetchTimestamp() override;
+  std::string fetchSnapshot() override;
+  std::string fetchTargets() override;
+
+ private:
+  static std::string fetchFile(const boost::filesystem::path &meta_file_path);
+
+  std::string name;
+  boost::filesystem::path src_dir_;
+};
+
+}  // namespace aklite::tuf


### PR DESCRIPTION
The API allows a better isolation between aktualizr-lite and libaktualizr, and also allows the use of multiple sources for a same TUF repository.

Changes were originally submitted in #279