### PR TITLE
bootloader: fix format of recently added code

### DIFF
--- a/src/bootloader/bootloaderlite.cc
+++ b/src/bootloader/bootloaderlite.cc
@@ -37,8 +37,8 @@ void BootloaderLite::installNotify(const Uptane::Target& target) const {
     case RollbackMode::kUbootGeneric:
       break;
     case RollbackMode::kFioEFI:
-          env_cmd_vars_ = boost::str(boost::format("%s=%s") % OstreeTargetPathVar %
-                                     getTargetDir(sysroot_->deployment_path(), target.sha256Hash()));
+      env_cmd_vars_ = boost::str(boost::format("%s=%s") % OstreeTargetPathVar %
+                                 getTargetDir(sysroot_->deployment_path(), target.sha256Hash()));
     case RollbackMode::kUbootMasked:
     case RollbackMode::kFioVB: {
       const auto target_version_val{getDeploymentVersion(target.sha256Hash())};
@@ -101,8 +101,7 @@ std::string BootloaderLite::getVersion(const std::string& deployment_dir, const 
     std::string target_dir = getTargetDir(deployment_dir, hash);
 
     if (target_dir.empty()) {
-      LOG_WARNING << "Target's system root directory is not found for hash: " << hash <<
-                   " in: " << deployment_dir;
+      LOG_WARNING << "Target's system root directory is not found for hash: " << hash << " in: " << deployment_dir;
       return std::string();
     }
 
@@ -122,8 +121,7 @@ std::string BootloaderLite::getVersion(const std::string& deployment_dir, const 
   }
 }
 
-std::string BootloaderLite::getTargetDir(const std::string& deployment_dir,
-                                         const std::string& target_hash) {
+std::string BootloaderLite::getTargetDir(const std::string& deployment_dir, const std::string& target_hash) {
   for (auto& p : boost::filesystem::directory_iterator(deployment_dir)) {
     std::string dir = p.path().string();
     if (!boost::filesystem::is_directory(dir)) {

--- a/src/bootloader/bootloaderlite.h
+++ b/src/bootloader/bootloaderlite.h
@@ -58,8 +58,7 @@ class BootloaderLite : public Bootloader, public BootFwUpdateStatus {
 
   static VersionNumbRes verStrToNumber(const std::string& ver_str);
   static std::string extractVersionValue(const std::string& version_line);
-  static std::string getTargetDir(const std::string& deployment_dir,
-                                  const std::string& target_hash);
+  static std::string getTargetDir(const std::string& deployment_dir, const std::string& target_hash);
 
   OSTree::Sysroot::Ptr sysroot_;
   const std::string get_env_cmd_;


### PR DESCRIPTION
Commit: fa9e0e5 (bootloader: add support for env variables, 2024-06-06) introduced a few code formatting errors, now corrected by running `make format`.

---
@igoropaniuk `make format` generates a few changes over your original code. I took the liberty of creating a new commit for it.