### PR TITLE
custom-client: Add additional running modes, with separate commands

### DIFF
--- a/apps/aklite-offline/cmds.cpp
+++ b/apps/aklite-offline/cmds.cpp
@@ -9,8 +9,10 @@ namespace aklite_offline {
 
 int CheckCmd::checkSrcDir(const po::variables_map& vm, const boost::filesystem::path& src_dir) const {
   AkliteClient client(vm, false, false);
-  const auto ret_code{aklite::cli::CheckLocal(client, (src_dir / "tuf").string(), (src_dir / "ostree_repo").string(),
-                                              (src_dir / "apps").string())};
+  const LocalUpdateSource local_update_source{.tuf_repo = (src_dir / "tuf").string(),
+                                              .ostree_repo = (src_dir / "ostree_repo").string(),
+                                              .app_store = (src_dir / "apps").string()};
+  const auto ret_code{aklite::cli::CheckIn(client, &local_update_source)};
   return static_cast<int>(ret_code);
 }
 

--- a/examples/custom-client-cxx/CMakeLists.txt
+++ b/examples/custom-client-cxx/CMakeLists.txt
@@ -1,8 +1,18 @@
 cmake_minimum_required (VERSION 3.5)
-project(custom-sota-client)
 
-add_executable(custom-sota-client main.cc)
+set(TARGET custom-sota-client)
+project(${TARGET})
 
-target_compile_definitions(custom-sota-client PRIVATE BOOST_LOG_DYN_LINK)
-target_link_libraries(custom-sota-client boost_log pthread aktualizr_lite aktualizr)
-install(TARGETS custom-sota-client RUNTIME DESTINATION bin)
+set(SRC
+  daemon.cpp
+  cli.cpp
+  main.cpp
+)
+
+add_executable(${TARGET} ${SRC})
+target_link_libraries(${TARGET} boost_program_options)
+
+target_compile_definitions(${TARGET} PRIVATE BOOST_LOG_DYN_LINK)
+target_link_libraries(${TARGET} boost_log boost_filesystem pthread aktualizr_lite aktualizr)
+install(TARGETS ${TARGET} RUNTIME DESTINATION bin)
+

--- a/examples/custom-client-cxx/cli.cpp
+++ b/examples/custom-client-cxx/cli.cpp
@@ -1,0 +1,205 @@
+#include <iostream>
+#include <thread>
+
+#include <boost/filesystem.hpp>
+#include <boost/log/core.hpp>
+#include <boost/log/expressions.hpp>
+#include <boost/log/trivial.hpp>
+#include <boost/process.hpp>
+
+#include "aktualizr-lite/api.h"
+#include "aktualizr-lite/cli/cli.h"
+#include "cli.h"
+
+#define LOG_INFO BOOST_LOG_TRIVIAL(info)
+#define LOG_WARNING BOOST_LOG_TRIVIAL(warning)
+#define LOG_ERROR BOOST_LOG_TRIVIAL(error)
+
+static void print_status(aklite::cli::StatusCode ret) {
+  switch (ret) {
+    case aklite::cli::StatusCode::Ok:
+      std::cout << "SUCCESS";
+      break;
+
+    // Possible return codes for check, pull and install commands
+    case aklite::cli::StatusCode::CheckinOkCached:
+      std::cout << "SUCCESS: Unable to fetch updated TUF metadata, but stored metadata is valid";
+      break;
+    case aklite::cli::StatusCode::CheckinFailure:
+      std::cout << "FAILURE: Unable to get TUF metadata";
+      break;
+    case aklite::cli::StatusCode::CheckinNoMatchingTargets:
+      std::cout << "FAILURE: There is no matching target for the device";
+      break;
+    case aklite::cli::StatusCode::CheckinNoTargetContent:
+      std::cout << "FAILURE: There is no target metadata in the local path";
+      break;
+    case aklite::cli::StatusCode::TufTargetNotFound:
+      std::cout << "FAILURE: Selected target not found";
+      break;
+
+    // Possible return codes for pull and install commands
+    case aklite::cli::StatusCode::InstallationInProgress:
+      std::cout << "FAILURE: Unable to pull/install: there is an installation that needs completion";
+      break;
+    case aklite::cli::StatusCode::DownloadFailure:
+      std::cout << "FAILURE: Unable to download target";
+      break;
+    case aklite::cli::StatusCode::DownloadFailureVerificationFailed:
+      std::cout << "FAILURE: Target downloaded but verification has failed";
+      break;
+    case aklite::cli::StatusCode::DownloadFailureNoSpace:
+      std::cout << "FAILURE: There is no enough free space to download the target";
+      break;
+    case aklite::cli::StatusCode::InstallAlreadyInstalled:
+      std::cout << "FAILURE: Selected target is already installed";
+      break;
+    case aklite::cli::StatusCode::InstallDowngradeAttempt:
+      // Should not hit this error, since force_downgrade is set to true
+      std::cout << "FAILURE: Attempted to install a previous version";
+      break;
+
+    // Possible return codes for install command
+    case aklite::cli::StatusCode::InstallAppsNeedFinalization:
+      std::cout << "SUCCESS: Execute `custom-sota-client run` command to finalize installation";
+      break;
+    case aklite::cli::StatusCode::InstallNeedsRebootForBootFw:
+      std::cout << "FAILURE: Reboot is required before installing the target";
+      break;
+    case aklite::cli::StatusCode::InstallAppPullFailure:
+      std::cout << "FAILURE: Unable read target data, make sure it was pulled";
+      break;
+
+    // Possible return codes for install and run command
+    case aklite::cli::StatusCode::InstallNeedsReboot:
+      std::cout << "SUCCESS: Reboot to finalize installation";
+      break;
+    case aklite::cli::StatusCode::OkNeedsRebootForBootFw:
+      std::cout << "SUCCESS: Reboot to finalize bootloader installation";
+      break;
+    case aklite::cli::StatusCode::InstallRollbackNeedsReboot:
+      std::cout << "FAILURE: Installation failed, rollback initiated but requires reboot to finalize";
+      break;
+
+    // Possible return codes for run command
+    case aklite::cli::StatusCode::NoPendingInstallation:
+      std::cout << "FAILURE: No pending installation to run";
+      break;
+    case aklite::cli::StatusCode::InstallRollbackOk:
+    case aklite::cli::StatusCode::InstallOfflineRollbackOk:
+      std::cout << "FAILURE: Installation failed, rollback performed";
+      break;
+    case aklite::cli::StatusCode::InstallRollbackFailed:
+      std::cout << "FAILURE: Installation failed and rollback operation was not successful";
+      break;
+    case aklite::cli::StatusCode::UnknownError:
+      std::cout << "FAILURE: Unknown error";
+      break;
+
+    default:
+      std::cout << "FAILURE: Unexpected return code " << static_cast<int>(ret);
+      break;
+  }
+  std::cout << std::endl;
+}
+
+static std::unique_ptr<AkliteClient> init_client(bool online_mode) {
+  boost::log::core::get()->set_filter(boost::log::trivial::severity >= boost::log::trivial::info);
+
+  std::vector<boost::filesystem::path> cfg_dirs;
+
+  auto env{boost::this_process::environment()};
+  if (env.end() != env.find("AKLITE_CONFIG_DIR")) {
+    cfg_dirs.emplace_back(env.get("AKLITE_CONFIG_DIR"));
+  } else if (online_mode) {
+    cfg_dirs = AkliteClient::CONFIG_DIRS;
+  } else {
+    // sota.toml is optional in offline mode
+    for (const auto& cfg : AkliteClient::CONFIG_DIRS) {
+      if (boost::filesystem::exists(cfg)) {
+        cfg_dirs.emplace_back(cfg);
+      }
+    }
+  }
+
+  try {
+    return std::make_unique<AkliteClient>(cfg_dirs, false, false);
+  } catch (const std::exception& exc) {
+    LOG_ERROR << "Failed to initialize the client: " << exc.what();
+    return nullptr;
+  }
+}
+
+int cmd_check(std::string local_repo_path) {
+  auto client = init_client(local_repo_path.empty());
+  if (client == nullptr) {
+    return EXIT_FAILURE;
+  }
+
+  LocalUpdateSource local_update_source;
+  if (local_repo_path.empty()) {
+    LOG_INFO << "Online mode";
+  } else {
+    auto abs_repo_path = boost::filesystem::canonical(local_repo_path).string();
+    LOG_INFO << "Offline mode. Updates path=" << abs_repo_path;
+    local_update_source = {abs_repo_path + "/tuf", abs_repo_path + "/ostree_repo", abs_repo_path + "/apps"};
+  }
+
+  auto status = aklite::cli::CheckIn(*client, local_repo_path.empty() ? nullptr : &local_update_source);
+  print_status(status);
+  return aklite::cli::IsSuccessCode(status) ? EXIT_SUCCESS : EXIT_FAILURE;
+}
+
+int cmd_pull(std::string target_name, std::string local_repo_path) {
+  auto client = init_client(local_repo_path.empty());
+  if (client == nullptr) {
+    return EXIT_FAILURE;
+  }
+
+  LocalUpdateSource local_update_source;
+  if (local_repo_path.empty()) {
+    LOG_INFO << "Online mode";
+  } else {
+    auto abs_repo_path = boost::filesystem::canonical(local_repo_path).string();
+    LOG_INFO << "Offline mode. Updates path=" << abs_repo_path;
+    local_update_source = {abs_repo_path + "/tuf", abs_repo_path + "/ostree_repo", abs_repo_path + "/apps"};
+  }
+
+  auto status =
+      aklite::cli::Pull(*client, -1, target_name, true, local_repo_path.empty() ? nullptr : &local_update_source);
+  print_status(status);
+  return aklite::cli::IsSuccessCode(status) ? EXIT_SUCCESS : EXIT_FAILURE;
+}
+
+int cmd_install(std::string target_name, std::string local_repo_path) {
+  auto client = init_client(local_repo_path.empty());
+  if (client == nullptr) {
+    return EXIT_FAILURE;
+  }
+
+  LocalUpdateSource local_update_source;
+  if (local_repo_path.empty()) {
+    LOG_INFO << "Online mode";
+  } else {
+    auto abs_repo_path = boost::filesystem::canonical(local_repo_path).string();
+    LOG_INFO << "Offline mode. Updates path=" << abs_repo_path;
+    local_update_source = {abs_repo_path + "/tuf", abs_repo_path + "/ostree_repo", abs_repo_path + "/apps"};
+  }
+
+  auto status =
+      aklite::cli::Install(*client, -1, target_name, InstallMode::All, true,
+                           local_repo_path.empty() ? nullptr : &local_update_source, aklite::cli::PullMode::None);
+  print_status(status);
+  return aklite::cli::IsSuccessCode(status) ? EXIT_SUCCESS : EXIT_FAILURE;
+}
+
+int cmd_run() {
+  auto client = init_client(false);
+  if (client == nullptr) {
+    return EXIT_FAILURE;
+  }
+
+  auto status = aklite::cli::CompleteInstall(*client);
+  print_status(status);
+  return aklite::cli::IsSuccessCode(status) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/examples/custom-client-cxx/cli.h
+++ b/examples/custom-client-cxx/cli.h
@@ -1,0 +1,12 @@
+#ifndef AKLITE_AKLITE_CUSTOM_CLI_H
+#define AKLITE_AKLITE_CUSTOM_CLI_H
+
+#include <string>
+
+int cmd_pull(std::string target_name, std::string local_repo_path);
+int cmd_install(std::string target_name, std::string local_repo_path);
+int cmd_check(std::string local_repo_path);
+int cmd_daemon(std::string local_repo_path);
+int cmd_run();  
+
+#endif

--- a/examples/custom-client-cxx/cmds.h
+++ b/examples/custom-client-cxx/cmds.h
@@ -1,0 +1,149 @@
+#ifndef AKLITE_CUSTOM_CMD_H
+#define AKLITE_CUSTOM_CMD_H
+
+#include <string>
+
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/split.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/program_options.hpp>
+#include <boost/log/core.hpp>
+#include <boost/log/trivial.hpp>
+#include <boost/log/expressions.hpp>
+
+#include "cli.h"
+
+#define LOG_INFO    BOOST_LOG_TRIVIAL(info)
+#define LOG_WARNING BOOST_LOG_TRIVIAL(warning)
+#define LOG_ERROR   BOOST_LOG_TRIVIAL(error)
+
+namespace po = boost::program_options;
+
+class Cmd {
+ public:
+  using Ptr = std::shared_ptr<Cmd>;
+  const std::string& name() const { return _name; }
+  const po::options_description& options() const { return _options; }
+  const std::vector<std::string>& pos_options() const { return _pos_options; }
+
+  virtual int operator()(const po::variables_map& vm) const = 0;
+
+ protected:
+  Cmd(std::string name, const po::options_description& options, std::vector<std::string>& pos_options) : _name{std::move(name)}, _options{options}, _pos_options{pos_options} {}
+
+ private:
+  const std::string _name;
+  const po::options_description& _options;
+  const std::vector<std::string>& _pos_options;
+};
+
+class CheckCmd : public Cmd {
+ public:
+  CheckCmd() : Cmd("check", _options, _pos_options) {
+    _options.add_options()("help,h", "print usage")(
+        "src-dir,s", po::value<std::string>()->default_value(std::string("")), "Directory that contains an update");
+  }
+
+  int operator()(const po::variables_map& vm) const override {
+    try {
+      return cmd_check(vm["src-dir"].as<std::string>());
+    } catch (const std::exception& exc) {
+      LOG_ERROR << "Failed to check the update source directory: " << exc.what();
+      return EXIT_FAILURE;
+    }
+  }
+
+ private:
+  po::options_description _options;
+  std::vector<std::string> _pos_options;
+};
+
+class InstallCmd : public Cmd {
+ public:
+  InstallCmd() : Cmd("install", _options, _pos_options) {
+    _options.add_options()("help,h", "print usage")(
+        "src-dir,s", po::value<std::string>()->default_value(std::string("")), "Directory that contains an update")(
+        "target,t", po::value<std::string>()->default_value(std::string("")), "Target name");
+    _pos_options.emplace_back("target");
+  }
+
+  int operator()(const po::variables_map& vm) const override {
+    try {
+      return cmd_install(vm["target"].as<std::string>(), vm["src-dir"].as<std::string>());
+    } catch (const std::exception& exc) {
+      LOG_ERROR << "Failed to install target: " << exc.what();
+      return EXIT_FAILURE;
+    }
+  }
+
+ private:
+  po::options_description _options;
+  std::vector<std::string> _pos_options;
+  bool force_downgrade{false};
+};
+
+class RunCmd : public Cmd {
+ public:
+  RunCmd() : Cmd("run", _options, _pos_options) {
+    _options.add_options()("help,h", "print usage");
+  }
+
+  int operator()(const po::variables_map& vm) const override {
+    try {
+      return cmd_run();
+    } catch (const std::exception& exc) {
+      LOG_ERROR << "Failed to list Apps: " << exc.what();
+      return EXIT_FAILURE;
+    }
+  }
+
+ private:
+  po::options_description _options;
+  std::vector<std::string> _pos_options;
+};
+
+class PullCmd : public Cmd {
+ public:
+  PullCmd() : Cmd("pull", _options, _pos_options) {
+    _options.add_options()("help,h", "print usage")(
+        "src-dir,s", po::value<std::string>()->default_value(std::string("")), "Directory that contains an update")(
+        "target,t", po::value<std::string>()->default_value(std::string("")), "Target name");
+    _pos_options.emplace_back("target");
+  }
+
+  int operator()(const po::variables_map& vm) const override {
+    try {
+      return cmd_pull(vm["target"].as<std::string>(), vm["src-dir"].as<std::string>());
+    } catch (const std::exception& exc) {
+      LOG_ERROR << "Failed to get current status information: " << exc.what();
+      return EXIT_FAILURE;
+    }
+  }
+
+ private:
+  po::options_description _options;
+  std::vector<std::string> _pos_options;
+};
+
+class DaemonCmd : public Cmd {
+ public:
+  DaemonCmd() : Cmd("daemon", _options, _pos_options) {
+    _options.add_options()("help,h", "print usage")(
+      "src-dir,s", po::value<std::string>()->default_value(std::string("")), "Directory that contains an update");
+  }
+
+  int operator()(const po::variables_map& vm) const override {
+    try {
+      return cmd_daemon(vm["src-dir"].as<std::string>());
+    } catch (const std::exception& exc) {
+      LOG_ERROR << "Failed to get current status information: " << exc.what();
+      return EXIT_FAILURE;
+    }
+  }
+
+ private:
+  po::options_description _options;
+  std::vector<std::string> _pos_options;
+};
+
+#endif  // AKLITE_CUSTOM_CMD_H

--- a/examples/custom-client-cxx/main.cpp
+++ b/examples/custom-client-cxx/main.cpp
@@ -1,0 +1,87 @@
+#include <iostream>
+#include <vector>
+
+#include <boost/program_options.hpp>
+
+#include "cmds.h"
+
+namespace po = boost::program_options;
+
+static std::vector<Cmd::Ptr> cmds{
+    std::make_shared<CheckCmd>(),
+    std::make_shared<InstallCmd>(),
+    std::make_shared<RunCmd>(),
+    std::make_shared<PullCmd>(),
+    std::make_shared<DaemonCmd>(),
+};
+
+static void print_usage() {
+  std::cout << "Usage:\n\t custom-sota-client [cmd] [options]\nSupported commands: ";
+  for (const auto& cmd : cmds) {
+    std::cout << cmd->name() << " ";
+  }
+  std::cout << std::endl;
+  std::cout << "Default command is \"daemon\"" << std::endl;
+}
+
+int main(int argc, char** argv) {
+  std::string cmd_name = "daemon";
+
+  if (argc > 1) {
+    cmd_name = {argv[1]};
+    if (cmd_name == "--help" || cmd_name == "-h") {
+      print_usage();
+      exit(EXIT_SUCCESS);
+    }
+  }
+
+  const auto find_it{std::find_if(cmds.begin(), cmds.end(), [&cmd_name](const Cmd::Ptr& cmd) {
+    return cmd->name() == cmd_name;
+  })};
+
+  if (cmds.end() == find_it) {
+    LOG_ERROR << "Unsupported command: " << cmd_name << "\n";
+    print_usage();
+    exit(EXIT_FAILURE);
+  }
+
+  LOG_INFO << "Command: " << cmd_name;
+
+  const Cmd& cmd{**find_it};
+  po::options_description cmd_opts{cmd.options()};
+  po::variables_map vm;
+  po::positional_options_description run_pos;
+  run_pos.add("cmd", 1);
+  po::options_description arg_opts;
+  arg_opts.add_options()("cmd", po::value<std::string>());
+  arg_opts.add(cmd_opts);
+  auto pos_opts = cmd.pos_options();
+  for (const auto& option : pos_opts) {
+    run_pos.add(option.c_str(), 1);
+  }
+  auto print_usage = [](const std::string& cmd, const std::vector<std::string>& pos_opts,
+                        const po::options_description& opts) {
+    std::cout << "custom-sota-client " << cmd;
+    for (const auto& option : pos_opts) {
+      std::cout << " [" + option + "]";
+    }
+    std::cout << " [options]\n" << opts;
+  };
+
+  try {
+    po::store(po::command_line_parser(argc, argv).options(arg_opts).positional(run_pos).run(), vm);
+    po::notify(vm);
+  } catch (const std::exception& exc) {
+    LOG_ERROR << exc.what() << "\n";
+    print_usage(cmd_name, pos_opts, cmd_opts);
+    exit(EXIT_FAILURE);
+  }
+
+  if (vm.count("help") == 1) {
+    print_usage(vm["cmd"].as<std::string>(), pos_opts, cmd_opts);
+    exit(EXIT_SUCCESS);
+  }
+  boost::log::core::get()->set_filter(boost::log::trivial::severity >= boost::log::trivial::info);
+
+  return cmd(vm);
+}

--- a/include/aktualizr-lite/cli/cli.h
+++ b/include/aktualizr-lite/cli/cli.h
@@ -42,6 +42,8 @@ StatusCode Install(AkliteClient &client, int version = -1, const std::string &ta
                    const LocalUpdateSource *local_update_source = nullptr);
 StatusCode CompleteInstall(AkliteClient &client);
 
+bool IsSuccessCode(StatusCode status);
+
 }  // namespace aklite::cli
 
 #endif  // AKTUALIZR_LITE_CLI_H_

--- a/include/aktualizr-lite/cli/cli.h
+++ b/include/aktualizr-lite/cli/cli.h
@@ -34,12 +34,29 @@ enum class StatusCode {
   InstallRollbackFailed = 130,
 };
 
+/**
+ * The installation mode to be applied. Specified during InstallContext context initialization.
+ */
+enum class PullMode {
+  /**
+   * Default mode, do pull target during install operation.
+   */
+  All = 0,
+  /**
+   * Do no pull target during install. Target is expected to be pulled before.
+   */
+  None,
+};
+
 StatusCode CheckIn(AkliteClient &client, const LocalUpdateSource *local_update_source);
 
+StatusCode Pull(AkliteClient &client, int version = -1, const std::string &target_name = "",
+                bool force_downgrade = true, const LocalUpdateSource *local_update_source = nullptr);
 
 StatusCode Install(AkliteClient &client, int version = -1, const std::string &target_name = "",
                    InstallMode install_mode = InstallMode::All, bool force_downgrade = true,
-                   const LocalUpdateSource *local_update_source = nullptr);
+                   const LocalUpdateSource *local_update_source = nullptr, PullMode pull_mode = PullMode::All);
+
 StatusCode CompleteInstall(AkliteClient &client);
 
 bool IsSuccessCode(StatusCode status);

--- a/include/aktualizr-lite/cli/cli.h
+++ b/include/aktualizr-lite/cli/cli.h
@@ -34,8 +34,8 @@ enum class StatusCode {
   InstallRollbackFailed = 130,
 };
 
-StatusCode CheckLocal(AkliteClient &client, const std::string &tuf_repo, const std::string &ostree_repo,
-                      const std::string &apps_dir = "");
+StatusCode CheckIn(AkliteClient &client, const LocalUpdateSource *local_update_source);
+
 
 StatusCode Install(AkliteClient &client, int version = -1, const std::string &target_name = "",
                    InstallMode install_mode = InstallMode::All, bool force_downgrade = true,

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -41,6 +41,12 @@ static const std::unordered_map<InstallResult::Status, StatusCode> i2s = {
     {InstallResult::Status::DownloadFailed, StatusCode::InstallAppPullFailure},
 };
 
+bool IsSuccessCode(StatusCode status) {
+  return (status == StatusCode::Ok || status == StatusCode::CheckinOkCached ||
+          status == StatusCode::OkNeedsRebootForBootFw || status == StatusCode::InstallNeedsReboot ||
+          status == StatusCode::InstallAppsNeedFinalization);
+}
+
 StatusCode CheckIn(AkliteClient &client, const LocalUpdateSource *local_update_source) {
   CheckInResult cr{CheckInResult::Status::Failed, "", std::vector<TufTarget>{}};
   if (local_update_source == nullptr) {

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -41,10 +41,13 @@ static const std::unordered_map<InstallResult::Status, StatusCode> i2s = {
     {InstallResult::Status::DownloadFailed, StatusCode::InstallAppPullFailure},
 };
 
-StatusCode CheckLocal(AkliteClient &client, const std::string &tuf_repo, const std::string &ostree_repo,
-                      const std::string &apps_dir) {
-  const LocalUpdateSource local_update_source{tuf_repo, ostree_repo, apps_dir};
-  const CheckInResult cr{client.CheckInLocal(&local_update_source)};
+StatusCode CheckIn(AkliteClient &client, const LocalUpdateSource *local_update_source) {
+  CheckInResult cr{CheckInResult::Status::Failed, "", std::vector<TufTarget>{}};
+  if (local_update_source == nullptr) {
+    cr = client.CheckIn();
+  } else {
+    cr = client.CheckInLocal(local_update_source);
+  }
   if (cr) {
     if (cr.Targets().empty()) {
       std::cout << "\nNo Targets found" << std::endl;

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -96,8 +96,20 @@ StatusCode Install(AkliteClient &client, int version, const std::string &target_
     }
   }
   if (target.IsUnknown()) {
-    LOG_ERROR << "No Target found; version: " << (version == -1 ? "latest" : std::to_string(version))
-              << ", hardware ID: " << client.GetConfig().get("provision.primary_ecu_hardware_id", "")
+    std::string target_string;
+    if (version == -1 && target_name.empty()) {
+      target_string = " version: latest,";
+    } else {
+      if (!target_name.empty()) {
+        target_string = " name: " + target_name + ",";
+      }
+      if (version != -1) {
+        target_string += " version: " + std::to_string(version) + ",";
+      }
+    }
+
+    LOG_ERROR << "No Target found;" << target_string
+              << " hardware ID: " << client.GetConfig().get("provision.primary_ecu_hardware_id", "")
               << ", tag: " << client.GetConfig().get("pacman.tags", "");
     return StatusCode::TufTargetNotFound;
   }

--- a/tests/aklite_offline_test.cc
+++ b/tests/aklite_offline_test.cc
@@ -404,8 +404,8 @@ TEST_F(AkliteOffline, OfflineClientCheckinFailure) {
 
   // Now try to do checkin against the outdated TUF repo
   AkliteClient client(createLiteClient());
-  ASSERT_EQ(aklite::cli::StatusCode::CheckinFailure,
-            aklite::cli::CheckLocal(client, outdated_repo_path.string(), src()->ostree_repo, src()->app_store));
+  LocalUpdateSource outdated_src = { outdated_repo_path.string(), src()->ostree_repo, src()->app_store };
+  ASSERT_EQ(aklite::cli::StatusCode::CheckinFailure, aklite::cli::CheckIn(client, &outdated_src));
 }
 
 TEST_F(AkliteOffline, OfflineClientCheckinCheckinNoMatchingTargets) {
@@ -414,8 +414,7 @@ TEST_F(AkliteOffline, OfflineClientCheckinCheckinNoMatchingTargets) {
 
   cfg_.pacman.extra["tags"] = "bad-tag";
   AkliteClient client(createLiteClient());
-  ASSERT_EQ(aklite::cli::StatusCode::CheckinNoMatchingTargets,
-            aklite::cli::CheckLocal(client, src()->tuf_repo, src()->ostree_repo, src()->app_store));
+  ASSERT_EQ(aklite::cli::StatusCode::CheckinNoMatchingTargets, aklite::cli::CheckIn(client, src()));
 }
 
 TEST_F(AkliteOffline, OfflineClientCheckinCheckinNoTargetContent) {
@@ -424,8 +423,7 @@ TEST_F(AkliteOffline, OfflineClientCheckinCheckinNoTargetContent) {
 
   boost::filesystem::remove_all(app_store_.appsDir() / "app-01");
   AkliteClient client(createLiteClient());
-  ASSERT_EQ(aklite::cli::StatusCode::CheckinNoTargetContent,
-            aklite::cli::CheckLocal(client, src()->tuf_repo, src()->ostree_repo, src()->app_store));
+  ASSERT_EQ(aklite::cli::StatusCode::CheckinNoTargetContent, aklite::cli::CheckIn(client, src()));
 }
 
 TEST_F(AkliteOffline, OfflineClient) {


### PR DESCRIPTION
Original running mode now invoked with `custom-sota-daemon`.

Added commands: `check`, `pull`, `install`, `run`.

---
Items for discussion:

- I did not use AkLiteClient (cli.cc) methods, but copied over code from there. We could use `cli.cc`, but from what I understand, methods provided by `api.cc` are the interface for a customized client. If we start to officially provide `cli.cc` methods to external users, that must be a well though decision, as the behavior and signature of `cli.cc` methods should not be changed anymore.

- I avoided code reuse between different commands code. That is to simplify custom solution by users, simply taking one command code and changing it.

- I did not add `log-level` cmd option, but is not hard to add.

- See a few TBD comments bellow, if it is OK to return SUCCESS in those cases.

---
I've been using the new commands for a while, but if the overall structure is OK, I'll do a few more tests before merge.
