### PR TITLE
offline: Require all enabled apps for offline update

### DIFF
--- a/src/composeappmanager.h
+++ b/src/composeappmanager.h
@@ -61,6 +61,7 @@ class ComposeAppManager : public RootfsTreeManager {
   void handleRemovedApps(const Uptane::Target& target) const;
   Json::Value getAppsState() const;
   static bool compareAppsStates(const Json::Value& left, const Json::Value& right);
+  static AppsContainer getRequiredApps(const Config& cfg, const Uptane::Target& target);
 
  private:
   void completeInitialTarget(Uptane::Target& init_target) override;


### PR DESCRIPTION
It is unsafe to employ "content-based" shortlisting due to the potential risk of installing unwanted targets or unintentionally removing necessary apps.

The proposed alternative mandates that all enabled/configured apps listed in the target must be present in the update source bundle, specifically the intersection of pacman.compose_app and target.apps. This ensures that a device is updated with the anticipated ostree and apps as defined by the target JSON and device configuration.

It's worth noting that there might be scenarios where multiple targets share the same ostree and the app intersection. This is not problematic as the update content remains consistent across these targets. The only drawback is that the offline updater might display an unexpected target name in the logs, potentially deviating from the user's expectations. However, it's crucial to emphasize that the update content, including ostree version and app list with their respective versions, precisely aligns with the user's intended installation.