### PR TITLE
cmake: Add BUILD_P11 option to aklite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ option(BUILD_AKLITE_OFFLINE "Set to ON to build cli command for an offline updat
 option(BUILD_AKLITE_WITH_NERDCTL "Set to ON to build with support of nerdctl/containerd" OFF)
 option(BUILD_AKLITE_APPS "Set to ON to build cli command for Apps management" ON)
 option(BUILD_TUFCTL "Set to ON to build sample tuf control application" OFF)
+option(BUILD_P11 "Support for key storage in a HSM via PKCS#11" ON)
 
 # If we build the sota tools we don't need aklite (???) and vice versa
 # if we build aklite we don't need the sota tools
@@ -76,3 +77,4 @@ message(STATUS "BUILD_AKLITE_OFFLINE: ${BUILD_AKLITE_OFFLINE}")
 message(STATUS "BUILD_AKLITE_WITH_NERDCTL: ${BUILD_AKLITE_WITH_NERDCTL}")
 message(STATUS "BUILD_AKLITE_APPS: ${BUILD_AKLITE_APPS}")
 message(STATUS "BUILD_TUFCTL: ${BUILD_TUFCTL}")
+message(STATUS "BUILD_P11: ${BUILD_P11}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,6 +63,10 @@ if(ALLOW_MANUAL_ROLLBACK)
   add_definitions(-DALLOW_MANUAL_ROLLBACK)
 endif(ALLOW_MANUAL_ROLLBACK)
 
+if(BUILD_P11)
+  add_definitions(-DBUILD_P11)
+endif(BUILD_P11)
+
 target_compile_definitions(${TARGET_EXE} PRIVATE BOOST_LOG_DYN_LINK)
 
 set(INCS


### PR DESCRIPTION
The lack of this option, and corresponding logic in the new TUF API code, was leading to a linking error when P11 was not enabled in aktualizr build.