### PR TITLE
api: Don't send events if offline update

### DIFF
--- a/src/api.cc
+++ b/src/api.cc
@@ -789,7 +789,7 @@ std::unique_ptr<InstallContext> AkliteClient::Installer(const TufTarget& t, std:
   tuf_repo_->checkMeta();
   for (const auto& tt : tuf_repo_->GetTargets()) {
     if (tt == t) {
-      target = std::make_unique<Uptane::Target>(Target::fromTufTarget(tt));
+      target = std::make_unique<Uptane::Target>(Target::fromTufTarget(t));
       break;
     }
   }

--- a/src/liteclient.cc
+++ b/src/liteclient.cc
@@ -305,7 +305,7 @@ void LiteClient::checkForUpdatesEndWithFailure(const std::string& err) {
 }
 
 void LiteClient::notify(const Uptane::Target& t, std::unique_ptr<ReportEvent> event) const {
-  if (!config.tls.server.empty()) {
+  if (!(config.tls.server.empty() || t.custom_data().isMember("local-src-dir"))) {
     event->custom["targetName"] = t.filename();
     event->custom["version"] = t.custom_version();
     if (event->custom.isMember("details")) {


### PR DESCRIPTION
There is no point in attempting to send update events in the case of an offline update. Sending events during the download and install phases is prevented by overriding the input configuration, specifically by setting the TLS server URL to an empty string.

Unfortunately, applying the same workaround to the finalization phase is not feasible since there is no update-specific "installer" instance available. This change ensures that the client does not send update events during the finalization phase by checking the target custom field, which is only present in an offline update.