### PR TITLE
Offline update corner case fixes

### DIFF
--- a/apps/aklite-offline/cmds.h
+++ b/apps/aklite-offline/cmds.h
@@ -70,9 +70,8 @@ class InstallCmd : public Cmd {
       return installUpdate(vm, boost::filesystem::canonical(vm["src-dir"].as<boost::filesystem::path>()),
                            force_downgrade);
     } catch (const std::exception& exc) {
-      std::cerr << "Failed to install offline update; src-dir: "
-                << boost::filesystem::canonical(vm["src-dir"].as<boost::filesystem::path>().string())
-                << ", err: " << exc.what();
+      std::cerr << "Failed to install offline update; src-dir: " << vm["src-dir"].as<boost::filesystem::path>().string()
+                << ", err: " << exc.what() << "\n";
       return EXIT_FAILURE;
     }
   }

--- a/src/api.cc
+++ b/src/api.cc
@@ -340,7 +340,12 @@ CheckInResult AkliteClient::CheckInLocal(const LocalUpdateSource* local_update_s
       .AppsDir = local_update_source->app_store,
   };
 
-  if (result.status == CheckInResult::Status::Failed) {
+  if (result.status == CheckInResult::Status::OkCached) {
+    // There is no reason to allow offline update if the specified TUF metadata are invalid,
+    // even if a local copy is valid.
+    result.status = CheckInResult::Status::Failed;
+  }
+  if (!result) {
     return result;
   }
 

--- a/src/api.cc
+++ b/src/api.cc
@@ -631,6 +631,12 @@ class LocalLiteInstall : public LiteInstall {
 
     ostree_sysroot_ = std::make_shared<OSTree::Sysroot>(offline_update_config_.pacman);
     storage_ = INvStorage::newStorage(offline_update_config_.storage, false, StorageClient::kTUF);
+    if (offline_update_config_.pacman.type == ComposeAppManager::Name &&
+        offline_update_config_.pacman.extra.count("reset_apps") == 0) {
+      LOG_ERROR << "Cannot perform offline update if non-restorable app engine is set; set `[pacman].reset_apps = "
+                   "\"\"` in the device config.";
+      throw std::invalid_argument("Invalid app engine type");
+    }
   }
 
   DownloadResult Download() override {

--- a/src/liteclient.h
+++ b/src/liteclient.h
@@ -98,6 +98,7 @@ class LiteClient {
   data::InstallationResult finalizePendingUpdate(boost::optional<Uptane::Target>& target);
   void initRequestHeaders(std::vector<std::string>& headers) const;
   void updateRequestHeaders();
+  static bool isRegistered(const KeyManager& key_manager);
 
   boost::filesystem::path callback_program;
   std::unique_ptr<KeyManager> key_manager_;

--- a/tests/test_lite.sh
+++ b/tests/test_lite.sh
@@ -114,6 +114,7 @@ booted = "staged"
 docker_images_reload_cmd = "/bin/true"
 compose_apps_root = "$sota_dir/compose-apps"
 compose_apps_tree = "$sota_dir/apps-tree"
+enforce_composeapp_engine = ""
 EOF
 
 ## Check that we can do the info command


### PR DESCRIPTION
- Fix offline update for non-registered devices
- Don't allow offline update if the provided TUF meta are invalid even if a local/cached one are valid.
- Fix error printing if the specified source directory doesn't exist.