### PR TITLE
fixup!: Check shortilst value before using it

### DIFF
--- a/tests/fixtures/liteclient/tufrepomock.cc
+++ b/tests/fixtures/liteclient/tufrepomock.cc
@@ -19,7 +19,9 @@ class TufRepoMock {
 
   Uptane::Target addTarget(const std::string& name, const std::string& hash, const std::string& hardware_id,
                            const std::string& version, const Json::Value& apps_json = Json::Value(),
-                           const Json::Value& delta_stat = Json::Value(), const std::string& ci_app_shortlist = "") {
+                           const Json::Value& delta_stat = Json::Value(),
+                           const std::string* ci_app_shortlist = nullptr,
+                           const std::string& ci_app_uri = "http://apps.tar") {
     Delegation null_delegation{};
     Hash hash_obj{Hash::Type::kSha256, hash};
 
@@ -30,8 +32,14 @@ class TufRepoMock {
     custom_json["hardwareIds"][0] = hardware_id;
     custom_json["ecuIdentifiers"]["test_primary_ecu_serial_id"]["hardwareId"] = hardware_id;
     custom_json["tags"][0] = "default-tag";
-    if (!ci_app_shortlist.empty()) {
-      custom_json["fetched-apps"]["shortlist"] = ci_app_shortlist;
+    if (ci_app_shortlist != nullptr ) {
+      if (ci_app_uri.empty()) {
+        custom_json["fetched-apps"]["uri"] = Json::nullValue;
+      } else {
+        custom_json["fetched-apps"]["uri"] = ci_app_uri;
+      }
+
+      custom_json["fetched-apps"]["shortlist"] = *ci_app_shortlist;
     }
 
     custom_json[Target::ComposeAppField] = apps_json;


### PR DESCRIPTION
Make sure that the `shortlist` field is present, not `null`, and not empty string before using it - adding to the install target the apps that are in intersection of the tuf target app list and the `fetched-apps.shortlist` field.

This helps to overcome a problem if `fetched-apps.shortlist` is set to `""` by the ci-scripts if the `shortlist` field is not present in `preloaded_images` nor `app_shortlist` in `offline` sections of the factory config.