### PR TITLE
tests: Improve reliability of events verification

### DIFF
--- a/tests/device-gateway_fake.py
+++ b/tests/device-gateway_fake.py
@@ -187,6 +187,7 @@ class Handler(SimpleHTTPRequestHandler):
                     cur_events.append(e)
                     event_ids.add(e["id"])
             json.dump(cur_events, f)
+            os.fsync(f)
 
     def _reset_events(self):
         if os.path.exists(self.server.events_file):

--- a/tests/fixtures/liteclient/devicegatewaymock.cc
+++ b/tests/fixtures/liteclient/devicegatewaymock.cc
@@ -50,8 +50,15 @@ class DeviceGatewayMock {
   std::string getTlsUri() const { return url_; }
   const std::string& getPort() const { return port_; }
   Json::Value getReqHeaders() const { return Utils::parseJSONFile(req_headers_file_); }
-  Json::Value getEvents() const { return Utils::parseJSONFile(events_file_); }
+  Json::Value getEvents() const {
+    // Allow some time for the ReportQueue to be flushed and the events to arrive at the Device Gateway mock.
+    // The flush operation is forced in the LiteClient destructor, but we inspect the sent events while keeping an
+    // LiteClient instance active.
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    return Utils::parseJSONFile(events_file_);
+  }
   bool resetEvents(std::shared_ptr<HttpClient> http_client) const {
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
     const HttpResponse r = http_client->post(url_ + "/events/reset", Json::nullValue);
     return r.isOk();
   }


### PR DESCRIPTION
Add a fsync operation inside the fake device gateway used for testing, and also add a delay before reading the generated events file. The delay is required because the sending of events inside aklite is not done synchronously. A ReportQueue flush is forced on LiteClient destruction, but we keep an instance active during the test procedure.

---

@mike-sul original results looked promising, but now I still get false negatives when running on Github. I'll take a better look tomorrow.

An alternative implementation would be to add some method to force the ReportQueue flush and make sure the execution only proceeds after the reply from the device gateway, but it is probably not worth it.