### PR TITLE
Strengthen target check before starting installation

### DIFF
--- a/include/aktualizr-lite/tuf/tuf.h
+++ b/include/aktualizr-lite/tuf/tuf.h
@@ -91,7 +91,8 @@ class TufTarget {
    * @return true if the targets match, otherwise false
    */
   bool operator==(const TufTarget& other) const {
-    return other.name_ == name_ && other.sha256_ == sha256_ && other.version_ == version_;
+    return other.name_ == name_ && other.sha256_ == sha256_ && other.version_ == version_ &&
+           other.AppsJson() == AppsJson();
   }
 
   /**

--- a/src/api.cc
+++ b/src/api.cc
@@ -281,12 +281,9 @@ static std::vector<Uptane::Target> getAvailableTargets(const PackageConfig& pcon
     const ComposeAppManager::AppsContainer required_apps{
         ComposeAppManager::getRequiredApps(ComposeAppManager::Config(pconfig), t)};
     std::set<std::string> missing_apps;
-    Json::Value apps_to_install;
     for (const auto& app : required_apps) {
       if (found_apps.count(app.second) == 0) {
         missing_apps.insert(app.second);
-      } else {
-        apps_to_install[app.first]["uri"] = app.second;
       }
     }
     if (!missing_apps.empty()) {
@@ -296,9 +293,7 @@ static std::vector<Uptane::Target> getAvailableTargets(const PackageConfig& pcon
       }
       continue;
     }
-    Json::Value updated_custom{t.custom_data()};
-    updated_custom[Target::ComposeAppField] = apps_to_install;
-    found_targets.emplace_back(Target::updateCustom(t, updated_custom));
+    found_targets.emplace_back(t);
     LOG_INFO << "\tall target content have been found";
     if (just_latest) {
       break;

--- a/src/api.cc
+++ b/src/api.cc
@@ -762,7 +762,7 @@ std::unique_ptr<InstallContext> AkliteClient::Installer(const TufTarget& t, std:
   // Make sure the metadata is loaded from storage and valid.
   tuf_repo_->checkMeta();
   for (const auto& tt : tuf_repo_->GetTargets()) {
-    if (tt.Name() == t.Name()) {
+    if (tt == t) {
       target = std::make_unique<Uptane::Target>(Target::fromTufTarget(tt));
       break;
     }
@@ -775,6 +775,8 @@ std::unique_ptr<InstallContext> AkliteClient::Installer(const TufTarget& t, std:
       // and not installed_versions)
       target = std::make_unique<Uptane::Target>(uptane_target);
     } else {
+      LOG_ERROR << "The specified Target is not found amoung trusted TUF targets:\n"
+                << "\tName: " << t.Name() << ", ostree hash: " << t.Sha256Hash() << "\n\tApps: " << t.AppsJson();
       return nullptr;
     }
   }

--- a/tests/aklite_offline_test.cc
+++ b/tests/aklite_offline_test.cc
@@ -678,9 +678,7 @@ TEST_F(AkliteOffline, InvalidTargetInstallOstree) {
   const auto& available_targtets = cr.Targets();
   ASSERT_EQ(1, available_targtets.size());
   auto ic = client.Installer(target_not_available, "", "", InstallMode::OstreeOnly, src());
-  ASSERT_TRUE(ic != nullptr);
-  auto dr = ic->Download();
-  ASSERT_EQ(DownloadResult::Status::DownloadFailed, dr.status);
+  ASSERT_TRUE(ic == nullptr);
 }
 
 TEST_F(AkliteOffline, InvalidTargetInstallApps) {
@@ -696,9 +694,7 @@ TEST_F(AkliteOffline, InvalidTargetInstallApps) {
   const auto& available_targtets = cr.Targets();
   ASSERT_EQ(1, available_targtets.size());
   auto ic = client.Installer(target_not_available, "", "", InstallMode::OstreeOnly, src());
-  ASSERT_TRUE(ic != nullptr);
-  auto dr = ic->Download();
-  ASSERT_EQ(DownloadResult::Status::DownloadFailed, dr.status);
+  ASSERT_TRUE(ic == nullptr);
 }
 
 int main(int argc, char** argv) {

--- a/tests/aklite_offline_test.cc
+++ b/tests/aklite_offline_test.cc
@@ -220,16 +220,20 @@ class AkliteOffline : public ::testing::Test {
     return client.GetCurrent();
   }
 
-  void setInitialTarget(const std::string& hash, bool known = true) {
+  void setInitialTarget(const std::string& hash, bool known = true, Json::Value* custom_data = nullptr) {
     Uptane::EcuMap ecus{{Uptane::EcuSerial("test_primary_ecu_serial_id"), Uptane::HardwareIdentifier(hw_id)}};
     std::vector<Hash> hashes{Hash(Hash::Type::kSha256, hash)};
     Uptane::Target initial_target =
         Uptane::Target{known ? hw_id + "-lmp-1" : Target::InitialTarget, ecus, hashes, 0, "", "OSTREE"};
     // update the initial Target to add the hardware ID so Target::MatchTarget() works correctly
-    auto custom{initial_target.custom_data()};
-    custom["hardwareIds"][0] = cfg_.provision.primary_ecu_hardware_id;
-    custom["version"] = "1";
-    initial_target.updateCustom(custom);
+    if (known && custom_data != nullptr) {
+      initial_target.updateCustom(*custom_data);
+    } else {
+      auto custom{initial_target.custom_data()};
+      custom["hardwareIds"][0] = cfg_.provision.primary_ecu_hardware_id;
+      custom["version"] = "1";
+      initial_target.updateCustom(custom);
+    }
     // set initial bootloader version
     const auto boot_fw_ver{bootloader::BootloaderLite::getVersion(sys_repo_.getDeploymentPath(), hash)};
     boot_flag_mgr_->set("bootfirmware_version", boot_fw_ver);
@@ -306,6 +310,7 @@ class AkliteOffline : public ::testing::Test {
       installed_target_json[initial_target_.Name()]["custom"] = custom;
       Utils::writeFile(cfg_.import.base_path / "installed_versions", installed_target_json);
       // ASSERT_EQ(getCurrent().filename(), initial_target_.filename());
+      setInitialTarget(initial_target_.Sha256Hash(), true, &custom);
     } else {
       // we need to remove the initial target from the TUF repo so it's not listed in the source TUF repo
       // for the following offline update and as result it will be "unknown" to the client.
@@ -597,8 +602,10 @@ TEST_F(AkliteOffline, RollbackToInitialTarget) {
   // emulate "normal" rollback - boot on the previous target
   sys_repo_.deploy(initial_target_.Sha256Hash());
   ASSERT_EQ(aklite::cli::StatusCode::InstallRollbackOk, run());
-  ASSERT_EQ(initial_target_, getCurrent());
-  ASSERT_TRUE(areAppsInSync());
+  // If if's so called "initial" target then we don't know what apps were installed
+  // at a device initial startup, so we just check if name and ostree hash of targets match.
+  ASSERT_EQ(initial_target_.Name(), getCurrent().Name());
+  ASSERT_EQ(initial_target_.Sha256Hash(), getCurrent().Sha256Hash());
 }
 
 TEST_F(AkliteOffline, RollbackToInitialTargetIfAppDrivenRolllback) {
@@ -613,8 +620,8 @@ TEST_F(AkliteOffline, RollbackToInitialTargetIfAppDrivenRolllback) {
   ASSERT_EQ(aklite::cli::StatusCode::InstallRollbackNeedsReboot, run());
   reboot();
   ASSERT_EQ(aklite::cli::StatusCode::Ok, run());
-  ASSERT_EQ(initial_target_, getCurrent());
-  ASSERT_TRUE(areAppsInSync());
+  ASSERT_EQ(initial_target_.Name(), getCurrent().Name());
+  ASSERT_EQ(initial_target_.Sha256Hash(), getCurrent().Sha256Hash());
 }
 
 TEST_F(AkliteOffline, RollbackToUnknown) {

--- a/tests/apiclient_test.cc
+++ b/tests/apiclient_test.cc
@@ -459,34 +459,14 @@ TEST_F(ApiClientTest, InstallTargetWithHackedOstree) {
   const auto malicious_ostree_commit{addOstreeCommit()};
   TufTarget malicious_target{valid_target.Name(), malicious_ostree_commit, valid_target.Version(),
                              valid_target.Custom()};
-  {
-    AkliteClient client(liteclient);
+  AkliteClient client(liteclient);
 
-    auto result = client.CheckIn();
-    ASSERT_EQ(CheckInResult::Status::Ok, result.status);
-    auto latest = result.GetLatest();
-    ASSERT_EQ(latest.Name(), malicious_target.Name());
-    auto installer = client.Installer(malicious_target);
-    ASSERT_NE(nullptr, installer);
-    auto dresult = installer->Download();
-    ASSERT_EQ(DownloadResult::Status::Ok, dresult.status);
-
-    auto iresult = installer->Install();
-    ASSERT_EQ(InstallResult::Status::NeedsCompletion, iresult.status);
-    reboot(liteclient);
-  }
-  {
-    AkliteClient client(liteclient);
-
-    auto ciresult = client.CompleteInstallation();
-    ASSERT_EQ(InstallResult::Status::Ok, ciresult.status);
-    const auto current{client.GetCurrent()};
-    ASSERT_EQ(current.Name(), malicious_target.Name());
-    // malicious rootfs is not installed, however there is no any installation error
-    ASSERT_NE(current.Sha256Hash(), malicious_target.Sha256Hash());
-    ASSERT_EQ(current.Sha256Hash(), valid_target.Sha256Hash());
-    ASSERT_EQ(current.AppsJson(), valid_target.AppsJson());
-  }
+  auto result = client.CheckIn();
+  ASSERT_EQ(CheckInResult::Status::Ok, result.status);
+  auto latest = result.GetLatest();
+  ASSERT_EQ(latest.Name(), malicious_target.Name());
+  auto installer = client.Installer(malicious_target);
+  ASSERT_EQ(nullptr, installer);
 }
 
 TEST_F(ApiClientTest, InstallTargetWithHackedApps) {
@@ -500,34 +480,14 @@ TEST_F(ApiClientTest, InstallTargetWithHackedApps) {
   auto custom_data{valid_target.Custom()};
   custom_data[TufTarget::ComposeAppField] = malicious_apps;
   TufTarget malicious_target{valid_target.Name(), valid_target.Sha256Hash(), valid_target.Version(), custom_data};
-  {
-    AkliteClient client(liteclient);
+  AkliteClient client(liteclient);
 
-    auto result = client.CheckIn();
-    ASSERT_EQ(CheckInResult::Status::Ok, result.status);
-    auto latest = result.GetLatest();
-    ASSERT_EQ(latest.Name(), malicious_target.Name());
-    auto installer = client.Installer(malicious_target, "", "", InstallMode::OstreeOnly);
-    ASSERT_NE(nullptr, installer);
-    auto dresult = installer->Download();
-    ASSERT_EQ(DownloadResult::Status::Ok, dresult.status);
-
-    auto iresult = installer->Install();
-    ASSERT_EQ(InstallResult::Status::AppsNeedCompletion, iresult.status);
-  }
-  {
-    AkliteClient client(liteclient);
-
-    auto ciresult = client.CompleteInstallation();
-    ASSERT_EQ(InstallResult::Status::Ok, ciresult.status);
-    const auto current{client.GetCurrent()};
-    ASSERT_EQ(current.Name(), malicious_target.Name());
-    ASSERT_EQ(current.Sha256Hash(), malicious_target.Sha256Hash());
-    // malicious apps are not installed, however there is no any installation error
-    ASSERT_NE(current.AppsJson(), malicious_target.AppsJson());
-    ASSERT_EQ(current.Sha256Hash(), valid_target.Sha256Hash());
-    ASSERT_EQ(current.AppsJson(), valid_target.AppsJson());
-  }
+  auto result = client.CheckIn();
+  ASSERT_EQ(CheckInResult::Status::Ok, result.status);
+  auto latest = result.GetLatest();
+  ASSERT_EQ(latest.Name(), malicious_target.Name());
+  auto installer = client.Installer(malicious_target, "", "", InstallMode::OstreeOnly);
+  ASSERT_EQ(nullptr, installer);
 }
 
 int main(int argc, char** argv) {

--- a/tests/apiclient_test.cc
+++ b/tests/apiclient_test.cc
@@ -80,6 +80,13 @@ class ApiClientTest : public fixtures::ClientTest {
 
   void setPacmanType(const std::string& pacman_type) { pacman_type_ = pacman_type; }
 
+  std::string addOstreeCommit() {
+    const std::string unique_content = Utils::randomUuid();
+    const std::string unique_file = Utils::randomUuid();
+    Utils::writeFile(getSysRootFs().path + "/" + unique_file, unique_content, true);
+    return getOsTreeRepo().commit(getSysRootFs().path, "lmp");
+  }
+
  private:
   std::shared_ptr<NiceMock<MockAppEngine>> app_engine_mock_;
   std::shared_ptr<LiteClient> lite_client_;
@@ -440,6 +447,86 @@ TEST_F(ApiClientTest, SwitchTag) {
     // make sure the update to tag_target was successful
     ASSERT_EQ(client.GetCurrent().Name(), tag_target.filename());
     ASSERT_EQ(client.GetCurrent().Sha256Hash(), tag_target.sha256Hash());
+  }
+}
+
+TEST_F(ApiClientTest, InstallTargetWithHackedOstree) {
+  auto liteclient = createLiteClient();
+  ASSERT_TRUE(targetsMatch(liteclient->getCurrent(), getInitialTarget()));
+
+  std::vector<AppEngine::App> apps{{"app-01", "app-01-URI"}};
+  auto valid_target = Target::toTufTarget(createTarget(&apps));
+  const auto malicious_ostree_commit{addOstreeCommit()};
+  TufTarget malicious_target{valid_target.Name(), malicious_ostree_commit, valid_target.Version(),
+                             valid_target.Custom()};
+  {
+    AkliteClient client(liteclient);
+
+    auto result = client.CheckIn();
+    ASSERT_EQ(CheckInResult::Status::Ok, result.status);
+    auto latest = result.GetLatest();
+    ASSERT_EQ(latest.Name(), malicious_target.Name());
+    auto installer = client.Installer(malicious_target);
+    ASSERT_NE(nullptr, installer);
+    auto dresult = installer->Download();
+    ASSERT_EQ(DownloadResult::Status::Ok, dresult.status);
+
+    auto iresult = installer->Install();
+    ASSERT_EQ(InstallResult::Status::NeedsCompletion, iresult.status);
+    reboot(liteclient);
+  }
+  {
+    AkliteClient client(liteclient);
+
+    auto ciresult = client.CompleteInstallation();
+    ASSERT_EQ(InstallResult::Status::Ok, ciresult.status);
+    const auto current{client.GetCurrent()};
+    ASSERT_EQ(current.Name(), malicious_target.Name());
+    // malicious rootfs is not installed, however there is no any installation error
+    ASSERT_NE(current.Sha256Hash(), malicious_target.Sha256Hash());
+    ASSERT_EQ(current.Sha256Hash(), valid_target.Sha256Hash());
+    ASSERT_EQ(current.AppsJson(), valid_target.AppsJson());
+  }
+}
+
+TEST_F(ApiClientTest, InstallTargetWithHackedApps) {
+  auto liteclient = createLiteClient();
+  ASSERT_TRUE(targetsMatch(liteclient->getCurrent(), getInitialTarget()));
+
+  std::vector<AppEngine::App> apps{{"app-01", "app-01-URI"}};
+  auto valid_target = Target::toTufTarget(createAppTarget(apps));
+  auto malicious_apps{valid_target.AppsJson()};
+  malicious_apps["app-01"]["uri"] = "malicious_app_uri";
+  auto custom_data{valid_target.Custom()};
+  custom_data[TufTarget::ComposeAppField] = malicious_apps;
+  TufTarget malicious_target{valid_target.Name(), valid_target.Sha256Hash(), valid_target.Version(), custom_data};
+  {
+    AkliteClient client(liteclient);
+
+    auto result = client.CheckIn();
+    ASSERT_EQ(CheckInResult::Status::Ok, result.status);
+    auto latest = result.GetLatest();
+    ASSERT_EQ(latest.Name(), malicious_target.Name());
+    auto installer = client.Installer(malicious_target, "", "", InstallMode::OstreeOnly);
+    ASSERT_NE(nullptr, installer);
+    auto dresult = installer->Download();
+    ASSERT_EQ(DownloadResult::Status::Ok, dresult.status);
+
+    auto iresult = installer->Install();
+    ASSERT_EQ(InstallResult::Status::AppsNeedCompletion, iresult.status);
+  }
+  {
+    AkliteClient client(liteclient);
+
+    auto ciresult = client.CompleteInstallation();
+    ASSERT_EQ(InstallResult::Status::Ok, ciresult.status);
+    const auto current{client.GetCurrent()};
+    ASSERT_EQ(current.Name(), malicious_target.Name());
+    ASSERT_EQ(current.Sha256Hash(), malicious_target.Sha256Hash());
+    // malicious apps are not installed, however there is no any installation error
+    ASSERT_NE(current.AppsJson(), malicious_target.AppsJson());
+    ASSERT_EQ(current.Sha256Hash(), valid_target.Sha256Hash());
+    ASSERT_EQ(current.AppsJson(), valid_target.AppsJson());
   }
 }
 


### PR DESCRIPTION
Strengthen target check before starting installation:
 - make sure the target specified to the installer matches the one that is found in the local TUF repo;
 - make sure the target specified to the local installer is available locally - its content is found in the specified local folder during the check-in phase.