### PR TITLE
offline: Don't require docker restart if just app update

### DIFF
--- a/apps/aklite-offline/cmds.cpp
+++ b/apps/aklite-offline/cmds.cpp
@@ -37,6 +37,11 @@ int InstallCmd::installUpdate(const Config& cfg_in, const boost::filesystem::pat
         cfg_in, {src_dir / "tuf", src_dir / "ostree_repo", src_dir / "apps"}, nullptr, force_downgrade);
 
     switch (install_res) {
+      case offline::PostInstallAction::Ok: {
+        std::cout << "Please run `aklite-offline run` command to start the updated Apps\n";
+        ret_code = 10;
+        break;
+      }
       case offline::PostInstallAction::NeedRebootForBootFw: {
         ret_code = 90;
         std::cout
@@ -52,12 +57,6 @@ int InstallCmd::installUpdate(const Config& cfg_in, const boost::filesystem::pat
         std::cout
             << "Please reboot a device and execute `aklite-offline run` command "
                "to apply installation and start the updated Apps (unless no Apps to update or dockerless system)\n";
-        break;
-      }
-      case offline::PostInstallAction::NeedDockerRestart: {
-        std::cout << "Please restart `docker` service `systemctl restart docker` and execute `aklite-offline run` "
-                     "command to start the updated Apps\n";
-        ret_code = 101;
         break;
       }
       case offline::PostInstallAction::AlreadyInstalled: {

--- a/src/offline/client.h
+++ b/src/offline/client.h
@@ -22,9 +22,9 @@ struct UpdateSrc {
 
 enum class PostInstallAction {
   Undefined = -1,
+  Ok,
   NeedReboot,
   NeedRebootForBootFw,
-  NeedDockerRestart,
   AlreadyInstalled,
   DowngradeAttempt
 };

--- a/tests/aklite_offline_test.cc
+++ b/tests/aklite_offline_test.cc
@@ -202,8 +202,7 @@ class AkliteOffline : public ::testing::Test {
     for (const auto& app : apps_not_to_preload) {
       boost::filesystem::remove_all(app_store_.appsDir() / app);
     }
-    ASSERT_EQ(install(), offline::PostInstallAction::NeedDockerRestart);
-    reloadDockerEngine();
+    ASSERT_EQ(install(), offline::PostInstallAction::Ok);
     ASSERT_EQ(run(), offline::PostRunAction::Ok);
 
     if (add_installed_versions) {
@@ -360,8 +359,7 @@ TEST_F(AkliteOffline, OfflineClientAppsOnly) {
   const auto target{addTarget({createApp("app-01")}, true)};
   ASSERT_EQ(1, check().size());
   ASSERT_TRUE(target.MatchTarget(check().front()));
-  ASSERT_EQ(install(), offline::PostInstallAction::NeedDockerRestart);
-  reloadDockerEngine();
+  ASSERT_EQ(install(), offline::PostInstallAction::Ok);
   ASSERT_EQ(run(), offline::PostRunAction::Ok);
   ASSERT_TRUE(target.MatchTarget(getCurrent()));
 }


### PR DESCRIPTION
The recent [patch](https://github.com/foundriesio/meta-lmp/blob/main/meta-lmp-base/recipes-containers/docker/files/0001-tarexport-optimize-image-loading-on-local-host.patch) to the docker engine makes its restart redundant since app images are correctly registered at the end of the image loading process. 