### PR TITLE
Offline update: checking bundle metadata

### DIFF
--- a/include/aktualizr-lite/api.h
+++ b/include/aktualizr-lite/api.h
@@ -34,6 +34,7 @@ class CheckInResult {
     ExpiredMetadata,
     MetadataFetchFailure,
     MetadataNotFound,
+    BundleMetadataError,
   };
   CheckInResult(Status status, std::string primary_hwid, std::vector<TufTarget> targets)
       : status(status), primary_hwid_(std::move(primary_hwid)), targets_(std::move(targets)) {}

--- a/include/aktualizr-lite/cli/cli.h
+++ b/include/aktualizr-lite/cli/cli.h
@@ -21,6 +21,7 @@ enum class StatusCode {
   CheckinExpiredMetadata = 12,
   CheckinMetadataFetchFailure = 13,
   CheckinMetadataNotFound = 14,
+  CheckinInvalidBundleMetadata = 15,
   TufTargetNotFound = 20,
   InstallationInProgress = 30,
   NoPendingInstallation = 40,

--- a/src/api.cc
+++ b/src/api.cc
@@ -141,8 +141,7 @@ static std::vector<TufTarget> filterTargets(const std::vector<TufTarget>& allTar
                                             const std::vector<std::string>& secondary_hwids) {
   std::vector<TufTarget> targets;
   for (const auto& t : allTargets) {
-    if (!tags.empty() /* Should we really allow a device configuration without a tag? */
-        && !t.HasOneOfTags(tags)) {
+    if (!tags.empty() && !t.HasOneOfTags(tags)) {
       continue;
     }
     if (t.HardwareId() == hwidToFind) {
@@ -419,10 +418,11 @@ CheckInResult AkliteClient::CheckInLocal(const LocalUpdateSource* local_update_s
 
   LOG_INFO << "The local TUF repo has been successfully updated";
   LOG_INFO << "Searching for matching TUF Targets...";
-  auto matchingTargets = filterTargets(tuf_repo_->GetTargets(), hw_id_, client_->tags, secondary_hwids_);
+  auto matchingTargets = filterTargets(tuf_repo_->GetTargets(), hw_id_, {}, secondary_hwids_);
   if (matchingTargets.empty()) {
     err_msg =
-        "Couldn't find Targets matching the current device tag and hardware ID; check a device tag or a hardware ID";
+        "Couldn't find Targets matching the device's hardware ID; check a tag or a hardware ID of the device and the "
+        "bundle's tag";
     LOG_ERROR << err_msg;
     return CheckInResult{CheckInResult::Status::NoMatchingTargets, "", {}};
   }

--- a/src/api.cc
+++ b/src/api.cc
@@ -492,8 +492,9 @@ CheckInResult AkliteClient::CheckInLocal(const LocalUpdateSource* local_update_s
     }
   }
 
-  LOG_INFO << "Searching for TUF Targets matching a device's hardware ID (`" << hw_id_ << "`)...";
-  auto matchingTargets = filterTargets(bundle_targets, hw_id_, {}, secondary_hwids_);
+  LOG_INFO << "Searching for TUF Targets matching a device's hardware ID and tag; hw-id: " + hw_id_ +
+                  ", tag: " + (client_->tags.empty() ? "<not set>" : boost::algorithm::join(client_->tags, ","));
+  auto matchingTargets = filterTargets(bundle_targets, hw_id_, client_->tags, secondary_hwids_);
   if (matchingTargets.empty()) {
     err_msg =
         "Couldn't find Targets matching the device's hardware ID; check a tag or a hardware ID of the device and the "

--- a/src/api.cc
+++ b/src/api.cc
@@ -413,6 +413,15 @@ CheckInResult AkliteClient::CheckInLocal(const LocalUpdateSource* local_update_s
       }
     }
 
+    if (!client_->tags.empty()) {
+      const auto bundle_tag{bundle_meta["signed"]["x-fio-offline-bundle"]["tag"].asString()};
+      if (client_->tags.end() == std::find(client_->tags.begin(), client_->tags.end(), bundle_tag)) {
+        const std::string err{"Cannot apply the update bundle to the device:  the bundle tag `" + bundle_tag +
+                              "` differs from the device tag(s) `" + boost::algorithm::join(client_->tags, ",") + "`"};
+        throw BundleMetaError(BundleMetaError::Type::IncorrectTagType, err);
+      }
+    }
+
     LOG_INFO << "Updating the local TUF repo with metadata located in " << local_update_source->tuf_repo << "...";
     auto repo_src =
         std::make_shared<aklite::tuf::LocalRepoSource>("temp-local-repo-source", local_update_source->tuf_repo);

--- a/src/api.cc
+++ b/src/api.cc
@@ -400,11 +400,18 @@ CheckInResult AkliteClient::CheckInLocal(const LocalUpdateSource* local_update_s
   Json::Value bundle_meta;
 
   try {
-    LOG_INFO << "Checking metadata of the bundle located in " << local_update_source->tuf_repo << "...";
-    bundle_meta = checkAndGetBundleMeta(tuf_repo_, local_update_source->tuf_repo);
-    printBundleMeta(bundle_meta);
-    checkBundleType(bundle_meta, client_->type());
-    checkBundleTag(bundle_meta, client_->tags);
+    const auto bundle_path{boost::filesystem::path(local_update_source->tuf_repo) / "bundle-targets.json"};
+    if (!boost::filesystem::exists(bundle_path)) {
+      LOG_WARNING << "Failed to find the bundle metadata; " << bundle_path << " is missing!";
+      LOG_WARNING << "Please update `fioctl` to version >= v0.42 and re-run `fioctl targets offline-update`"
+                     " to generate a bundle with metadata";
+    } else {
+      LOG_INFO << "Checking metadata of the bundle located in " << local_update_source->tuf_repo << "...";
+      bundle_meta = checkAndGetBundleMeta(tuf_repo_, local_update_source->tuf_repo);
+      printBundleMeta(bundle_meta);
+      checkBundleType(bundle_meta, client_->type());
+      checkBundleTag(bundle_meta, client_->tags);
+    }
 
     LOG_INFO << "Updating the local TUF repo with metadata located in " << local_update_source->tuf_repo << "...";
     auto repo_src =

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -27,6 +27,7 @@ static const std::unordered_map<CheckInResult::Status, StatusCode> c2s = {
     {CheckInResult::Status::ExpiredMetadata, StatusCode::CheckinExpiredMetadata},
     {CheckInResult::Status::MetadataFetchFailure, StatusCode::CheckinMetadataFetchFailure},
     {CheckInResult::Status::MetadataNotFound, StatusCode::CheckinMetadataNotFound},
+    {CheckInResult::Status::BundleMetadataError, StatusCode::CheckinInvalidBundleMetadata},
 };
 
 static const std::unordered_map<DownloadResult::Status, StatusCode> d2s = {

--- a/src/liteclient.h
+++ b/src/liteclient.h
@@ -22,6 +22,12 @@ class Installer;
 
 class LiteClient {
  public:
+  enum class Type {
+    Undefined = -1,
+    Dev,
+    Prod,
+  };
+
   explicit LiteClient(Config config_in, const std::shared_ptr<AppEngine>& app_engine = nullptr,
                       const std::shared_ptr<P11EngineGuard>& p11 = nullptr,
                       std::shared_ptr<Uptane::IMetadataFetcher> meta_fetcher = nullptr);
@@ -81,6 +87,7 @@ class LiteClient {
   Uptane::Target getPendingTarget() const;
   bool isBootFwUpdateInProgress() const;
   bool wasTargetInstalled(const Uptane::Target& target) const;
+  Type type() const { return type_; }
 
  private:
   FRIEND_TEST(helpers, locking);
@@ -101,6 +108,7 @@ class LiteClient {
   void initRequestHeaders(std::vector<std::string>& headers) const;
   void updateRequestHeaders();
   static bool isRegistered(const KeyManager& key_manager);
+  static Type getClientType(const KeyManager& key_manager);
 
   boost::filesystem::path callback_program;
   std::unique_ptr<KeyManager> key_manager_;
@@ -121,6 +129,7 @@ class LiteClient {
   Json::Value apps_state_;
   const int report_queue_run_pause_s_{10};
   const int report_queue_event_limit_{6};
+  Type type_{Type::Undefined};
 };
 
 #endif  // AKTUALIZR_LITE_CLIENT_H_

--- a/tests/aklite_offline_test.cc
+++ b/tests/aklite_offline_test.cc
@@ -423,7 +423,7 @@ TEST_F(AkliteOffline, OfflineClientCheckinSecurityError) {
   // Now try to do checkin against the outdated TUF repo
   AkliteClient client(createLiteClient());
   LocalUpdateSource outdated_src = {outdated_repo_path.string(), src()->ostree_repo, src()->app_store};
-  ASSERT_EQ(aklite::cli::StatusCode::CheckinSecurityError, aklite::cli::CheckIn(client, &outdated_src));
+  ASSERT_EQ(aklite::cli::StatusCode::CheckinOkCached, aklite::cli::CheckIn(client, &outdated_src));
 }
 
 TEST_F(AkliteOffline, OfflineClientCheckinMetadataNotFound) {

--- a/tests/aklite_offline_test.cc
+++ b/tests/aklite_offline_test.cc
@@ -281,8 +281,8 @@ class AkliteOffline : public ::testing::Test {
       apps_json[app.name]["uri"] = app.uri;
     }
     // add new target to TUF repo
-    const std::string name = hw_id + "-" + os + "-" + version;
-    return Target::toTufTarget(repo.addTarget(name, hash, hw_id, version, apps_json, Json::Value(), ci_app_shortlist));
+    const std::string name = hw_id_ + "-" + os + "-" + version;
+    return Target::toTufTarget(repo.addTarget(name, hash, hw_id_, version, apps_json, Json::Value(), ci_app_shortlist));
   }
 
   TufTarget addTarget(const std::vector<AppEngine::App>& apps, bool just_apps = false,
@@ -384,6 +384,7 @@ class AkliteOffline : public ::testing::Test {
   const LocalUpdateSource* src() const { return &local_update_source_; }
 
   void setAppsShortlist(const std::string& shortlist) { cfg_.pacman.extra["compose_apps"] = shortlist; }
+  void setTargetHwId(const std::string& hw_id) { hw_id_ = hw_id; }
 
  protected:
   static const std::string hw_id;
@@ -404,6 +405,7 @@ class AkliteOffline : public ::testing::Test {
   TufTarget initial_target_;
   Docker::DockerClient::Ptr docker_client_;
   LocalUpdateSource local_update_source_;
+  std::string hw_id_{hw_id};
 };
 
 const std::string AkliteOffline::hw_id{"raspberrypi4-64"};
@@ -448,11 +450,12 @@ TEST_F(AkliteOffline, OfflineClientCheckinExpiredMetadata) {
 }
 
 TEST_F(AkliteOffline, OfflineClientCheckinCheckinNoMatchingTargets) {
+  AkliteClient client(createLiteClient());
+
+  setTargetHwId("some-other-hw-id");
   const auto prev_target{addTarget({createApp("app-01")})};
   const auto target{addTarget({createApp("app-01")})};
 
-  cfg_.pacman.extra["tags"] = "bad-tag";
-  AkliteClient client(createLiteClient());
   ASSERT_EQ(aklite::cli::StatusCode::CheckinNoMatchingTargets, aklite::cli::CheckIn(client, src()));
 }
 

--- a/tests/apiclient_test.cc
+++ b/tests/apiclient_test.cc
@@ -146,6 +146,7 @@ TEST_F(ApiClientTest, CheckInLocal) {
 
   // Accessing repo metadata files directly from the local filesystem
   auto repo_dir = getTufRepo().getRepoPath();
+  tuf_repo_.updateBundleMeta(initial_target_.filename());
 
   const LocalUpdateSource local_update_source_ = {repo_dir, ostree_repo_.getPath()};
   auto result = client.CheckInLocal(&local_update_source_);
@@ -161,6 +162,7 @@ TEST_F(ApiClientTest, CheckInLocal) {
   ASSERT_EQ(1, result.Targets().size());
 
   auto new_target = createTarget();
+  tuf_repo_.updateBundleMeta(new_target.filename());
   result = client.CheckInLocal(&local_update_source_);
   ASSERT_EQ(0, getDeviceGateway().getEvents().size());
   ASSERT_EQ("", getDeviceGateway().readSotaToml());

--- a/tests/fixtures/dockerdaemon.cc
+++ b/tests/fixtures/dockerdaemon.cc
@@ -31,7 +31,7 @@ class DockerDaemon {
 
   const std::string& dataRoot() const { return dir_.string(); }
 
-  std::string getUrl() const { return "http://localhost:" + port_; }
+  std::string getUrl() const { return "tcp://localhost:" + port_; }
   std::string getUnixSocket() const { return "unix://" +  unix_sock_.PathString(); }
 
   std::shared_ptr<HttpInterface> getClient() { return std::make_shared<DockerDaemon::HttpClient>(*this); }

--- a/tests/fixtures/liteclient/tufrepomock.cc
+++ b/tests/fixtures/liteclient/tufrepomock.cc
@@ -18,7 +18,8 @@ class TufRepoMock {
   void setLatest(const Uptane::Target& latest) { latest_ = latest; }
 
   Uptane::Target addTarget(const std::string& name, const std::string& hash, const std::string& hardware_id,
-                           const std::string& version, const Json::Value& apps_json = Json::Value(), const Json::Value& delta_stat = Json::Value()) {
+                           const std::string& version, const Json::Value& apps_json = Json::Value(),
+                           const Json::Value& delta_stat = Json::Value(), const std::string& ci_app_shortlist = "") {
     Delegation null_delegation{};
     Hash hash_obj{Hash::Type::kSha256, hash};
 
@@ -29,6 +30,9 @@ class TufRepoMock {
     custom_json["hardwareIds"][0] = hardware_id;
     custom_json["ecuIdentifiers"]["test_primary_ecu_serial_id"]["hardwareId"] = hardware_id;
     custom_json["tags"][0] = "default-tag";
+    if (!ci_app_shortlist.empty()) {
+      custom_json["fetched-apps"]["shortlist"] = ci_app_shortlist;
+    }
 
     custom_json[Target::ComposeAppField] = apps_json;
     repo_.addCustomImage(name, hash_obj, 0, hardware_id, "", 0, null_delegation, custom_json);

--- a/tests/fixtures/liteclient/tufrepomock.cc
+++ b/tests/fixtures/liteclient/tufrepomock.cc
@@ -55,6 +55,55 @@ class TufRepoMock {
     repo_.generateRepo(KeyType::kED25519);
   }
 
+  KeyPair getTargetsKey() const {
+    return repo_.getKey(Uptane::Role::Targets());
+  }
+
+  void updateBundleMeta(const std::string& target_name) {
+    Json::Value targets_meta{Utils::parseJSONFile(getRepoPath() + "/targets.json")};
+
+    boost::filesystem::path bundle_meta_path{getRepoPath() + "/bundle-targets.json"};
+    Json::Value bundle_meta;
+    if (boost::filesystem::exists(bundle_meta_path)) {
+      bundle_meta = Utils::parseJSONFile(bundle_meta_path);
+      bundle_meta["signed"]["x-fio-offline-bundle"]["targets"].append(target_name);
+    } else {
+      bundle_meta["signed"]["_type"] = "Targets";
+      bundle_meta["signed"]["expires"] = targets_meta["signed"]["expires"];
+      bundle_meta["signed"]["version"] = targets_meta["signed"]["version"];
+      bundle_meta["signed"]["x-fio-offline-bundle"]["targets"][0] = target_name;
+      bundle_meta["signed"]["x-fio-offline-bundle"]["type"] = "ci";
+      bundle_meta["signed"]["x-fio-offline-bundle"]["tag"] = "default-tag";
+    }
+
+    const auto key{getTargetsKey()};
+
+    std::string b64sig = Utils::toBase64(Crypto::Sign(key.public_key.Type(), nullptr, key.private_key,
+                                                      Utils::jsonToCanonicalStr(bundle_meta["signed"])));
+    Json::Value signature;
+    switch (key.public_key.Type()) {
+      case KeyType::kRSA2048:
+      case KeyType::kRSA3072:
+      case KeyType::kRSA4096:
+        signature["method"] = "rsassa-pss";
+        break;
+      case KeyType::kED25519:
+        signature["method"] = "ed25519";
+        break;
+      default:
+        throw std::runtime_error("Unknown key type");
+    }
+    signature["sig"] = b64sig;
+    signature["keyid"] = key.public_key.KeyId();
+    bundle_meta["signatures"][0] = signature;
+
+    Utils::writeFile(bundle_meta_path, bundle_meta);
+  }
+
+  std::string getBundleMetaPath() const {
+    return getRepoPath() + "/bundle-targets.json";
+  }
+
  private:
   const boost::filesystem::path root_;
   ImageRepo repo_;


### PR DESCRIPTION
Verify a bundle metadata before updating a local/device TUF repo:
- check its signatures;
- check a bundle type (ci, prod), and whether it matches the device's one;
- check a bundle tag, and whether it matches the device's one;
- check whether the bundle targets are listed in the TUF targets of the device TUF repo.

Update and extend the unit tests to support the new use-cases.