### PR TITLE
[WIP] Allow install to be called independently of pull

### DIFF
--- a/src/liteclient.cc
+++ b/src/liteclient.cc
@@ -698,6 +698,12 @@ DownloadResultWithStat LiteClient::download(const Uptane::Target& target, const 
 }
 
 data::ResultCode::Numeric LiteClient::install(const Uptane::Target& target, InstallMode install_mode) {
+  auto status = package_manager_->verifyTarget(target);
+  if (status != TargetStatus::kGood) {
+    LOG_ERROR << "Unable to install target " << target.filename() << ". Verification failed.";
+    return data::ResultCode::Numeric::kVerificationFailed;
+  }
+
   notifyInstallStarted(target);
   auto iresult = installPackage(target, install_mode);
   if (iresult.result_code.num_code == data::ResultCode::Numeric::kNeedCompletion) {


### PR DESCRIPTION
These are the changes required to support a standalone install operation. They allow apps to be installed properly, and the installation to fail at the right time when the target was not pulled.

At the current stage, there is some code duplication that could be avoided (see `TDB` comments).

A subsequent PR will include the custom client commands allowing a standalone install operation.