### PR TITLE
Allow install to be called independently of pull - V2

### DIFF
--- a/src/api.cc
+++ b/src/api.cc
@@ -404,6 +404,14 @@ class LiteInstall : public InstallContext {
   InstallResult Install() override {
     client_->logTarget("Installing: ", *target_);
 
+    // Call appsInSync to update applications list inside the package manager
+    client_->appsInSync(*target_);
+    // setAppsNotChecked is required to force a re-load of apps list in case of a new Download operation
+    client_->setAppsNotChecked();
+    if (client_->VerifyTarget(*target_) != TargetStatus::kGood) {
+      return InstallResult{InstallResult::Status::DownloadFailed, ""};
+    }
+
     auto rc = client_->install(*target_, mode_);
     auto status = InstallResult::Status::Failed;
     if (rc == data::ResultCode::Numeric::kNeedCompletion) {

--- a/src/composeappmanager.cc
+++ b/src/composeappmanager.cc
@@ -326,6 +326,10 @@ TargetStatus ComposeAppManager::verifyTarget(const Uptane::Target& target) const
   all_apps_to_fetch.insert(cur_apps_to_fetch_.begin(), cur_apps_to_fetch_.end());
 
   for (const auto& pair : all_apps_to_fetch) {
+    if (!app_engine_->isFetched({pair.first, pair.second})) {
+      return TargetStatus::kNotFound;
+    }
+
     if (!app_engine_->verify({pair.first, pair.second})) {
       return TargetStatus::kInvalid;
     }

--- a/tests/apiclient_test.cc
+++ b/tests/apiclient_test.cc
@@ -342,6 +342,34 @@ TEST_F(ApiClientTest, InstallModeOstreeOnlyIfJustApps) {
   }
 }
 
+TEST_F(ApiClientTest, InstallWithoutDownload) {
+  auto liteclient = createLiteClient();
+  ASSERT_TRUE(targetsMatch(liteclient->getCurrent(), getInitialTarget()));
+
+  // Create a new Target: update rootfs and commit it into Treehub's repo
+  auto new_target = createTarget();
+
+  AkliteClient client(liteclient);
+  auto result = client.CheckIn();
+  ASSERT_EQ(CheckInResult::Status::Ok, result.status);
+
+  auto latest = result.GetLatest();
+
+  auto installer = client.Installer(latest);
+  ASSERT_NE(nullptr, installer);
+
+  // Install before Download will fail
+  auto iresult = installer->Install();
+  ASSERT_EQ(InstallResult::Status::DownloadFailed, iresult.status);
+
+  auto dresult = installer->Download();
+  ASSERT_EQ(DownloadResult::Status::Ok, dresult.status);
+
+  // After Download, installation of the same target should succeed
+  iresult = installer->Install();
+  ASSERT_EQ(InstallResult::Status::NeedsCompletion, iresult.status);
+}
+
 TEST_F(ApiClientTest, Secondaries) {
   AkliteClient client(createLiteClient(InitialVersion::kOff));
   std::vector<SecondaryEcu> ecus;

--- a/tests/apiclient_test.cc
+++ b/tests/apiclient_test.cc
@@ -370,6 +370,74 @@ TEST_F(ApiClientTest, InstallWithoutDownload) {
   ASSERT_EQ(InstallResult::Status::NeedsCompletion, iresult.status);
 }
 
+TEST_F(ApiClientTest, InstallDownloadInSeparateInstances) {
+  auto liteclient = createLiteClient();
+  ASSERT_TRUE(targetsMatch(liteclient->getCurrent(), getInitialTarget()));
+
+  std::vector<AppEngine::App> apps_1{{"app-01", "app-01-URI"}};
+  auto target_1 = createAppTarget(apps_1);
+
+  // Download using one AkliteClient instance
+  {
+    AkliteClient client(liteclient);
+    auto result = client.CheckIn();
+    ASSERT_EQ(CheckInResult::Status::Ok, result.status);
+
+    auto latest = result.GetLatest();
+    auto installer = client.Installer(latest);
+    ASSERT_NE(nullptr, installer);
+    auto dresult = installer->Download();
+    ASSERT_EQ(DownloadResult::Status::Ok, dresult.status);
+    ASSERT_FALSE(targetsMatch(liteclient->getCurrent(), target_1));
+  }
+
+  // Install using another AkliteClient instance
+  {
+    AkliteClient client(liteclient);
+    auto result = client.CheckIn();
+    ASSERT_EQ(CheckInResult::Status::Ok, result.status);
+
+    auto latest = result.GetLatest();
+    auto installer = client.Installer(latest);
+    ASSERT_NE(nullptr, installer);
+    auto iresult = installer->Install();
+    ASSERT_EQ(InstallResult::Status::Ok, iresult.status);
+    ASSERT_TRUE(targetsMatch(liteclient->getCurrent(), target_1));
+  }
+
+  // Repeat same process just updating one app
+  std::vector<AppEngine::App> apps_2{{"app-01", "app-01-URI-NEW"}};
+  auto target_2 = createAppTarget(apps_2);
+
+  // Download using one AkliteClient instance
+  {
+    AkliteClient client(liteclient);
+    auto result = client.CheckIn();
+    ASSERT_EQ(CheckInResult::Status::Ok, result.status);
+
+    auto latest = result.GetLatest();
+    auto installer = client.Installer(latest);
+    ASSERT_NE(nullptr, installer);
+    auto dresult = installer->Download();
+    ASSERT_EQ(DownloadResult::Status::Ok, dresult.status);
+    ASSERT_TRUE(targetsMatch(liteclient->getCurrent(), target_1));
+  }
+
+  // Install using another AkliteClient instance
+  {
+    AkliteClient client(liteclient);
+    auto result = client.CheckIn();
+    ASSERT_EQ(CheckInResult::Status::Ok, result.status);
+
+    auto latest = result.GetLatest();
+    auto installer = client.Installer(latest);
+    ASSERT_NE(nullptr, installer);
+    auto iresult = installer->Install();
+    ASSERT_EQ(InstallResult::Status::Ok, iresult.status);
+    ASSERT_TRUE(targetsMatch(liteclient->getCurrent(), target_2));
+  }
+}
+
 TEST_F(ApiClientTest, Secondaries) {
   AkliteClient client(createLiteClient(InitialVersion::kOff));
   std::vector<SecondaryEcu> ecus;


### PR DESCRIPTION
[Creating a new PR since the current solution is very different (code wise) to the original PR #300.]

These are the changes required to support a standalone install operation. They allow apps to be installed properly, and the installation to fail at the right time when the target was not pulled.

A subsequent PR will include the custom client commands allowing a standalone install operation.
