### PR TITLE
appengine: Don't require connectivity when starting app

### DIFF
--- a/tests/aklite_rollback_test.cc
+++ b/tests/aklite_rollback_test.cc
@@ -157,15 +157,9 @@ TEST_P(AkliteTest, RollbackIfOstreeInstallFails) {
     client->checkForUpdatesBegin();
     ASSERT_TRUE(client->isRollback(target_02));
     const auto app_engine_type{GetParam()};
-    if (app_engine_type == "RestorableAppEngine") {
-      // a download process doesn't "break" currently installed and running retsorable apps
-      // appsInSync cleans any unneeded layers stored in the skopeo/OCI store
-      ASSERT_TRUE(client->appsInSync(client->getCurrent()));
-    } else {
-      ASSERT_FALSE(client->appsInSync(client->getCurrent()));
-      // sync target_01 apps
-      updateApps(*client, client->getCurrent(), client->getCurrent());
-    }
+    ASSERT_FALSE(client->appsInSync(client->getCurrent()));
+    // sync target_01 apps
+    updateApps(*client, client->getCurrent(), client->getCurrent());
     client->checkForUpdatesEnd(target_01);
 
     // make sure the initial target_01 is running

--- a/tests/restorableappengine_test.cc
+++ b/tests/restorableappengine_test.cc
@@ -284,9 +284,6 @@ TEST_F(RestorableAppEngineTest, FetchAndInstall) {
   ASSERT_TRUE(app_engine->isFetched(app));
   ASSERT_TRUE(app_engine->verify(app));
   ASSERT_FALSE(app_engine->isRunning(app));
-  daemon_.setImagePullFailFlag(true);
-  ASSERT_FALSE(app_engine->install(app));
-  daemon_.setImagePullFailFlag(false);
   const auto install_res{app_engine->install(app)};
   ASSERT_EQ(install_res, true) << install_res.err;
   ASSERT_TRUE(app_engine->getInstalledApps() & app);
@@ -298,10 +295,6 @@ TEST_F(RestorableAppEngineTest, FetchAndRun) {
   ASSERT_TRUE(app_engine->fetch(app));
   ASSERT_TRUE(app_engine->isFetched(app));
   ASSERT_TRUE(app_engine->verify(app));
-  daemon_.setImagePullFailFlag(true);
-  ASSERT_FALSE(app_engine->run(app));
-  ASSERT_FALSE(app_engine->isRunning(app));
-  daemon_.setImagePullFailFlag(false);
   const auto run_res{app_engine->run(app)};
   ASSERT_EQ(run_res, true) << run_res.err;
   ASSERT_TRUE(app_engine->getInstalledApps() & app);
@@ -446,7 +439,7 @@ TEST_F(RestorableAppEngineTest, FetchFetchAndRun) {
 
   ASSERT_TRUE(app_engine->fetch(app));
   ASSERT_TRUE(app_engine->isFetched(app));
-  ASSERT_FALSE(app_engine->getInstalledApps() & app);
+  ASSERT_TRUE(app_engine->getInstalledApps() & app);
   ASSERT_FALSE(app_engine->isRunning(app));
   ASSERT_EQ(1, registry.getAppManifestPullNumb(app.uri));
 
@@ -481,7 +474,7 @@ TEST_F(RestorableAppEngineTest, FetchRunAndUpdate) {
   ASSERT_TRUE(app_engine->isFetched(updated_app));
   ASSERT_TRUE(app_engine->verify(updated_app));
   ASSERT_FALSE(app_engine->isRunning(updated_app));
-  ASSERT_FALSE(app_engine->getInstalledApps() & updated_app);
+  ASSERT_TRUE(app_engine->getInstalledApps() & updated_app);
 
   // run updated App
   ASSERT_TRUE(app_engine->run(updated_app));
@@ -586,10 +579,8 @@ TEST_F(RestorableAppEngineTest, VerifyFailure) {
   auto app =
       registry.addApp(fixtures::ComposeApp::create("app-005", "service-01", "image-01", AppInvalidServiceTemplate));
 
-  ASSERT_TRUE(app_engine->fetch(app));
-  ASSERT_TRUE(app_engine->isFetched(app));
+  ASSERT_FALSE(app_engine->fetch(app));
   ASSERT_EQ(1, registry.getAppManifestPullNumb(app.uri));
-  ASSERT_FALSE(app_engine->verify(app));
 }
 
 TEST_F(RestorableAppEngineTest, VerifySkopeoTmpFileRemoval) {


### PR DESCRIPTION
The goal of the change is to address a need for connection with Registry during app startup.
To achieve this, the following steps are taken:

- Images are loaded into the Docker store immediately after being pulled onto a device (into the Skopeo's image store).

- `docker compose pull` is invoked after the images have been loaded, it updates Docker engine's DB with digest references to the images.

As result, the subsequent call `docker compose up -d` does NOT require a connection with Registry, and apps can be started when a device is offline.