### PR TITLE
Fix/send empty app header

### DIFF
--- a/src/liteclient.cc
+++ b/src/liteclient.cc
@@ -792,18 +792,6 @@ void LiteClient::setAppsNotChecked() {
 
 std::string LiteClient::getDeviceID() const { return key_manager_->getCN(); }
 
-void LiteClient::add_apps_header(std::vector<std::string>& headers, PackageConfig& config) {
-  if (config.type == ComposeAppManager::Name) {
-    ComposeAppManager::Config cfg(config);
-    // TODO: consider this header renaming
-    if (!!cfg.apps) {
-      headers.emplace_back("x-ats-dockerapps: " + boost::algorithm::join(*cfg.apps, ","));
-    } else {
-      headers.emplace_back("x-ats-dockerapps: ");
-    }
-  }
-}
-
 void LiteClient::initRequestHeaders(std::vector<std::string>& headers) const {
   headers.emplace_back("x-ats-ostreehash: unknown");
   headers.emplace_back("x-ats-target: unknown");


### PR DESCRIPTION
It turned out that libcurl requires setting a header value as <header-name>; to send the header with an empty value in a http request as <header-value>:\n.
This change makes sure that a header is set in libcurl correctly if the header value is empty.
The previous version set it as <header-name>: which led to not sending the header in a request at all - libcurl simply removes such header from a list of request headers.