### PR TITLE
makefile: add code coverage report for unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ option(BUILD_AKLITE_OFFLINE "Set to ON to build cli command for an offline updat
 option(BUILD_TUFCTL "Set to ON to build sample tuf control application" OFF)
 option(BUILD_P11 "Support for key storage in a HSM via PKCS#11" ON)
 option(USE_COMPOSEAPP_ENGINE "Set to ON to build the app engine based on the composeapp utility" ON)
+option(BUILD_WITH_CODE_COVERAGE_AKLITE "Enable gcov code coverage" OFF)
 
 # If we build the sota tools we don't need aklite (???) and vice versa
 # if we build aklite we don't need the sota tools

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ TASKS = config build format tidy garage-tools custom-client test-uptane-vectors
 .PHONY: $(TASKS) test
 
 
-all $(TASKS):
-	docker run --init -u $(shell id -u):$(shell id -g) --rm -v $(PWD):$(PWD) -w $(PWD) -eCCACHE_DIR=$(CCACHE_DIR) -eCC=$(CC) -eCXX=$(CXX) -eBUILD_DIR=$(BUILD_DIR) -eTARGET=$(TARGET) -ePKCS11_ENGINE_PATH=$(PKCS11_ENGINE_PATH) $(CONTAINER) make -f dev-flow.mk $@
+all $(TASKS) config-coverage test-coverage-html:
+	docker run --init -u $(shell id -u):$(shell id -g) --rm -v $(PWD):$(PWD) -w $(PWD) -eCCACHE_DIR=$(CCACHE_DIR) -eCC=$(CC) -eCXX=$(CXX) -eBUILD_DIR=$(BUILD_DIR) -eTARGET=$(TARGET) -ePKCS11_ENGINE_PATH=$(PKCS11_ENGINE_PATH) -eTEST_LABEL=$(TEST_LABEL) $(CONTAINER) make -f dev-flow.mk $@
 
 test:
 	docker run --init -u $(shell id -u):$(shell id -g) --rm -v $(PWD):$(PWD) -w $(PWD) -eTEST_LABEL=$(TEST_LABEL) -eCTEST_ARGS=$(CTEST_ARGS) -eBUILD_DIR=$(BUILD_DIR) -eGTEST_FILTER=$(GTEST_FILTER) $(CONTAINER) make -f dev-flow.mk $@

--- a/dev-flow.mk
+++ b/dev-flow.mk
@@ -16,10 +16,13 @@ all: config build
 config:
 	cmake -S . -B ${BUILD_DIR} -DCMAKE_BUILD_TYPE=Debug -DBUILD_P11=ON -GNinja -DCMAKE_CXX_COMPILER=${CXX} -DCMAKE_C_COMPILER=${CC} -DCMAKE_CXX_FLAGS="-Wno-error=deprecated-declarations" -DPKCS11_ENGINE_PATH=${PKCS11_ENGINE_PATH} ${EXTRA_CMAKE_CONFIG_ARGS}
 
+config-coverage:
+	cmake -S . -B ${BUILD_DIR} -DCMAKE_BUILD_TYPE=Debug -DBUILD_P11=ON -GNinja -DCMAKE_CXX_COMPILER=${CXX} -DCMAKE_C_COMPILER=${CC} -DCMAKE_CXX_FLAGS="-Wno-error=deprecated-declarations" -DPKCS11_ENGINE_PATH=${PKCS11_ENGINE_PATH} ${EXTRA_CMAKE_CONFIG_ARGS} -DTEST_LABEL=${TEST_LABEL} -DBUILD_WITH_CODE_COVERAGE_AKLITE=ON
+
 build:
 	cmake --build ${BUILD_DIR} --target ${TARGET}
 
-format:
+format test-coverage-html:
 	cmake --build ${BUILD_DIR} --target $@
 
 tidy:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -83,7 +83,8 @@ RUN apt-get update && apt-get -y install --no-install-suggests --no-install-reco
   zip \
   docker-compose \
   sudo \
-  shellcheck
+  shellcheck \
+  gcovr
 
 RUN ln -s clang-11 /usr/bin/clang && \
     ln -s clang++-11 /usr/bin/clang++

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -84,6 +84,20 @@ set(INCS
 
 target_include_directories(${TARGET_EXE} PRIVATE ${INCS})
 target_include_directories(${TARGET_LIB} PRIVATE ${AKLITE_DIR}/include ${INCS})
+if(BUILD_WITH_CODE_COVERAGE_AKLITE)
+  target_link_options(
+    ${TARGET_LIB}
+    PRIVATE "-fprofile-arcs"
+    PRIVATE "-ftest-coverage"
+  )
+  target_compile_options(
+    ${TARGET_LIB}
+    PRIVATE "--coverage"
+    PRIVATE "-fprofile-arcs"
+    PRIVATE "-ftest-coverage"
+  )
+  target_link_libraries(${TARGET_LIB} gcov)
+endif()
 
 target_link_libraries(${TARGET_LIB} aktualizr_lib)
 target_link_libraries(${TARGET_EXE} ${TARGET_LIB})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,25 @@ set(TEST_LIBS
   gmock
 )
 
+# Setup coverage
+if(BUILD_WITH_CODE_COVERAGE_AKLITE)
+  include(CodeCoverage)
+  add_definitions(${COVERAGE_COMPILER_FLAGS})
+
+  set(COVERAGE_GCOVR_EXCLUDES
+    '${CMAKE_SOURCE_DIR}/aktualizr/'
+    '${CMAKE_SOURCE_DIR}/tests/'
+    '${CMAKE_BINARY_DIR}'
+  )
+  SET(GCOVR_ADDITIONAL_ARGS --exclude-unreachable-branches --print-summary)
+  include(ProcessorCount)
+  ProcessorCount(PROC_COUNT)
+  setup_target_for_coverage_gcovr_html(
+    NAME test-coverage-html
+    EXECUTABLE ${CMAKE_CTEST_COMMAND} ${CTEST_EXTRA_ARGS} -j ${PROC_COUNT} -L ${TEST_LABEL} USES_TERMINAL
+  )
+endif(BUILD_WITH_CODE_COVERAGE_AKLITE)
+
 add_aktualizr_test(NAME yaml2json
   SOURCES yaml2json_test.cc
   PROJECT_WORKING_DIRECTORY


### PR DESCRIPTION
Coverage HTML report can be generated by calling the following Makefile targets: config-coverage build test-coverage-html

gcovr is required, and it was added to the build image Dockerfile.