### PR TITLE
apps: Use composectl to rm and prune apps

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.22.2-bookworm AS composeapp
 # Build composeapp
 WORKDIR /build
 RUN git clone https://github.com/foundriesio/composeapp.git && \
-    cd composeapp && git checkout 9875947a7dd4adbe155324241e8bb17ea9be7f1a && make && cp ./bin/composectl /usr/bin/
+    cd composeapp && git checkout 1b6f1f2d8f55d40fef10c8ddfef224a9a58caa27 && make && cp ./bin/composectl /usr/bin/
 
 
 FROM ubuntu:jammy

--- a/src/composeapp/appengine.h
+++ b/src/composeapp/appengine.h
@@ -24,8 +24,10 @@ class AppEngine : public Docker::RestorableAppEngine {
         local_source_path_{local_source_path} {}
 
   Result fetch(const App& app) override;
+  void remove(const App& app) override;
   bool isRunning(const App& app) const override;
   Json::Value getRunningAppsInfo() const override;
+  void prune(const Apps& app_shortlist) override;
 
  private:
   bool isAppFetched(const App& app) const override;

--- a/src/docker/restorableappengine.h
+++ b/src/docker/restorableappengine.h
@@ -114,6 +114,7 @@ class RestorableAppEngine : public AppEngine {
   const boost::filesystem::path& storeRoot() const { return store_root_; }
   const boost::filesystem::path& installRoot() const { return install_root_; }
   const std::string& dockerHost() const { return docker_host_; }
+  Docker::DockerClient::Ptr& dockerClient() { return docker_client_; }
   const StorageSpaceFunc& storageSpaceFunc() const { return storage_space_func_; }
 
   virtual bool isAppFetched(const App& app) const;

--- a/tests/fixtures/dockerdaemon.cc
+++ b/tests/fixtures/dockerdaemon.cc
@@ -87,6 +87,10 @@ class DockerDaemon {
       return BaseHttpClient::post(url, content_type, data);
     }
 
+    HttpResponse post(const std::string&, const Json::Value&) override {
+      return HttpResponse("", 200, CURLE_OK, "");
+    }
+
    private:
     DockerDaemon& daemon_;
   };


### PR DESCRIPTION
1. Use `composectl` to stop, uninstall, remove, and prune apps along with their docker images and containers.
2. Updated Dockerfile to switch to the corresponding `composectl` version.
3. Adjust the docker daemon mock to the changes.