### PR TITLE
offline: Add --target parameter to aklite-offline install

### DIFF
--- a/apps/aklite-offline/cmds.cpp
+++ b/apps/aklite-offline/cmds.cpp
@@ -17,12 +17,12 @@ int CheckCmd::checkSrcDir(const po::variables_map& vm, const boost::filesystem::
 }
 
 int InstallCmd::installUpdate(const po::variables_map& vm, const boost::filesystem::path& src_dir,
-                              bool force_downgrade) const {
+                              const std::string& target_name, bool force_downgrade) const {
   AkliteClient client(vm, false, false);
   const LocalUpdateSource local_update_source{.tuf_repo = (src_dir / "tuf").string(),
                                               .ostree_repo = (src_dir / "ostree_repo").string(),
                                               .app_store = (src_dir / "apps").string()};
-  auto ret_code{aklite::cli::Install(client, -1, "", InstallMode::OstreeOnly, force_downgrade, &local_update_source)};
+  auto ret_code{aklite::cli::Install(client, -1, target_name, InstallMode::OstreeOnly, force_downgrade, &local_update_source)};
   switch (ret_code) {
     case aklite::cli::StatusCode::InstallAppsNeedFinalization: {
       std::cout << "Please run `aklite-offline run` command to start the updated Apps\n";

--- a/apps/aklite-offline/cmds.h
+++ b/apps/aklite-offline/cmds.h
@@ -62,13 +62,14 @@ class InstallCmd : public Cmd {
                                                     "set log level 0-5 (trace, debug, info, warning, error, fatal)")(
         "config,c", po::value<std::vector<boost::filesystem::path>>()->composing(), "Configuration file or directory")(
         "src-dir,s", po::value<boost::filesystem::path>()->required(), "Directory that contains an update")(
-        "force,f", po::bool_switch(&force_downgrade), "Force downgrade");
+        "force,f", po::bool_switch(&force_downgrade), "Force downgrade")(
+        "target,t", po::value<std::string>()->default_value(std::string("")), "Target name");
   }
 
   int operator()(const po::variables_map& vm) const override {
     try {
       return installUpdate(vm, boost::filesystem::canonical(vm["src-dir"].as<boost::filesystem::path>()),
-                           force_downgrade);
+                           vm["target"].as<std::string>(), force_downgrade);
     } catch (const std::exception& exc) {
       std::cerr << "Failed to install offline update; src-dir: " << vm["src-dir"].as<boost::filesystem::path>().string()
                 << ", err: " << exc.what() << "\n";
@@ -77,7 +78,8 @@ class InstallCmd : public Cmd {
   }
 
  private:
-  int installUpdate(const po::variables_map& vm, const boost::filesystem::path& src_dir, bool force_downgrade) const;
+  int installUpdate(const po::variables_map& vm, const boost::filesystem::path& src_dir,
+                    const std::string& target_name, bool force_downgrade) const;
 
  private:
   po::options_description _options;


### PR DESCRIPTION
This allow a specific target in a offline installation source dir to be selected for installation. The one with a higher version is still selected by default if the parameter is omitted.