### PR TITLE
api: Add offline target installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ if(BUILD_AKLITE)
   add_dependencies(aklite aktualizr-lite)
 
   add_custom_target(aklite-tests)
-  add_dependencies(aklite-tests aklite t_lite-helpers uptane-generator t_compose-apps t_ostree t_liteclient t_yaml2json t_composeappengine t_restorableappengine t_aklite t_aklite_rollback t_aklite_rollback_ext t_apiclient t_exec t_docker t_aklite_offline t_boot_flag_mgmt t_cli t_nospace)
+  add_dependencies(aklite-tests aklite t_lite-helpers uptane-generator t_compose-apps t_ostree t_liteclient t_yaml2json t_composeappengine t_restorableappengine t_aklite t_aklite_rollback t_aklite_rollback_ext t_apiclient t_exec t_docker t_aklite_offline  t_aklite_offline_api t_boot_flag_mgmt t_cli t_nospace)
 
   set(CMAKE_MODULE_PATH "${AKTUALIZR_DIR}/cmake-modules;${CMAKE_MODULE_PATH}")
 

--- a/examples/custom-client-cxx/main.cc
+++ b/examples/custom-client-cxx/main.cc
@@ -83,8 +83,8 @@ int main(int argc, char **argv) {
 
     try {
       CheckInResult res = local_update_path.empty()?
-        client->CheckIn() :
-        client->CheckInLocal(local_update_path);
+                           client->CheckIn():
+                           client->CheckInLocal(local_update_path + "/tuf", local_update_path + "/ostree_repo", local_update_path + "/apps");
       if (res.status != CheckInResult::Status::Ok && res.status != CheckInResult::Status::OkCached) {
         LOG_WARNING << "Unable to update latest metadata, going to sleep for " << interval
                     << " seconds before starting a new update cycle";

--- a/examples/custom-client-cxx/main.cc
+++ b/examples/custom-client-cxx/main.cc
@@ -41,6 +41,7 @@ static std::string get_reboot_cmd(const AkliteClient &client) {
 
 int main(int argc, char **argv) {
   boost::log::core::get()->set_filter(boost::log::trivial::severity >= boost::log::trivial::info);
+  std::string local_update_path;
 
   std::vector<boost::filesystem::path> cfg_dirs;
   auto env{boost::this_process::environment()};
@@ -48,6 +49,13 @@ int main(int argc, char **argv) {
     cfg_dirs.emplace_back(env.get("AKLITE_CONFIG_DIR"));
   } else {
     cfg_dirs = AkliteClient::CONFIG_DIRS;
+  }
+
+  if (env.end() != env.find("AKLITE_LOCAL_UPDATE_PATH")) {
+    local_update_path = env.get("AKLITE_LOCAL_UPDATE_PATH");
+    LOG_INFO << "Offline mode. Updates path=" << local_update_path;
+  } else {
+    LOG_INFO << "Online mode";
   }
 
   std::unique_ptr<AkliteClient> client;
@@ -74,7 +82,9 @@ int main(int argc, char **argv) {
     LOG_INFO << "Checking for a new Target...";
 
     try {
-      auto res = client->CheckIn();
+      CheckInResult res = local_update_path.empty()?
+        client->CheckIn() :
+        client->CheckInLocal(local_update_path);
       if (res.status != CheckInResult::Status::Ok && res.status != CheckInResult::Status::OkCached) {
         LOG_WARNING << "Unable to update latest metadata, going to sleep for " << interval
                     << " seconds before starting a new update cycle";
@@ -105,7 +115,7 @@ int main(int argc, char **argv) {
 
       if (latest.Name() != current.Name() && !client->IsRollback(latest)) {
         std::string reason = "Updating from " + current.Name() + " to " + latest.Name();
-        auto installer = client->Installer(latest, reason);
+        auto installer = client->Installer(latest, reason, "", InstallMode::All, local_update_path);
         if (!installer) {
           LOG_ERROR << "Found latest Target but failed to retrieve its metadata from DB, skipping update";
           std::this_thread::sleep_for(std::chrono::seconds(interval));
@@ -131,7 +141,7 @@ int main(int argc, char **argv) {
           LOG_ERROR << "Unable to install target: " << ires;
         }
       } else {
-        auto installer = client->CheckAppsInSync();
+        auto installer = client->CheckAppsInSync(local_update_path);
         if (installer != nullptr) {
           LOG_INFO << "Syncing Active Target Apps";
           auto dres = installer->Download();

--- a/examples/custom-client-cxx/main.cc
+++ b/examples/custom-client-cxx/main.cc
@@ -148,8 +148,8 @@ int main(int argc, char **argv) {
         } else {
           LOG_ERROR << "Unable to install target: " << ires;
         }
-      } else {
-        auto installer = client->CheckAppsInSync(&local_update_source);
+      } else if (!is_local_update || client->IsRollback(latest)) {
+        auto installer = client->CheckAppsInSync();
         if (installer != nullptr) {
           LOG_INFO << "Syncing Active Target Apps";
           auto dres = installer->Download();
@@ -162,6 +162,8 @@ int main(int argc, char **argv) {
             }
           }
         }
+      } else {
+        LOG_INFO << "Device is up-to-date";
       }
     } catch (const std::exception &exc) {
       LOG_ERROR << "Failed to find or update Target: " << exc.what();

--- a/examples/custom-client-cxx/main.cc
+++ b/examples/custom-client-cxx/main.cc
@@ -92,7 +92,7 @@ int main(int argc, char **argv) {
     try {
       CheckInResult res = !is_local_update?
                            client->CheckIn():
-                           client->CheckInLocal(local_update_source.tuf_repo, local_update_source.ostree_repo, local_update_source.app_store);
+                           client->CheckInLocal(&local_update_source);
       if (res.status != CheckInResult::Status::Ok && res.status != CheckInResult::Status::OkCached) {
         LOG_WARNING << "Unable to update latest metadata, going to sleep for " << interval
                     << " seconds before starting a new update cycle";

--- a/include/aktualizr-lite/api.h
+++ b/include/aktualizr-lite/api.h
@@ -234,7 +234,7 @@ class AkliteClient {
    * an InstallContext is returned that may be called to synchronize the
    * apps.
    */
-  std::unique_ptr<InstallContext> CheckAppsInSync(const LocalUpdateSource *local_update_source = nullptr) const;
+  std::unique_ptr<InstallContext> CheckAppsInSync() const;
 
   /**
    * Performs a "check-in" with the device-gateway. A check-in consists of:

--- a/include/aktualizr-lite/api.h
+++ b/include/aktualizr-lite/api.h
@@ -226,7 +226,7 @@ class AkliteClient {
    * an InstallContext is returned that may be called to synchronize the
    * apps.
    */
-  std::unique_ptr<InstallContext> CheckAppsInSync() const;
+  std::unique_ptr<InstallContext> CheckAppsInSync(std::string src_path = "") const;
 
   /**
    * Performs a "check-in" with the device-gateway. A check-in consists of:
@@ -247,8 +247,11 @@ class AkliteClient {
    *  2) read timestamp and snapshot metadata.
    *  3) read a new targets.json if needed
    *
-   * This is an EXPERIMENTAL implementation. If there is Target data to be updated
-   * later on, it will still be fetched from the remote servers (ostree, app registry).
+   * If there is Target data to be updated, it may be later on either fetched from
+   * the remote servers (ostree, app registry) or copied from a local directory,
+   * depending on which Installer is instantiated (LiteInstall or LocalLiteInstall).
+   *
+   * This is an EXPERIMENTAL implementation.
    */
   CheckInResult CheckInLocal(const std::string &path) const;
 
@@ -284,7 +287,8 @@ class AkliteClient {
    * Create an InstallContext object to help drive an update.
    */
   std::unique_ptr<InstallContext> Installer(const TufTarget &t, std::string reason = "",
-                                            std::string correlation_id = "", InstallMode = InstallMode::All) const;
+                                            std::string correlation_id = "", InstallMode = InstallMode::All,
+                                            std::string src_path = "") const;
 
   /**
    * @brief Complete a pending installation

--- a/include/aktualizr-lite/api.h
+++ b/include/aktualizr-lite/api.h
@@ -162,6 +162,14 @@ class DeviceResult {
   std::string repo_id;
 };
 
+struct LocalUpdateSource {
+  std::string tuf_repo;
+  std::string ostree_repo;
+  std::string app_store;
+  // needed for unit testing or if a custom container engine is used
+  void *docker_client_ptr;
+};
+
 /**
  * AkliteClient provides an easy-to-use API for users wanting to customize
  * the behavior of aktualizr-lite.
@@ -226,7 +234,7 @@ class AkliteClient {
    * an InstallContext is returned that may be called to synchronize the
    * apps.
    */
-  std::unique_ptr<InstallContext> CheckAppsInSync(std::string src_path = "") const;
+  std::unique_ptr<InstallContext> CheckAppsInSync(const LocalUpdateSource *local_update_source = nullptr) const;
 
   /**
    * Performs a "check-in" with the device-gateway. A check-in consists of:
@@ -289,7 +297,7 @@ class AkliteClient {
    */
   std::unique_ptr<InstallContext> Installer(const TufTarget &t, std::string reason = "",
                                             std::string correlation_id = "", InstallMode = InstallMode::All,
-                                            std::string src_path = "") const;
+                                            const LocalUpdateSource *local_update_source = nullptr) const;
 
   /**
    * @brief Complete a pending installation

--- a/include/aktualizr-lite/api.h
+++ b/include/aktualizr-lite/api.h
@@ -253,7 +253,8 @@ class AkliteClient {
    *
    * This is an EXPERIMENTAL implementation.
    */
-  CheckInResult CheckInLocal(const std::string &path) const;
+  CheckInResult CheckInLocal(const std::string &tuf_repo, const std::string &ostree_repo,
+                             const std::string &apps_dir = "") const;
 
   /**
    * Return the active aktualizr-lite configuration.

--- a/include/aktualizr-lite/api.h
+++ b/include/aktualizr-lite/api.h
@@ -261,8 +261,7 @@ class AkliteClient {
    *
    * This is an EXPERIMENTAL implementation.
    */
-  CheckInResult CheckInLocal(const std::string &tuf_repo, const std::string &ostree_repo,
-                             const std::string &apps_dir = "") const;
+  CheckInResult CheckInLocal(const LocalUpdateSource *local_update_source) const;
 
   /**
    * Return the active aktualizr-lite configuration.

--- a/src/api.cc
+++ b/src/api.cc
@@ -672,6 +672,13 @@ class LocalLiteInstall : public LiteInstall {
   }
 
   // TODO: implement `Install()` in such the way that `LiteClient` is not required as it is done for `Download()`
+  InstallResult Install() override {
+    const auto tls_server{client_->config.tls.server};
+    client_->config.tls.server = "";
+    auto ir{LiteInstall::Install()};
+    client_->config.tls.server = tls_server;
+    return ir;
+  }
 
  private:
   std::unique_ptr<Downloader> createOfflineDownloader() {

--- a/src/api.cc
+++ b/src/api.cc
@@ -2,6 +2,7 @@
 
 #include <sys/file.h>
 #include <unistd.h>
+#include <boost/process.hpp>
 #include <boost/property_tree/ini_parser.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
@@ -15,6 +16,8 @@
 
 #include "aktualizr-lite/tuf/tuf.h"
 #include "composeappmanager.h"
+#include "docker/restorableappengine.h"
+#include "ostree/repo.h"
 #include "tuf/akhttpsreposource.h"
 #include "tuf/akrepo.h"
 #include "tuf/localreposource.h"
@@ -210,9 +213,143 @@ CheckInResult AkliteClient::CheckIn() const {
   return UpdateMetaAndGetTargets(repo_src);
 }
 
+static bool compareTargets(const Uptane::Target& t1, const Uptane::Target& t2) {
+  return !(Target::Version(t1.custom_version()) < Target::Version(t2.custom_version()));
+}
+
+struct UpdateSrc {
+  boost::filesystem::path TufDir;
+  boost::filesystem::path OstreeRepoDir;
+  boost::filesystem::path AppsDir;
+  std::string TargetName;
+};
+
+static void parseUpdateContent(const boost::filesystem::path& apps_dir, std::set<std::string>& found_apps) {
+  if (!boost::filesystem::exists(apps_dir)) {
+    return;
+  }
+  for (auto const& app_dir_entry : boost::filesystem::directory_iterator{apps_dir}) {
+    const auto app_name{app_dir_entry.path().filename().string()};
+    for (auto const& app_ver_dir_entry : boost::filesystem::directory_iterator{app_dir_entry.path()}) {
+      const auto uri_file{app_ver_dir_entry.path() / "uri"};
+      const auto app_uri{Utils::readFile(uri_file.string())};
+      LOG_DEBUG << "Found app; uri: " << app_uri;
+      found_apps.insert(app_uri);
+    }
+  }
+}
+
+static std::vector<Uptane::Target> getAvailableTargets(const PackageConfig& pconfig,
+                                                       const std::vector<Uptane::Target>& allowed_targets,
+                                                       const UpdateSrc& src, bool just_latest = true) {
+  if (allowed_targets.empty()) {
+    LOG_ERROR << "No targets are available for a given device; check a hardware ID and/or a tag";
+    return std::vector<Uptane::Target>{};
+  }
+  std::vector<Uptane::Target> found_targets;
+  std::set<std::string> found_apps;
+
+  parseUpdateContent(src.AppsDir / "apps", found_apps);
+  LOG_INFO << "Apps found in the source directory " << src.AppsDir;
+  for (const auto& app : found_apps) {
+    LOG_INFO << "\t" << app;
+  }
+
+  const OSTree::Repo repo{src.OstreeRepoDir.string()};
+  Uptane::Target found_target(Uptane::Target::Unknown());
+
+  const std::string search_msg{just_latest ? "a target" : "all targets"};
+  LOG_INFO << "Searching for " << search_msg << " starting from " << allowed_targets.begin()->filename()
+           << " that match content provided in the source directory\n"
+           << "\tpacman type: \t" << pconfig.type << "\n\t apps dir: \t" << src.AppsDir << "\n\t ostree dir: \t"
+           << src.OstreeRepoDir;
+  for (const auto& t : allowed_targets) {
+    LOG_INFO << "Checking " << t.filename();
+    if (!repo.hasCommit(t.sha256Hash())) {
+      LOG_INFO << "\tmissing ostree commit: " << t.sha256Hash();
+      continue;
+    }
+    if (pconfig.type != ComposeAppManager::Name) {
+      found_targets.emplace_back(t);
+      LOG_INFO << "\tall target content have been found";
+      if (!just_latest) {
+        continue;
+      }
+      break;
+    }
+    const ComposeAppManager::AppsContainer required_apps{
+        ComposeAppManager::getRequiredApps(ComposeAppManager::Config(pconfig), t)};
+    std::set<std::string> missing_apps;
+    Json::Value apps_to_install;
+    for (const auto& app : required_apps) {
+      if (found_apps.count(app.second) == 0) {
+        missing_apps.insert(app.second);
+      } else {
+        apps_to_install[app.first]["uri"] = app.second;
+      }
+    }
+    if (!missing_apps.empty()) {
+      LOG_INFO << "\tmissing apps:";
+      for (const auto& app : missing_apps) {
+        LOG_INFO << "\t\t" << app;
+      }
+      continue;
+    }
+    Json::Value updated_custom{t.custom_data()};
+    updated_custom[Target::ComposeAppField] = apps_to_install;
+    found_targets.emplace_back(Target::updateCustom(t, updated_custom));
+    LOG_INFO << "\tall target content have been found";
+    if (just_latest) {
+      break;
+    }
+  }
+  return found_targets;
+}
+
+std::vector<Uptane::Target> fromTufTargets(const std::vector<TufTarget>& tufTargets) {
+  std::vector<Uptane::Target> ret;
+  ret.reserve(tufTargets.size());
+  for (auto const& t : tufTargets) {
+    ret.emplace_back(Target::fromTufTarget(t));
+  }
+  return ret;
+}
+
+std::vector<TufTarget> toTufTargets(const std::vector<Uptane::Target>& targets) {
+  std::vector<TufTarget> ret;
+  ret.reserve(targets.size());
+  for (auto const& t : targets) {
+    ret.emplace_back(Target::toTufTarget(t));
+  }
+  return ret;
+}
+
 CheckInResult AkliteClient::CheckInLocal(const std::string& path) const {
-  auto repo_src = std::make_shared<aklite::tuf::LocalRepoSource>("temp-local-repo-source", path);
-  return UpdateMetaAndGetTargets(repo_src);
+  auto repo_src = std::make_shared<aklite::tuf::LocalRepoSource>("temp-local-repo-source",
+                                                                 (boost::filesystem::path(path) / "tuf").c_str());
+  auto result = UpdateMetaAndGetTargets(repo_src);
+
+  UpdateSrc src{
+      .TufDir = boost::filesystem::path(path) / "tuf",
+      .OstreeRepoDir = boost::filesystem::path(path) / "ostree_repo",
+      .AppsDir = boost::filesystem::path(path) / "apps",
+  };
+
+  if (result.status == CheckInResult::Status::Failed) {
+    return result;
+  }
+
+  std::vector<Uptane::Target> available_targets =
+      getAvailableTargets(client_->config.pacman, fromTufTargets(result.Targets()), src, true);
+  if (available_targets.empty()) {
+    LOG_INFO << "Unable to locate complete target in " << path;
+    result.status = CheckInResult::Status::Failed;
+  } else {
+    LOG_INFO << "Selected target: " << available_targets.front().filename();
+    result = CheckInResult(result.status, client_->config.provision.primary_ecu_hardware_id,
+                           toTufTargets(available_targets));
+  }
+  return result;
 }
 
 boost::property_tree::ptree AkliteClient::GetConfig() const {
@@ -331,18 +468,259 @@ class LiteInstall : public InstallContext {
     client_->report_queue->enqueue(std::move(e));
   }
 
- private:
+ protected:
   std::shared_ptr<LiteClient> client_;
   std::unique_ptr<Uptane::Target> target_;
   std::string reason_;
   InstallMode mode_;
 };
 
+class BaseHttpClient : public HttpInterface {
+ public:
+  HttpResponse post(const std::string& url, const std::string& content_type, const std::string& data) override {
+    (void)url;
+    (void)content_type;
+    (void)data;
+    return HttpResponse("", 501, CURLE_OK, "");
+  }
+  HttpResponse post(const std::string& url, const Json::Value& data) override {
+    (void)url;
+    (void)data;
+    return HttpResponse("", 501, CURLE_OK, "");
+  }
+  HttpResponse put(const std::string& url, const std::string& content_type, const std::string& data) override {
+    (void)url;
+    (void)content_type;
+    (void)data;
+    return HttpResponse("", 501, CURLE_OK, "");
+  }
+  HttpResponse put(const std::string& url, const Json::Value& data) override {
+    (void)url;
+    (void)data;
+    return HttpResponse("", 501, CURLE_OK, "");
+  }
+  HttpResponse download(const std::string& url, curl_write_callback write_cb, curl_xferinfo_callback progress_cb,
+                        void* userp, curl_off_t from) override {
+    (void)url;
+    (void)write_cb;
+    (void)progress_cb;
+    (void)userp;
+    (void)from;
+    return HttpResponse("", 501, CURLE_OK, "");
+  }
+  std::future<HttpResponse> downloadAsync(const std::string& url, curl_write_callback write_cb,
+                                          curl_xferinfo_callback progress_cb, void* userp, curl_off_t from,
+                                          CurlHandler* easyp) override {
+    (void)url;
+    (void)write_cb;
+    (void)progress_cb;
+    (void)userp;
+    (void)from;
+    (void)easyp;
+    std::promise<HttpResponse> resp_promise;
+    resp_promise.set_value(HttpResponse("", 501, CURLE_OK, ""));
+    return resp_promise.get_future();
+  }
+  void setCerts(const std::string& ca, CryptoSource ca_source, const std::string& cert, CryptoSource cert_source,
+                const std::string& pkey, CryptoSource pkey_source) override {
+    (void)ca;
+    (void)ca_source;
+    (void)cert;
+    (void)cert_source;
+    (void)pkey;
+    (void)pkey_source;
+  }
+};
+
+class RegistryBasicAuthClient : public BaseHttpClient {
+ public:
+  HttpResponse get(const std::string& url, int64_t maxsize) override {
+    (void)url;
+    (void)maxsize;
+    return HttpResponse(R"({"Secret":"secret","Username":"test-user"})", 200, CURLE_OK, "");
+  }
+};
+
+class OfflineRegistry : public BaseHttpClient {
+ public:
+  explicit OfflineRegistry(boost::filesystem::path root_dir, std::string hostname = "hub.foundries.io")
+      : hostname_{std::move(hostname)}, root_dir_{std::move(root_dir)} {}
+
+  HttpResponse get(const std::string& url, int64_t maxsize) override {
+    (void)maxsize;
+    if (boost::starts_with(url, auth_endpoint_)) {
+      return HttpResponse(R"({"token":"token"})", 200, CURLE_OK, "");
+    }
+    return getAppItem(url);
+  }
+
+  HttpResponse download(const std::string& url, curl_write_callback write_cb, curl_xferinfo_callback progress_cb,
+                        void* userp, curl_off_t from) override {
+    (void)progress_cb;
+    (void)from;
+    const std::string hash_prefix{"sha256:"};
+    const auto digest_pos{url.rfind(hash_prefix)};
+    if (digest_pos == std::string::npos) {
+      return HttpResponse("Invalid URL", 400, CURLE_OK, "");
+    }
+    const auto hash_pos{digest_pos + hash_prefix.size()};
+    const auto hash{url.substr(hash_pos)};
+    const auto blob_path{(blobs_dir_ / hash).string()};
+
+    if (!boost::filesystem::exists(blob_path)) {
+      return HttpResponse("The app blob is missing: " + blob_path, 404, CURLE_OK, "Not found");
+    }
+
+    std::array<char, 1024 * 4> buf = {};
+    std::ifstream blob_file{blob_path};
+
+    std::streamsize read_byte_numb;
+    while (blob_file.good()) {
+      blob_file.read(buf.data(), sizeof(buf));
+      write_cb(buf.data(), blob_file.gcount(), 1, userp);
+    }
+    if (!blob_file.eof()) {
+      HttpResponse("Failed to read app blob data: " + blob_path, 500, CURLE_OK, "Internal Error");
+    }
+    return HttpResponse("", 200, CURLE_OK, "");
+  }
+
+  HttpResponse getAppItem(const std::string& url) const {
+    const std::string hash_prefix{"sha256:"};
+    const auto digest_pos{url.rfind(hash_prefix)};
+    if (digest_pos == std::string::npos) {
+      return HttpResponse("Invalid URL", 400, CURLE_OK, "");
+    }
+    const auto hash_pos{digest_pos + hash_prefix.size()};
+    const auto hash{url.substr(hash_pos)};
+    const auto blob_path{blobs_dir_ / hash};
+    if (!boost::filesystem::exists(blob_path)) {
+      return HttpResponse("The app blob is missing: " + blob_path.string(), 404, CURLE_OK, "Not found");
+    }
+    return HttpResponse(Utils::readFile(blobs_dir_ / hash), 200, CURLE_OK, "");
+  }
+
+  boost::filesystem::path blobsDir() const { return root_dir_ / "blobs"; }
+  const boost::filesystem::path& appsDir() const { return apps_dir_; }
+  const boost::filesystem::path& dir() const { return root_dir_; }
+
+ private:
+  const boost::filesystem::path root_dir_;
+  const std::string hostname_;
+  const std::string auth_endpoint_{"https://" + hostname_ + "/token-auth"};
+  const boost::filesystem::path apps_dir_{root_dir_ / "apps"};
+  const boost::filesystem::path blobs_dir_{root_dir_ / "blobs" / "sha256"};
+};
+
+class LocalLiteInstall : public LiteInstall {
+ public:
+  LocalLiteInstall(std::shared_ptr<LiteClient> client, std::unique_ptr<Uptane::Target> t, std::string& reason,
+                   std::string& local_path, InstallMode install_mode = InstallMode::All)
+      : LiteInstall(std::move(client), std::move(t), reason, install_mode) {
+    src_path_ = local_path;
+  }
+
+  std::unique_ptr<ComposeAppManager> createOfflineComposeAppManager(
+      const Config& cfg_in, const UpdateSrc& src, const std::shared_ptr<HttpInterface>& docker_client_http_client) {
+    Config cfg{cfg_in};  // make copy of the input config to avoid its modification by LiteClient
+
+    // turn off reporting update events to DG
+    cfg.tls.server = "";
+    // make LiteClient to pull from a local ostree repo
+    cfg.pacman.ostree_server = "file://" + src.OstreeRepoDir.string();
+
+    // Always use the compose app manager since it covers both use-cases, just ostree and ostree+apps.
+    cfg.pacman.type = ComposeAppManager::Name;
+
+    // Handle DG:/token-auth
+    std::shared_ptr<HttpInterface> registry_basic_auth_client{std::make_shared<RegistryBasicAuthClient>()};
+
+    std::shared_ptr<OfflineRegistry> offline_registry{std::make_shared<OfflineRegistry>(src.AppsDir)};
+    // Handle requests to Registry aimed to download App
+    Docker::RegistryClient::Ptr registry_client{std::make_shared<Docker::RegistryClient>(
+        registry_basic_auth_client, "",
+        [offline_registry](const std::vector<std::string>* v, const std::set<std::string>* s) {
+          (void)v;
+          (void)s;
+          return offline_registry;
+        })};
+
+    ComposeAppManager::Config pacman_cfg(cfg.pacman);
+    std::string compose_cmd{pacman_cfg.compose_bin.string()};
+    if (boost::filesystem::exists(pacman_cfg.compose_bin) && pacman_cfg.compose_bin.filename().compare("docker") == 0) {
+      compose_cmd = boost::filesystem::canonical(pacman_cfg.compose_bin).string() + " ";
+      // if it is a `docker` binary then turn it into ` the  `docker compose` command
+      // and make sure that the `compose` is actually supported by a given `docker` utility.
+      compose_cmd += "compose ";
+    }
+
+    std::string docker_host{"unix:///var/run/docker.sock"};
+    auto env{boost::this_process::environment()};
+    if (env.end() != env.find("DOCKER_HOST")) {
+      docker_host = env.get("DOCKER_HOST");
+    }
+
+    AppEngine::Ptr app_engine{std::make_shared<Docker::RestorableAppEngine>(
+        pacman_cfg.reset_apps_root, pacman_cfg.apps_root, pacman_cfg.images_data_root, registry_client,
+        docker_client_http_client ? std::make_shared<Docker::DockerClient>(docker_client_http_client)
+                                  : std::make_shared<Docker::DockerClient>(),
+        pacman_cfg.skopeo_bin.string(), docker_host, compose_cmd, Docker::RestorableAppEngine::GetDefStorageSpaceFunc(),
+        [offline_registry](const Docker::Uri& app_uri, const std::string& image_uri) {
+          Docker::Uri uri{Docker::Uri::parseUri(image_uri, false)};
+          return "--src-shared-blob-dir " + offline_registry->blobsDir().string() +
+                 " oci:" + offline_registry->appsDir().string() + "/" + app_uri.app + "/" + app_uri.digest.hash() +
+                 "/images/" + uri.registryHostname + "/" + uri.repo + "/" + uri.digest.hash();
+        },
+        false, /* don't create containers on install because it makes dockerd check if pinned images
+      present in its store what we should avoid until images are registered (hacked) in dockerd store */
+        true   /* indicate that this is an offline client */
+        )};
+
+    auto ostree_sysroot = std::make_shared<OSTree::Sysroot>(client_->config.pacman);
+    auto storage = INvStorage::newStorage(client_->config.storage, false, StorageClient::kTUF);
+
+    auto key_manager = std_::make_unique<KeyManager>(storage, client_->config.keymanagerConfig(), nullptr);
+    std::shared_ptr<RootfsTreeManager> basepacman = std::make_shared<ComposeAppManager>(
+        client_->config.pacman, client_->config.bootloader, storage, nullptr, ostree_sysroot, *key_manager, app_engine);
+
+    return std::make_unique<ComposeAppManager>(cfg.pacman, client_->config.bootloader, storage, nullptr,
+                                               ostree_sysroot, *key_manager, app_engine);
+  }
+
+  DownloadResult Download() override {
+    auto reason = reason_;
+    if (reason.empty()) {
+      reason = "Update to " + target_->filename();
+    }
+
+    client_->logTarget("Downloading: ", *target_);
+
+    auto updateSrc = UpdateSrc();
+    updateSrc.AppsDir = boost::filesystem::path(src_path_) / "apps";
+    updateSrc.OstreeRepoDir = boost::filesystem::path(src_path_) / "ostree_repo";
+
+    auto cap = createOfflineComposeAppManager(client_->config, updateSrc, nullptr);
+    auto download_res{cap->Download(Target::toTufTarget(*target_))};
+    if (!download_res) {
+      return DownloadResult{download_res.status, download_res.description, download_res.destination_path};
+    }
+
+    if (client_->VerifyTarget(*target_) != TargetStatus::kGood) {
+      return DownloadResult{DownloadResult::Status::VerificationFailed, "Downloaded target is invalid"};
+    }
+
+    return DownloadResult{DownloadResult::Status::Ok, ""};
+  }
+
+ private:
+  std::string src_path_;
+};
+
 bool AkliteClient::IsInstallationInProgress() const { return client_->getPendingTarget().IsValid(); }
 
 TufTarget AkliteClient::GetPendingTarget() const { return Target::toTufTarget(client_->getPendingTarget()); }
 
-std::unique_ptr<InstallContext> AkliteClient::CheckAppsInSync() const {
+std::unique_ptr<InstallContext> AkliteClient::CheckAppsInSync(std::string src_path) const {
   std::unique_ptr<InstallContext> installer = nullptr;
   auto target = std::make_unique<Uptane::Target>(client_->getCurrent());
   if (!client_->appsInSync(*target)) {
@@ -350,14 +728,19 @@ std::unique_ptr<InstallContext> AkliteClient::CheckAppsInSync() const {
     auto correlation_id = target->custom_version() + "-" + boost::uuids::to_string(tmp);
     target->setCorrelationId(correlation_id);
     std::string reason = "Sync active target apps";
-    installer = std::make_unique<LiteInstall>(client_, std::move(target), reason, InstallMode::All);
+    if (src_path.empty()) {
+      installer = std::make_unique<LiteInstall>(client_, std::move(target), reason, InstallMode::All);
+    } else {
+      installer = std::make_unique<LocalLiteInstall>(client_, std::move(target), reason, src_path, InstallMode::All);
+    }
   }
   client_->setAppsNotChecked();
   return installer;
 }
 
 std::unique_ptr<InstallContext> AkliteClient::Installer(const TufTarget& t, std::string reason,
-                                                        std::string correlation_id, InstallMode install_mode) const {
+                                                        std::string correlation_id, InstallMode install_mode,
+                                                        std::string src_path) const {
   if (read_only_) {
     throw std::runtime_error("Can't perform this operation from read-only mode");
   }
@@ -390,7 +773,11 @@ std::unique_ptr<InstallContext> AkliteClient::Installer(const TufTarget& t, std:
     throw std::runtime_error("Correlation ID's must be less than 64 bytes");
   }
   target->setCorrelationId(correlation_id);
-  return std::make_unique<LiteInstall>(client_, std::move(target), reason, install_mode);
+  if (src_path.empty()) {
+    return std::make_unique<LiteInstall>(client_, std::move(target), reason, install_mode);
+  } else {
+    return std::make_unique<LocalLiteInstall>(client_, std::move(target), reason, src_path, install_mode);
+  }
 }
 
 InstallResult AkliteClient::CompleteInstallation() {

--- a/src/api.cc
+++ b/src/api.cc
@@ -767,7 +767,7 @@ bool AkliteClient::IsInstallationInProgress() const { return client_->getPending
 
 TufTarget AkliteClient::GetPendingTarget() const { return Target::toTufTarget(client_->getPendingTarget()); }
 
-std::unique_ptr<InstallContext> AkliteClient::CheckAppsInSync(const LocalUpdateSource* local_update_source) const {
+std::unique_ptr<InstallContext> AkliteClient::CheckAppsInSync() const {
   std::unique_ptr<InstallContext> installer = nullptr;
   auto target = std::make_unique<Uptane::Target>(client_->getCurrent());
   if (!client_->appsInSync(*target)) {
@@ -775,12 +775,7 @@ std::unique_ptr<InstallContext> AkliteClient::CheckAppsInSync(const LocalUpdateS
     auto correlation_id = target->custom_version() + "-" + boost::uuids::to_string(tmp);
     target->setCorrelationId(correlation_id);
     std::string reason = "Sync active target apps";
-    if (local_update_source == nullptr) {
-      installer = std::make_unique<LiteInstall>(client_, std::move(target), reason, InstallMode::All);
-    } else {
-      installer =
-          std::make_unique<LocalLiteInstall>(client_, std::move(target), reason, local_update_source, InstallMode::All);
-    }
+    installer = std::make_unique<LiteInstall>(client_, std::move(target), reason, InstallMode::All);
   }
   client_->setAppsNotChecked();
   return installer;

--- a/src/api.cc
+++ b/src/api.cc
@@ -340,7 +340,8 @@ CheckInResult AkliteClient::CheckInLocal(const std::string& path) const {
   }
 
   std::vector<Uptane::Target> available_targets =
-      getAvailableTargets(client_->config.pacman, fromTufTargets(result.Targets()), src, true);
+      getAvailableTargets(client_->config.pacman, fromTufTargets(result.Targets()), src,
+                          false /* get all available targets, not just latest */);
   if (available_targets.empty()) {
     LOG_INFO << "Unable to locate complete target in " << path;
     result.status = CheckInResult::Status::Failed;

--- a/src/api.cc
+++ b/src/api.cc
@@ -347,13 +347,11 @@ CheckInResult AkliteClient::CheckInLocal(const std::string& tuf_repo, const std:
   if (available_targets.empty()) {
     LOG_INFO << "Unable to locate complete target in ostree dir  " << src.OstreeRepoDir << " and app dir "
              << src.AppsDir;
-    result.status = CheckInResult::Status::Failed;
-  } else {
-    LOG_INFO << "Selected target: " << available_targets.front().filename();
-    result = CheckInResult(result.status, client_->config.provision.primary_ecu_hardware_id,
-                           toTufTargets(available_targets));
+    return CheckInResult(CheckInResult::Status::Failed, client_->config.provision.primary_ecu_hardware_id,
+                         std::vector<TufTarget>{});
   }
-  return result;
+  return CheckInResult(result.status, client_->config.provision.primary_ecu_hardware_id,
+                       toTufTargets(available_targets));
 }
 
 boost::property_tree::ptree AkliteClient::GetConfig() const {

--- a/src/api.cc
+++ b/src/api.cc
@@ -683,8 +683,8 @@ class LocalLiteInstall : public LiteInstall {
     std::shared_ptr<RootfsTreeManager> basepacman = std::make_shared<ComposeAppManager>(
         client_->config.pacman, client_->config.bootloader, storage, nullptr, ostree_sysroot, *key_manager, app_engine);
 
-    return std::make_unique<ComposeAppManager>(cfg.pacman, client_->config.bootloader, storage, nullptr,
-                                               ostree_sysroot, *key_manager, app_engine);
+    return std::make_unique<ComposeAppManager>(cfg.pacman, client_->config.bootloader, storage, nullptr, ostree_sysroot,
+                                               *key_manager, app_engine);
   }
 
   DownloadResult Download() override {

--- a/src/liteclient.cc
+++ b/src/liteclient.cc
@@ -20,7 +20,7 @@
 #include "uptane/exceptions.h"
 #include "uptane/fetcher.h"
 
-LiteClient::LiteClient(Config& config_in, const AppEngine::Ptr& app_engine, const std::shared_ptr<P11EngineGuard>& p11,
+LiteClient::LiteClient(Config config_in, const AppEngine::Ptr& app_engine, const std::shared_ptr<P11EngineGuard>& p11,
                        std::shared_ptr<Uptane::IMetadataFetcher> meta_fetcher)
     : config{std::move(config_in)},
       primary_ecu{Uptane::EcuSerial::Unknown(), ""},

--- a/src/liteclient.h
+++ b/src/liteclient.h
@@ -22,7 +22,7 @@ class Installer;
 
 class LiteClient {
  public:
-  explicit LiteClient(Config& config_in, const std::shared_ptr<AppEngine>& app_engine = nullptr,
+  explicit LiteClient(Config config_in, const std::shared_ptr<AppEngine>& app_engine = nullptr,
                       const std::shared_ptr<P11EngineGuard>& p11 = nullptr,
                       std::shared_ptr<Uptane::IMetadataFetcher> meta_fetcher = nullptr);
   ~LiteClient();

--- a/src/rootfstreemanager.cc
+++ b/src/rootfstreemanager.cc
@@ -240,7 +240,7 @@ void RootfsTreeManager::setRemote(const std::string& name, const std::string& ur
                                   const boost::optional<const KeyManager*>& keys) {
   OSTree::Repo repo{sysroot_->repoPath()};
 
-  if (!!keys) {
+  if (!!keys && *keys != nullptr) {
     repo.addRemote(name, url, (*keys)->getCaFile(), (*keys)->getCertFile(), (*keys)->getPkeyFile());
   } else {
     repo.addRemote(name, url, "", "", "");

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -228,6 +228,18 @@ target_link_libraries(t_aklite_offline ${MAIN_TARGET_LIB} ${TEST_LIBS} testutili
 set_tests_properties(test_aklite_offline PROPERTIES ENVIRONMENT "LD_PRELOAD=${PROJECT_BINARY_DIR}/tests/libfstatvfs-mock.so")
 set_tests_properties(test_aklite_offline PROPERTIES LABELS "aklite:offline")
 
+add_aktualizr_test(NAME aklite_offline_api
+  SOURCES aklite_offline_api_test.cc
+  PROJECT_WORKING_DIRECTORY
+  ARGS
+  ${PROJECT_SOURCE_DIR}/tests/make_sys_rootfs.sh
+)
+aktualizr_source_file_checks(aklite_offline_api_test.cc)
+target_include_directories(t_aklite_offline_api PRIVATE ${AKLITE_DIR}/include ${TEST_INCS} ${AKTUALIZR_DIR}/tests/ ${AKTUALIZR_DIR}/src/)
+target_link_libraries(t_aklite_offline_api ${MAIN_TARGET_LIB} ${TEST_LIBS} testutilities uptane_generator_lib ${AKLITE_OFFLINE_LIB} fstatvfs-mock)
+set_tests_properties(test_aklite_offline_api PROPERTIES ENVIRONMENT "LD_PRELOAD=${PROJECT_BINARY_DIR}/tests/libfstatvfs-mock.so")
+set_tests_properties(test_aklite_offline_api PROPERTIES LABELS "aklite:offline-api")
+
 
 add_aktualizr_test(NAME boot_flag_mgmt
   SOURCES boot_flag_mgmt_test.cc

--- a/tests/aklite_offline_api_test.cc
+++ b/tests/aklite_offline_api_test.cc
@@ -354,6 +354,18 @@ TEST_F(AkliteOffline, OfflineClient) {
   ASSERT_EQ(target, current());
 }
 
+TEST_F(AkliteOffline, OfflineClientAppsOnly) {
+  const auto target{addTarget({createApp("app-01")}, true)};
+  auto cr = check();
+  ASSERT_EQ(CheckInResult::Status::Ok, cr.status);
+  ASSERT_EQ(target, cr.GetLatest());
+  auto dr = download(target);
+  ASSERT_EQ(DownloadResult::Status::Ok, dr.status);
+  auto ir = install(target);
+  ASSERT_EQ(InstallResult::Status::Ok, ir.status) << ir.description;
+  ASSERT_EQ(target, current());
+}
+
 int main(int argc, char** argv) {
   if (argc != 2) {
     std::cerr << argv[0] << " invalid arguments\n";

--- a/tests/aklite_offline_api_test.cc
+++ b/tests/aklite_offline_api_test.cc
@@ -146,7 +146,7 @@ class AkliteOffline : public ::testing::Test {
 
   CheckInResult check() {
     AkliteClient client(std::make_shared<LiteClient>(cfg_));
-    return client.CheckInLocal(tuf_repo_.getRepoPath(), ostree_repo_.getPath(), app_store_.dir().string());
+    return client.CheckInLocal(src());
   }
 
   DownloadResult download(const TufTarget& target) {

--- a/tests/aklite_offline_api_test.cc
+++ b/tests/aklite_offline_api_test.cc
@@ -1,0 +1,343 @@
+#include <gtest/gtest.h>
+#include <boost/filesystem.hpp>
+#include <boost/format.hpp>
+#include <boost/process.hpp>
+#include <fstream>
+
+#include "test_utils.h"
+#include "uptane_generator/image_repo.h"
+
+#include "aktualizr-lite/api.h"
+#include "appengine.h"
+#include "composeappmanager.h"
+#include "docker/restorableappengine.h"
+#include "liteclient.h"
+#include "offline/client.h"
+#include "target.h"
+
+// include test fixtures
+#include "fixtures/composeapp.cc"
+#include "fixtures/dockerdaemon.cc"
+#include "fixtures/liteclient/boot_flag_mgr.cc"
+#include "fixtures/liteclient/executecmd.cc"
+#include "fixtures/liteclient/ostreerepomock.cc"
+#include "fixtures/liteclient/sysostreerepomock.cc"
+#include "fixtures/liteclient/sysrootfs.cc"
+#include "fixtures/liteclient/tufrepomock.cc"
+
+// Defined in fstatvfs-mock.cc
+extern void SetFreeBlockNumb(uint64_t, uint64_t);
+extern void UnsetFreeBlockNumb();
+
+class AppStore {
+ public:
+  AppStore(const boost::filesystem::path& root_dir, const std::string& hostname = "hub.foundries.io")
+      : root_dir_{root_dir}, hostname_{hostname} {}
+
+  AppEngine::App addApp(const fixtures::ComposeApp::Ptr& app) {
+    const auto app_dir{apps_dir_ / app->name() / app->hash()};
+
+    // store App data
+    boost::filesystem::create_directories(app_dir);
+    Utils::writeFile(app_dir / "manifest.json", app->manifest());
+    Utils::writeFile(blobs_dir_ / app->hash(), app->manifest());
+    Utils::writeFile(app_dir / (app->archHash() + ".tgz"), app->archive());
+    Utils::writeFile(blobs_dir_ / app->archHash(), app->archive());
+    Utils::writeFile(blobs_dir_ / app->layersHash(), app->layersManifest());
+
+    // store image in the skopeo/OCI compliant way
+    const auto image_uri{app->image().uri()};
+    Docker::Uri uri{Docker::Uri::parseUri(image_uri)};
+    const auto image_dir{app_dir / "images" / uri.registryHostname / uri.repo / uri.digest.hash()};
+    boost::filesystem::create_directories(image_dir);
+    Utils::writeFile(image_dir / "oci-layout", std::string("{\"imageLayoutVersion\": \"1.0.0\"}"));
+
+    Json::Value index_json;
+    index_json["schemaVersion"] = 2;
+    index_json["manifests"][0]["mediaType"] = "application/vnd.docker.distribution.manifest.v2+json";
+    index_json["manifests"][0]["digest"] = "sha256:" + app->image().manifest().hash;
+    index_json["manifests"][0]["size"] = app->image().manifest().size;
+    index_json["manifests"][0]["platform"]["architecture"] = "amd64";
+    index_json["manifests"][0]["platform"]["os"] = "linux";
+    Utils::writeFile(image_dir / "index.json", Utils::jsonToStr(index_json));
+    Utils::writeFile(blobs_dir_ / app->image().manifest().hash, app->image().manifest().data);
+    Utils::writeFile(blobs_dir_ / app->image().config().hash, app->image().config().data);
+    Utils::writeFile(blobs_dir_ / app->image().layerBlob().hash, app->image().layerBlob().data);
+
+    const auto app_uri{hostname_ + '/' + "factory/" + app->name() + '@' + "sha256:" + app->hash()};
+    Utils::writeFile(app_dir / "uri", app_uri);
+    return {app->name(), app_uri};
+  }
+
+  boost::filesystem::path blobsDir() const { return root_dir_ / "blobs"; }
+  const boost::filesystem::path& appsDir() const { return apps_dir_; }
+  const boost::filesystem::path& dir() const { return root_dir_; }
+
+ private:
+  const boost::filesystem::path root_dir_;
+  const std::string hostname_;
+  const boost::filesystem::path apps_dir_{root_dir_ / "apps"};
+  const boost::filesystem::path blobs_dir_{root_dir_ / "blobs" / "sha256"};
+};
+
+class AkliteOffline : public ::testing::Test {
+ protected:
+  AkliteOffline()
+      : sys_rootfs_{(test_dir_.Path() / "sysroot-fs").string(), branch, hw_id, os},
+        sys_repo_{(test_dir_.Path() / "sysrepo").string(), os},
+        ostree_repo_{(test_dir_.Path() / "treehub").string(), true},
+        tuf_repo_{src_dir_ / "tuf"},
+        daemon_{test_dir_.Path() / "daemon"},
+        app_store_{test_dir_.Path() / "apps"},
+        boot_flag_mgr_{std::make_shared<FioVb>((test_dir_.Path() / "fiovb").string())},
+        initial_target_{Uptane::Target::Unknown()} {
+    // hardware ID
+    cfg_.provision.primary_ecu_hardware_id = hw_id;
+    cfg_.provision.primary_ecu_serial = "test_primary_ecu_serial_id";
+
+    // a path to the config dir
+    cfg_.storage.path = test_dir_.Path() / "sota-dir";
+
+    // ostree-based sysroot config
+    cfg_.pacman.sysroot = sys_repo_.getPath();
+    cfg_.pacman.os = os;
+    cfg_.pacman.booted = BootedType::kStaged;
+    // In most cases an offline device is not registered and does not have configuration set.
+    // If the package manager type is not set in a device config then it is initialized to `ostree` by default.
+    // The default value (`ostree`) is not  appropriate for the offline update so it sets the package manager to
+    // `ComposeAppManager::Name` by default unless no docker binaries are found on the system.
+    // Since the CI/test container doesn't have the docker binaries in its filesystem then we need to enforce
+    // the compose app package managaer usage because majority of the tests assume/require it.
+    // Also, enforcing of the package manager type can be useful of a system with docker but a user still would
+    // like to do only ostree update instead of ostree + apps update.
+    cfg_.pacman.extra["enforce_pacman_type"] = ComposeAppManager::Name;
+
+    // configure bootloader/booting related functionality
+    cfg_.bootloader.reboot_command = "/bin/true";
+    cfg_.bootloader.reboot_sentinel_dir = test_dir_.Path();
+    cfg_.bootloader.rollback_mode = RollbackMode::kFioVB;
+
+    cfg_.pacman.extra["reset_apps"] = "";
+    cfg_.pacman.extra["reset_apps_root"] = (test_dir_.Path() / "reset-apps").string();
+    cfg_.pacman.extra["compose_apps_root"] = (test_dir_.Path() / "compose-apps").string();
+    cfg_.pacman.extra["docker_compose_bin"] =
+        boost::filesystem::canonical("tests/docker-compose_fake.py").string() + " " + daemon_.dir().string() + " ";
+    cfg_.pacman.extra["images_data_root"] = daemon_.dataRoot();
+
+    cfg_.import.base_path = cfg_.storage.path / "import";
+
+    // add an initial rootfs to the ostree repo (treehub), pull it to the sysroot's repo, and deploy it
+    const auto hash{ostree_repo_.commit(sys_rootfs_.path, sys_rootfs_.branch)};
+    sys_repo_.getRepo().pullLocal(ostree_repo_.getPath(), hash);
+    sys_repo_.deploy(hash);
+    setInitialTarget(hash);
+  }
+
+  void SetUp() {
+    auto env{boost::this_process::environment()};
+    env.set("DOCKER_HOST", daemon_.getUrl());
+    SetFreeBlockNumb(90, 100);
+  }
+
+  void TearDown() { UnsetFreeBlockNumb(); }
+
+  CheckInResult check() {
+    AkliteClient client(std::make_shared<LiteClient>(cfg_));
+    return client.CheckInLocal(tuf_repo_.getRepoPath(), ostree_repo_.getPath(), app_store_.appsDir().string());
+  }
+
+  InstallResult install(const TufTarget& target) {
+    // TODO
+  }
+
+  offline::PostRunAction run() {
+    // TODO
+  }
+
+  const Uptane::Target getCurrent() {
+    // TODO
+  }
+
+  void setInitialTarget(const std::string& hash, bool known = true) {
+    Uptane::EcuMap ecus{{Uptane::EcuSerial("test_primary_ecu_serial_id"), Uptane::HardwareIdentifier(hw_id)}};
+    std::vector<Hash> hashes{Hash(Hash::Type::kSha256, hash)};
+    initial_target_ = Uptane::Target{known ? hw_id + "-lmp-1" : Target::InitialTarget, ecus, hashes, 0, "", "OSTREE"};
+    // update the initial Target to add the hardware ID so Target::MatchTarget() works correctly
+    auto custom{initial_target_.custom_data()};
+    custom["hardwareIds"][0] = cfg_.provision.primary_ecu_hardware_id;
+    custom["version"] = "1";
+    initial_target_.updateCustom(custom);
+    // set initial bootloader version
+    const auto boot_fw_ver{bootloader::BootloaderLite::getVersion(sys_repo_.getDeploymentPath(), hash)};
+    boot_flag_mgr_->set("bootfirmware_version", boot_fw_ver);
+  }
+  TufTarget addTarget(const std::vector<AppEngine::App>& apps, bool just_apps = false,
+                      bool add_bootloader_update = false) {
+    const auto& latest_target{tuf_repo_.getLatest()};
+    std::string version;
+    if (version.size() == 0) {
+      try {
+        version = std::to_string(std::stoi(latest_target.custom_version()) + 1);
+      } catch (...) {
+        LOG_INFO << "No target available, preparing the first version";
+        version = "2";
+      }
+    }
+    auto hash{latest_target.IsValid() ? latest_target.sha256Hash() : initial_target_.sha256Hash()};
+    if (!just_apps) {
+      // update rootfs and commit it into Treehub's repo
+      const std::string unique_content = Utils::randomUuid();
+      const std::string unique_file = Utils::randomUuid();
+      Utils::writeFile(sys_rootfs_.path + "/" + unique_file, unique_content, true);
+      if (add_bootloader_update) {
+        Utils::writeFile(sys_rootfs_.path + bootloader::BootloaderLite::VersionFile,
+                         std::string("bootfirmware_version=111"), true);
+      }
+      hash = ostree_repo_.commit(sys_rootfs_.path, branch);
+    }
+    Json::Value apps_json;
+    for (const auto& app : apps) {
+      apps_json[app.name]["uri"] = app.uri;
+    }
+    // add new target to TUF repo
+    const std::string name = hw_id + "-" + os + "-" + version;
+    return Target::toTufTarget(tuf_repo_.addTarget(name, hash, hw_id, version, apps_json));
+  }
+
+  void preloadApps(const std::vector<AppEngine::App>& apps, const std::vector<std::string>& apps_not_to_preload,
+                   bool add_installed_versions = true) {
+    // do App preloading by installing Target that refers to the current ostree hash
+    // and contains the list of apps to preload.
+    Uptane::Target preloaded_target{initial_target_};
+    Json::Value apps_json;
+
+    std::set<std::string> apps_to_shortlist;
+    for (const auto& app : apps) {
+      apps_json[app.name]["uri"] = app.uri;
+      apps_to_shortlist.emplace(app.name);
+    }
+    tuf_repo_.addTarget(cfg_.provision.primary_ecu_hardware_id + "-lmp-1", initial_target_.sha256Hash(),
+                        cfg_.provision.primary_ecu_hardware_id, "0", apps_json);
+
+    // content-based shortlisting
+    for (const auto& app : apps_not_to_preload) {
+      boost::filesystem::remove_all(app_store_.appsDir() / app);
+      apps_to_shortlist.erase(app);
+    }
+    setAppsShortlist(boost::algorithm::join(apps_to_shortlist, ","));
+    // ASSERT_EQ(install(), offline::PostInstallAction::Ok);
+    ASSERT_EQ(run(), offline::PostRunAction::Ok);
+
+    if (add_installed_versions) {
+      Json::Value installed_target_json;
+      installed_target_json[initial_target_.filename()]["hashes"]["sha256"] = initial_target_.sha256Hash();
+      installed_target_json[initial_target_.filename()]["length"] = 0;
+      installed_target_json[initial_target_.filename()]["is_current"] = true;
+      Json::Value custom;
+      custom[Target::ComposeAppField] = apps_json;
+      custom["name"] = cfg_.provision.primary_ecu_hardware_id + "-lmp";
+      custom["version"] = "1";
+      custom["hardwareIds"][0] = cfg_.provision.primary_ecu_hardware_id;
+      custom["targetFormat"] = "OSTREE";
+      custom["arch"] = "arm64";
+      installed_target_json[initial_target_.filename()]["custom"] = custom;
+      Utils::writeFile(cfg_.import.base_path / "installed_versions", installed_target_json);
+      ASSERT_EQ(getCurrent().filename(), initial_target_.filename());
+    } else {
+      // we need to remove the initial target from the TUF repo so it's not listed in the source TUF repo
+      // for the following offline update and as result it will be "unknown" to the client.
+      tuf_repo_.reset();
+      // Turn the "known" target to the "initial" since it's not in DB/TUF meta
+      setInitialTarget(initial_target_.sha256Hash(), false);
+    }
+    // remove the DB generated during the update for the app preloading, to emulate real-life situation
+    boost::filesystem::remove(cfg_.storage.sqldb_path.get(cfg_.storage.path));
+  }
+
+  const std::string getSentinelFilePath() const {
+    return (cfg_.bootloader.reboot_sentinel_dir / "need_reboot").string();
+  }
+
+  void reboot() {
+    boost::filesystem::remove(getSentinelFilePath());
+    reloadDockerEngine();
+  }
+
+  void reloadDockerEngine() {
+    // emulate registration of images located in `/var/lib/docker/image/overlay2/repositories.json
+    const boost::filesystem::path repositories_file{daemon_.dir() / "/image/overlay2/repositories.json"};
+    Json::Value repositories;
+    Json::Value images;
+    if (boost::filesystem::exists(repositories_file)) {
+      repositories = Utils::parseJSONFile(repositories_file.string());
+    } else {
+      repositories = Utils::parseJSON("{\"Repositories\":{}}");
+    }
+
+    for (const auto& repo : repositories["Repositories"]) {
+      for (Json::ValueConstIterator image_it = repo.begin(); image_it != repo.end(); ++image_it) {
+        const auto image_uri{image_it.key().asString()};
+        images[image_uri] = true;
+      }
+    }
+    // The docker daemon and docker compose mocks use the "image.json" file
+    Utils::writeFile(daemon_.dir() / "images.json", images);
+  }
+
+  AppEngine::App createApp(const std::string& name, const std::string& failure = "none") {
+    const auto layer_size{1024};
+    Json::Value layers;
+    layers["layers"][0]["digest"] =
+        "sha256:" + boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha256digest(Utils::randomUuid())));
+    layers["layers"][0]["size"] = layer_size;
+
+    return app_store_.addApp(fixtures::ComposeApp::createAppWithCustomeLayers(name, layers, boost::none, failure));
+  }
+
+  void setAppsShortlist(const std::string& shortlist) { cfg_.pacman.extra["compose_apps"] = shortlist; }
+
+ protected:
+  static const std::string hw_id;
+  static const std::string os;
+  static const std::string branch;
+
+ protected:
+  TemporaryDirectory test_dir_;  // must be the first element in the class
+  const boost::filesystem::path src_dir_{test_dir_.Path() / "offline-update-src"};
+  Config cfg_;
+  SysRootFS sys_rootfs_;        // a sysroot that is bitbaked and added to the ostree repo that liteclient fetches from
+  SysOSTreeRepoMock sys_repo_;  // an ostree-based sysroot that liteclient manages
+  OSTreeRepoMock ostree_repo_;  // a source ostree repo to fetch update from
+  TufRepoMock tuf_repo_;
+  fixtures::DockerDaemon daemon_;
+  AppStore app_store_;
+  BootFlagMgr::Ptr boot_flag_mgr_;
+  Uptane::Target initial_target_;
+};
+
+const std::string AkliteOffline::hw_id{"raspberrypi4-64"};
+const std::string AkliteOffline::os{"lmp"};
+const std::string AkliteOffline::branch{hw_id + "-" + os};
+
+TEST_F(AkliteOffline, OfflineClient) {
+  const auto prev_target{addTarget({createApp("app-01")})};
+  const auto target{addTarget({createApp("app-01")})};
+
+  auto cr = check();
+  ASSERT_EQ(CheckInResult::Status::Ok, cr.status);
+  ASSERT_EQ(2, cr.Targets().size());
+  ASSERT_EQ(target, cr.GetLatest());
+}
+
+int main(int argc, char** argv) {
+  if (argc != 2) {
+    std::cerr << argv[0] << " invalid arguments\n";
+    return EXIT_FAILURE;
+  }
+
+  ::testing::InitGoogleTest(&argc, argv);
+  logger_init();
+
+  SysRootFS::CreateCmd = argv[1];
+  return RUN_ALL_TESTS();
+}

--- a/tests/apiclient_test.cc
+++ b/tests/apiclient_test.cc
@@ -139,7 +139,9 @@ TEST_F(ApiClientTest, CheckInLocal) {
 
   // Accessing repo metadata files directly from the local filesystem
   auto repo_dir = getTufRepo().getRepoPath();
-  auto result = client.CheckInLocal(repo_dir, ostree_repo_.getPath());
+
+  const LocalUpdateSource local_update_source_ = {repo_dir, ostree_repo_.getPath()};
+  auto result = client.CheckInLocal(&local_update_source_);
   ASSERT_EQ(CheckInResult::Status::Ok, result.status);
   ASSERT_EQ(1, result.Targets().size());
 
@@ -152,7 +154,7 @@ TEST_F(ApiClientTest, CheckInLocal) {
   ASSERT_EQ(1, result.Targets().size());
 
   auto new_target = createTarget();
-  result = client.CheckInLocal(repo_dir, ostree_repo_.getPath());
+  result = client.CheckInLocal(&local_update_source_);
   ASSERT_EQ(0, getDeviceGateway().getEvents().size());
   ASSERT_EQ("", getDeviceGateway().readSotaToml());
   ASSERT_EQ(CheckInResult::Status::Ok, result.status);

--- a/tests/apiclient_test.cc
+++ b/tests/apiclient_test.cc
@@ -72,10 +72,18 @@ class ApiClientTest : public fixtures::ClientTest {
 
   std::shared_ptr<NiceMock<MockAppEngine>>& getAppEngine() { return app_engine_mock_; }
   bool resetEvents() { return getDeviceGateway().resetEvents(lite_client_->http_client); }
+  void tweakConf(Config& conf) override {
+    if (!pacman_type_.empty()) {
+      conf.pacman.type = pacman_type_;
+    }
+  }
+
+  void setPacmanType(const std::string& pacman_type) { pacman_type_ = pacman_type; }
 
  private:
   std::shared_ptr<NiceMock<MockAppEngine>> app_engine_mock_;
   std::shared_ptr<LiteClient> lite_client_;
+  std::string pacman_type_;
 };
 
 TEST_F(ApiClientTest, GetConfig) {
@@ -126,11 +134,12 @@ TEST_F(ApiClientTest, CheckIn) {
 }
 
 TEST_F(ApiClientTest, CheckInLocal) {
+  setPacmanType(RootfsTreeManager::Name);
   AkliteClient client(createLiteClient(InitialVersion::kOn));
 
   // Accessing repo metadata files directly from the local filesystem
   auto repo_dir = getTufRepo().getRepoPath();
-  auto result = client.CheckInLocal(repo_dir);
+  auto result = client.CheckInLocal(repo_dir, ostree_repo_.getPath());
   ASSERT_EQ(CheckInResult::Status::Ok, result.status);
   ASSERT_EQ(1, result.Targets().size());
 
@@ -143,13 +152,13 @@ TEST_F(ApiClientTest, CheckInLocal) {
   ASSERT_EQ(1, result.Targets().size());
 
   auto new_target = createTarget();
-  result = client.CheckInLocal(repo_dir);
+  result = client.CheckInLocal(repo_dir, ostree_repo_.getPath());
   ASSERT_EQ(0, getDeviceGateway().getEvents().size());
   ASSERT_EQ("", getDeviceGateway().readSotaToml());
   ASSERT_EQ(CheckInResult::Status::Ok, result.status);
   ASSERT_EQ(2, result.Targets().size());
-  ASSERT_EQ(new_target.filename(), result.Targets()[1].Name());
-  ASSERT_EQ(new_target.sha256Hash(), result.Targets()[1].Sha256Hash());
+  ASSERT_EQ(new_target.filename(), result.GetLatest().Name());
+  ASSERT_EQ(new_target.sha256Hash(), result.GetLatest().Sha256Hash());
 }
 
 TEST_F(ApiClientTest, CheckInWithoutTargetImport) {


### PR DESCRIPTION
Add a new LocalLiteInstall class, that inherits from the original
LiteInstall class, overriding the Download method, making it copy target
data locally instead of fetching it remotelly.

The implementation is strongly based on the standalone offline client
code.

---
Unit tests still need to be adjusted, specially `CheckInLocal` that  now requires apps and ostree data in order to accept a target as valid.

There is an ongoing discussion about `CheckAppsInSync`. Perhaps it does not need to receive a source path in the offline case, as reset-apps would be accessed instead.