### PR TITLE
cli: offline: Let client to decide on install mode

### DIFF
--- a/apps/aklite-offline/cmds.cpp
+++ b/apps/aklite-offline/cmds.cpp
@@ -20,7 +20,7 @@ int InstallCmd::installUpdate(const po::variables_map& vm, const boost::filesyst
   const LocalUpdateSource local_update_source{.tuf_repo = (src_dir / "tuf").string(),
                                               .ostree_repo = (src_dir / "ostree_repo").string(),
                                               .app_store = (src_dir / "apps").string()};
-  auto ret_code{aklite::cli::Install(client, -1, "", "", force_downgrade, &local_update_source)};
+  auto ret_code{aklite::cli::Install(client, -1, "", InstallMode::OstreeOnly, force_downgrade, &local_update_source)};
   switch (ret_code) {
     case aklite::cli::StatusCode::InstallAppsNeedFinalization: {
       // TBD: The former `aklite-offline` sets `10` as a an exit/status code, while

--- a/include/aktualizr-lite/cli/cli.h
+++ b/include/aktualizr-lite/cli/cli.h
@@ -4,8 +4,7 @@
 #include <cstdlib>
 #include <string>
 
-class AkliteClient;
-class LocalUpdateSource;
+#include "aktualizr-lite/api.h"
 
 namespace aklite::cli {
 
@@ -38,7 +37,7 @@ StatusCode CheckLocal(AkliteClient &client, const std::string &tuf_repo, const s
                       const std::string &apps_dir = "");
 
 StatusCode Install(AkliteClient &client, int version = -1, const std::string &target_name = "",
-                   const std::string &install_mode = "", bool force_downgrade = true,
+                   InstallMode install_mode = InstallMode::All, bool force_downgrade = true,
                    const LocalUpdateSource *local_update_source = nullptr);
 StatusCode CompleteInstall(AkliteClient &client);
 

--- a/src/api.cc
+++ b/src/api.cc
@@ -625,12 +625,6 @@ class LocalLiteInstall : public LiteInstall {
     // make LiteClient to pull from a local ostree repo
     offline_update_config_.pacman.ostree_server = "file://" + local_update_source_.ostree_repo;
 
-    // use the ostree only install mode for offline update by default, so updated containers
-    // are created and started on finalization (aka install completion, run command)
-    if (offline_update_config_.pacman.type != RootfsTreeManager::Name) {
-      mode_ = InstallMode::OstreeOnly;
-    }
-
     ostree_sysroot_ = std::make_shared<OSTree::Sysroot>(offline_update_config_.pacman);
     storage_ = INvStorage::newStorage(offline_update_config_.storage, false, StorageClient::kTUF);
   }

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -62,17 +62,8 @@ StatusCode CheckLocal(AkliteClient &client, const std::string &tuf_repo, const s
   return res2StatusCode<CheckInResult::Status>(c2s, cr.status);
 }
 
-StatusCode Install(AkliteClient &client, int version, const std::string &target_name, const std::string &install_mode,
+StatusCode Install(AkliteClient &client, int version, const std::string &target_name, InstallMode install_mode,
                    bool force_downgrade, const LocalUpdateSource *local_update_source) {
-  const static std::unordered_map<std::string, InstallMode> str2Mode = {{"delay-app-install", InstallMode::OstreeOnly}};
-  InstallMode mode{InstallMode::All};
-  if (!install_mode.empty()) {
-    if (str2Mode.count(install_mode) == 0) {
-      LOG_WARNING << "Unsupported installation mode: " << install_mode << "; falling back to the default install mode";
-    } else {
-      mode = str2Mode.at(install_mode);
-    }
-  }
   // Check if the device is in a correct state to start a new update
   if (client.IsInstallationInProgress()) {
     LOG_ERROR << "Cannot start Target installation since there is ongoing installation; target: "
@@ -136,7 +127,7 @@ StatusCode Install(AkliteClient &client, int version, const std::string &target_
     LOG_INFO << "To New Target: " << target.Name();
   }
 
-  const auto installer = client.Installer(target, "", "", mode, local_update_source);
+  const auto installer = client.Installer(target, "", "", install_mode, local_update_source);
   if (installer == nullptr) {
     LOG_ERROR << "Unexpected error: installer couldn't find Target in the DB; try again later";
     return StatusCode::UnknownError;

--- a/src/main.cc
+++ b/src/main.cc
@@ -444,7 +444,16 @@ static int cli_install(LiteClient& client, const bpo::variables_map& params) {
   std::shared_ptr<LiteClient> client_ptr{&client, [](LiteClient* /*unused*/) {}};
   AkliteClient akclient{client_ptr, false, true};
 
-  return static_cast<int>(aklite::cli::Install(akclient, version, target_name, install_mode));
+  const static std::unordered_map<std::string, InstallMode> str2Mode = {{"delay-app-install", InstallMode::OstreeOnly}};
+  InstallMode mode{InstallMode::All};
+  if (!install_mode.empty()) {
+    if (str2Mode.count(install_mode) == 0) {
+      LOG_WARNING << "Unsupported installation mode: " << install_mode << "; falling back to the default install mode";
+    } else {
+      mode = str2Mode.at(install_mode);
+    }
+  }
+  return static_cast<int>(aklite::cli::Install(akclient, version, target_name, mode));
 }
 
 static int cli_complete_install(LiteClient& client, const bpo::variables_map& params) {

--- a/tests/aklite_offline_test.cc
+++ b/tests/aklite_offline_test.cc
@@ -202,7 +202,7 @@ class AkliteOffline : public ::testing::Test {
 
   aklite::cli::StatusCode install() {
     AkliteClient client(createLiteClient());
-    return aklite::cli::Install(client, -1, "", "", false, src());
+    return aklite::cli::Install(client, -1, "", InstallMode::OstreeOnly, false, src());
   }
 
   aklite::cli::StatusCode run() {


### PR DESCRIPTION
Don't enforce the "ostree only" installation mode for an offline update. Instead, let a user/client decide which of the installation modes to apply.