### PR TITLE
Fix compilation with boost 1.84.0

### DIFF
--- a/src/composeappmanager.cc
+++ b/src/composeappmanager.cc
@@ -4,6 +4,7 @@
 
 #include <boost/format.hpp>
 #include <boost/process.hpp>
+#include <boost/range/iterator_range_core.hpp>
 
 #include "bootloader/bootloaderlite.h"
 #include "docker/restorableappengine.h"

--- a/src/docker/restorableappengine.cc
+++ b/src/docker/restorableappengine.cc
@@ -10,6 +10,7 @@
 #include <boost/format.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/process.hpp>
+#include <boost/range/iterator_range_core.hpp>
 
 #include "crypto/crypto.h"
 #include "docker/composeappengine.h"

--- a/src/helpers.cc
+++ b/src/helpers.cc
@@ -1,5 +1,6 @@
 #include "helpers.h"
 
+#include <boost/range/iterator_range_core.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
 


### PR DESCRIPTION
Explicitly include boost/range/iterator_range_core.hpp when required, instead of relying on indirect header inclusion.

---

Reported and tested by @quaresmajose 
