### PR TITLE
api, cli: Do not perform TUF checkin on every Pull or Install 

### DIFF
--- a/apps/aklite-offline/cmds.cpp
+++ b/apps/aklite-offline/cmds.cpp
@@ -19,7 +19,7 @@ int CheckCmd::checkSrcDir(const po::variables_map& vm, const boost::filesystem::
 
 int InstallCmd::installUpdate(const po::variables_map& vm, const boost::filesystem::path& src_dir,
                               const std::string& target_name, bool force_downgrade) const {
-  AkliteClientExt client(vm, false, false);
+  AkliteClientExt client(vm, false, false, false);
   const LocalUpdateSource local_update_source{.tuf_repo = (src_dir / "tuf").string(),
                                               .ostree_repo = (src_dir / "ostree_repo").string(),
                                               .app_store = (src_dir / "apps").string()};

--- a/include/aktualizr-lite/aklite_client_ext.h
+++ b/include/aktualizr-lite/aklite_client_ext.h
@@ -32,8 +32,8 @@ class GetTargetToInstallResult {
     RollbackTargetNotFound,
   };
 
-  explicit GetTargetToInstallResult(const CheckInResult &check_in_result)
-      : status(static_cast<Status>(check_in_result.status)) {}
+  explicit GetTargetToInstallResult(const CheckInResult &checkin_res)
+      : status(static_cast<Status>(checkin_res.status)) {}
 
   GetTargetToInstallResult(Status status, TufTarget selected_target, std::string reason)
       : status(status), selected_target(std::move(selected_target)), reason(std::move(reason)) {}
@@ -64,9 +64,21 @@ class AkliteClientExt : public AkliteClient {
   } state_when_download_failed{"", "", {.err = "undefined"}};
 
  public:
-  GetTargetToInstallResult GetTargetToInstall(const LocalUpdateSource *local_update_source = nullptr, int version = -1,
+  explicit AkliteClientExt(std::shared_ptr<LiteClient> client, bool read_only = false, bool apply_lock = false,
+                           bool invoke_post_cb_at_checkin = true)
+      : AkliteClient(std::move(client), read_only, apply_lock) {
+    invoke_post_cb_at_checkin_ = invoke_post_cb_at_checkin;
+  }
+
+  explicit AkliteClientExt(const boost::program_options::variables_map &cmdline_args, bool read_only = false,
+                           bool finalize = true, bool invoke_post_cb_at_checkin = true)
+      : AkliteClient(cmdline_args, read_only, finalize) {
+    invoke_post_cb_at_checkin_ = invoke_post_cb_at_checkin;
+  }
+
+  GetTargetToInstallResult GetTargetToInstall(const CheckInResult &checkin_res, int version = -1,
                                               const std::string &target_name = "", bool allow_bad_target = false,
-                                              bool force_apps_sync = false);
+                                              bool force_apps_sync = false, bool offline_mode = false);
   InstallResult PullAndInstall(const TufTarget &target, const std::string &reason = "",
                                const std::string &correlation_id = "", InstallMode install_mode = InstallMode::All,
                                const LocalUpdateSource *local_update_source = nullptr, bool do_download = true,

--- a/include/aktualizr-lite/api.h
+++ b/include/aktualizr-lite/api.h
@@ -284,6 +284,8 @@ class AkliteClient {
    */
   CheckInResult CheckInLocal(const LocalUpdateSource *local_update_source) const;
 
+  CheckInResult CheckInCurrent(const LocalUpdateSource *local_update_source = nullptr) const;
+
   /**
    * Return the active aktualizr-lite configuration.
    */
@@ -362,7 +364,8 @@ class AkliteClient {
   static const std::vector<boost::filesystem::path> CONFIG_DIRS;
 
  protected:
-  bool usingUpdateClientApi{false};
+  /* check-for-update-post success callback may be called at the end of CheckIn, or the end of GetTargetToInstall */
+  bool invoke_post_cb_at_checkin_{true};
   bool is_booted_env{true};
   std::shared_ptr<LiteClient> client_;
 

--- a/include/aktualizr-lite/cli/cli.h
+++ b/include/aktualizr-lite/cli/cli.h
@@ -55,14 +55,30 @@ enum class PullMode {
   None,
 };
 
+/**
+ * The TUF check mode to be used.
+ */
+enum class CheckMode {
+  /**
+   * Default mode, do update TUF metadata from remote of local source.
+   */
+  Update = 0,
+  /**
+   * Do not update TUF roles: use currently stored metadata.
+   */
+  Current,
+};
+
 StatusCode CheckIn(AkliteClient &client, const LocalUpdateSource *local_update_source = nullptr);
 
 StatusCode Pull(AkliteClientExt &client, int version = -1, const std::string &target_name = "",
-                bool force_downgrade = true, const LocalUpdateSource *local_update_source = nullptr);
+                bool force_downgrade = true, const LocalUpdateSource *local_update_source = nullptr,
+                CheckMode check_mode = CheckMode::Update);
 
 StatusCode Install(AkliteClientExt &client, int version = -1, const std::string &target_name = "",
                    InstallMode install_mode = InstallMode::All, bool force_downgrade = true,
-                   const LocalUpdateSource *local_update_source = nullptr, PullMode pull_mode = PullMode::All);
+                   const LocalUpdateSource *local_update_source = nullptr, PullMode pull_mode = PullMode::All,
+                   CheckMode check_mode = CheckMode::Update);
 
 StatusCode CompleteInstall(AkliteClient &client);
 

--- a/include/aktualizr-lite/cli/cli.h
+++ b/include/aktualizr-lite/cli/cli.h
@@ -55,7 +55,7 @@ enum class PullMode {
   None,
 };
 
-StatusCode CheckIn(AkliteClient &client, const LocalUpdateSource *local_update_source);
+StatusCode CheckIn(AkliteClient &client, const LocalUpdateSource *local_update_source = nullptr);
 
 StatusCode Pull(AkliteClientExt &client, int version = -1, const std::string &target_name = "",
                 bool force_downgrade = true, const LocalUpdateSource *local_update_source = nullptr);

--- a/src/api.cc
+++ b/src/api.cc
@@ -292,7 +292,7 @@ CheckInResult AkliteClient::CheckIn() const {
   }
   LOG_INFO << "Latest targets metadata contains " << matchingTargets.size() << " entries for tag=\""
            << boost::algorithm::join(client_->tags, ",") << "\" and hardware id=\"" << hw_id_ << "\"";
-  if (!usingUpdateClientApi) {
+  if (invoke_post_cb_at_checkin_) {
     client_->notifyTufUpdateFinished();
   }
   return CheckInResult(CheckInResult::Status::Ok, hw_id_, matchingTargets);
@@ -357,7 +357,7 @@ static std::vector<Uptane::Target> getAvailableTargets(const PackageConfig& pcon
       auto custom_data{t.custom_data()};
       custom_data[LocalSrcDirKey]["ostree"] = src.OstreeRepoDir.string();
       found_targets.emplace_back(Target::updateCustom(t, custom_data));
-      LOG_INFO << "\t" << t.filename() << " - all target content has been found";
+      LOG_INFO << "\t" << t.filename() << " - all target components have been found";
       if (!just_latest) {
         continue;
       }
@@ -373,7 +373,7 @@ static std::vector<Uptane::Target> getAvailableTargets(const PackageConfig& pcon
       custom_data[LocalSrcDirKey]["ostree"] = src.OstreeRepoDir.string();
       custom_data.removeMember("docker_compose_apps");
       found_targets.emplace_back(Target::updateCustom(t, custom_data));
-      LOG_INFO << "\t" << t.filename() << " - all target content has been found";
+      LOG_INFO << "\t" << t.filename() << " - all target components have been found";
       if (!just_latest) {
         continue;
       }
@@ -417,7 +417,7 @@ static std::vector<Uptane::Target> getAvailableTargets(const PackageConfig& pcon
     custom_data[LocalSrcDirKey]["ostree"] = src.OstreeRepoDir.string();
     custom_data[LocalSrcDirKey]["apps"] = src.AppsDir.string();
     found_targets.emplace_back(Target::updateCustom(t, custom_data));
-    LOG_INFO << "\t" << t.filename() << " - all target content has been found";
+    LOG_INFO << "\t" << t.filename() << " - all target components have been found";
     if (just_latest) {
       break;
     }
@@ -569,10 +569,59 @@ CheckInResult AkliteClient::CheckInLocal(const LocalUpdateSource* local_update_s
     return CheckInResult(CheckInResult::Status::NoTargetContent, hw_id_, std::vector<TufTarget>{});
   }
 
-  if (!usingUpdateClientApi) {
+  if (invoke_post_cb_at_checkin_) {
     client_->notifyTufUpdateFinished();
   }
   return CheckInResult(check_status, hw_id_, toTufTargets(available_targets));
+}
+
+CheckInResult AkliteClient::CheckInCurrent(const LocalUpdateSource* local_update_source) const {
+  std::string err_msg;
+  LOG_INFO << "Checking the stored TUF metadata...";
+  try {
+    tuf_repo_->CheckMeta();
+    LOG_INFO << "The stored TUF metadata is valid";
+  } catch (const std::exception& exc) {
+    err_msg = std::string("Stored TUF metadata is invalid: ") + exc.what();
+    LOG_WARNING << err_msg;
+    return CheckInResult{CheckInResult::Status::SecurityError, hw_id_, {}};
+  }
+
+  LOG_INFO << "Searching for matching TUF Targets...";
+  auto matchingTargets = filterTargets(tuf_repo_->GetTargets(), hw_id_, client_->tags, secondary_hwids_);
+  if (matchingTargets.empty()) {
+    // TODO: consider reporting about it to the backend to make it easier to figure out
+    // why specific devices are not picking up a new Target
+    err_msg = boost::str(boost::format("No Target found for the device; hw ID: %s; tags: %s") % hw_id_ %
+                         boost::algorithm::join(client_->tags, ","));
+    LOG_ERROR << err_msg;
+    return CheckInResult{CheckInResult::Status::NoMatchingTargets, hw_id_, {}};
+  }
+  LOG_INFO << "Latest targets metadata contains " << matchingTargets.size() << " entries for tag=\""
+           << boost::algorithm::join(client_->tags, ",") << "\" and hardware id=\"" << hw_id_ << "\"";
+
+  if (local_update_source != nullptr) {
+    LOG_INFO << "Looking for update content for each matching Target...";
+    UpdateSrc src{
+        .TufDir = local_update_source->tuf_repo,
+        .OstreeRepoDir = local_update_source->ostree_repo,
+        .AppsDir = local_update_source->app_store,
+    };
+    std::vector<Uptane::Target> available_targets =
+        getAvailableTargets(client_->config.pacman, fromTufTargets(matchingTargets), src,
+                            false /* get all available targets, not just latest */);
+    if (available_targets.empty()) {
+      err_msg = "No update content found in ostree dir  " + src.OstreeRepoDir.string() + " and app dir " +
+                src.AppsDir.string();
+      LOG_ERROR << err_msg;
+      client_->notifyTufUpdateFinished(err_msg);
+      return CheckInResult(CheckInResult::Status::NoTargetContent, hw_id_, std::vector<TufTarget>{});
+    }
+    return CheckInResult(CheckInResult::Status::OkCached, hw_id_, toTufTargets(available_targets));
+
+  } else {
+    return CheckInResult(CheckInResult::Status::OkCached, hw_id_, matchingTargets);
+  }
 }
 
 boost::property_tree::ptree AkliteClient::GetConfig() const {

--- a/src/api.cc
+++ b/src/api.cc
@@ -346,19 +346,18 @@ static std::vector<Uptane::Target> getAvailableTargets(const PackageConfig& pcon
   const std::string search_msg{just_latest ? "a target" : "all targets"};
   LOG_INFO << "Searching for " << search_msg << " starting from " << allowed_targets.begin()->filename()
            << " that match content provided in the source directory\n"
-           << "\tpacman type: \t" << pconfig.type << "\n\t apps dir: \t" << src.AppsDir << "\n\t ostree dir: \t"
+           << "\t pacman type: \t" << pconfig.type << "\n\t apps dir: \t" << src.AppsDir << "\n\t ostree dir: \t"
            << src.OstreeRepoDir;
   for (const auto& t : allowed_targets) {
-    LOG_INFO << "Checking " << t.filename();
     if (!repo.hasCommit(t.sha256Hash())) {
-      LOG_INFO << "\tmissing ostree commit: " << t.sha256Hash();
+      LOG_DEBUG << "\t" << t.filename() << " - missing ostree commit: " << t.sha256Hash();
       continue;
     }
     if (pconfig.type != ComposeAppManager::Name) {
       auto custom_data{t.custom_data()};
       custom_data[LocalSrcDirKey]["ostree"] = src.OstreeRepoDir.string();
       found_targets.emplace_back(Target::updateCustom(t, custom_data));
-      LOG_INFO << "\tall target content have been found";
+      LOG_INFO << "\t" << t.filename() << " - all target content has been found";
       if (!just_latest) {
         continue;
       }
@@ -374,7 +373,7 @@ static std::vector<Uptane::Target> getAvailableTargets(const PackageConfig& pcon
       custom_data[LocalSrcDirKey]["ostree"] = src.OstreeRepoDir.string();
       custom_data.removeMember("docker_compose_apps");
       found_targets.emplace_back(Target::updateCustom(t, custom_data));
-      LOG_INFO << "\tall target content have been found";
+      LOG_INFO << "\t" << t.filename() << " - all target content has been found";
       if (!just_latest) {
         continue;
       }
@@ -394,10 +393,7 @@ static std::vector<Uptane::Target> getAvailableTargets(const PackageConfig& pcon
       }
     }
     if (!missing_apps.empty()) {
-      LOG_INFO << "\tmissing apps:";
-      for (const auto& app : missing_apps) {
-        LOG_INFO << "\t\t" << app;
-      }
+      LOG_INFO << "\t" << t.filename() << " - missing apps: " << boost::algorithm::join(missing_apps, ", ");
       continue;
     }
     auto custom_data{t.custom_data()};
@@ -421,7 +417,7 @@ static std::vector<Uptane::Target> getAvailableTargets(const PackageConfig& pcon
     custom_data[LocalSrcDirKey]["ostree"] = src.OstreeRepoDir.string();
     custom_data[LocalSrcDirKey]["apps"] = src.AppsDir.string();
     found_targets.emplace_back(Target::updateCustom(t, custom_data));
-    LOG_INFO << "\tall target content have been found";
+    LOG_INFO << "\t" << t.filename() << " - all target content has been found";
     if (just_latest) {
       break;
     }

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -111,9 +111,23 @@ StatusCode CheckIn(AkliteClient &client, const LocalUpdateSource *local_update_s
   return res2StatusCode<CheckInResult::Status>(c2s, cr.status);
 }
 
+static CheckInResult checkIn(AkliteClientExt &client, CheckMode check_mode,
+                             const LocalUpdateSource *local_update_source) {
+  if (check_mode == CheckMode::Update) {
+    if (local_update_source == nullptr) {
+      return client.CheckIn();
+    } else {
+      return client.CheckInLocal(local_update_source);
+    }
+  } else {
+    return client.CheckInCurrent(local_update_source);
+  }
+}
+
 static StatusCode pullAndInstall(AkliteClientExt &client, int version, const std::string &target_name,
                                  InstallMode install_mode, bool force_downgrade,
-                                 const LocalUpdateSource *local_update_source, PullMode pull_mode, bool do_install) {
+                                 const LocalUpdateSource *local_update_source, PullMode pull_mode, bool do_install,
+                                 CheckMode check_mode) {
   // Check if the device is in a correct state to start a new update
   if (client.IsInstallationInProgress()) {
     LOG_ERROR << "Cannot start Target installation since there is ongoing installation; target: "
@@ -121,11 +135,16 @@ static StatusCode pullAndInstall(AkliteClientExt &client, int version, const std
     return StatusCode::InstallationInProgress;
   }
 
-  auto cr = client.GetTargetToInstall(local_update_source, version, target_name, true, true);
+  const auto ci_res = checkIn(client, check_mode, local_update_source);
+  if (!ci_res) {
+    return res2StatusCode<CheckInResult::Status>(c2s, ci_res.status);
+  }
+
+  auto gti_res = client.GetTargetToInstall(ci_res, version, target_name, true, true, local_update_source != nullptr);
 
   //
-  if (cr.selected_target.IsUnknown()) {
-    if (cr.status == GetTargetToInstallResult::Status::NoMatchingTargets) {
+  if (gti_res.selected_target.IsUnknown()) {
+    if (gti_res.status == GetTargetToInstallResult::Status::NoMatchingTargets) {
       std::string target_string;
       if (version == -1 && target_name.empty()) {
         target_string = " version: latest,";
@@ -141,39 +160,40 @@ static StatusCode pullAndInstall(AkliteClientExt &client, int version, const std
       LOG_ERROR << "No Target found;" << target_string
                 << " hardware ID: " << client.GetConfig().get("provision.primary_ecu_hardware_id", "")
                 << ", tag: " << client.GetConfig().get("pacman.tags", "");
-    } else if (cr) {
+    } else if (gti_res) {
       LOG_INFO << "No target to update";
     }
-    return res2StatusCode<GetTargetToInstallResult::Status>(t2s, cr.status);
+    return res2StatusCode<GetTargetToInstallResult::Status>(t2s, gti_res.status);
   }
 
   const auto current{client.GetCurrent()};
-  if (current.Version() > cr.selected_target.Version()) {
+  if (current.Version() > gti_res.selected_target.Version()) {
     LOG_WARNING << "Found TUF Target is lower version than the current on; "
-                << "current: " << current.Version() << ", found Target: " << cr.selected_target.Version();
+                << "current: " << current.Version() << ", found Target: " << gti_res.selected_target.Version();
 
     if (!force_downgrade) {
       LOG_ERROR << "Downgrade is not allowed by default, re-run the command with `--force` option to force downgrade";
       return StatusCode::InstallDowngradeAttempt;
     }
-    LOG_WARNING << "Downgrading from " << current.Version() << " to  " << cr.selected_target.Version() << "...";
+    LOG_WARNING << "Downgrading from " << current.Version() << " to  " << gti_res.selected_target.Version() << "...";
   }
 
-  auto ir = client.PullAndInstall(cr.selected_target, "", "", install_mode, local_update_source,
-                                  pull_mode == PullMode::All, do_install);
-  return res2StatusCode<InstallResult::Status>(i2s, ir.status);
+  auto pi_res = client.PullAndInstall(gti_res.selected_target, "", "", install_mode, local_update_source,
+                                      pull_mode == PullMode::All, do_install);
+  return res2StatusCode<InstallResult::Status>(i2s, pi_res.status);
 }
 
 StatusCode Pull(AkliteClientExt &client, int version, const std::string &target_name, bool force_downgrade,
-                const LocalUpdateSource *local_update_source) {
+                const LocalUpdateSource *local_update_source, CheckMode check_mode) {
   return pullAndInstall(client, version, target_name, InstallMode::All, force_downgrade, local_update_source,
-                        PullMode::All, false);
+                        PullMode::All, false, check_mode);
 }
 
 StatusCode Install(AkliteClientExt &client, int version, const std::string &target_name, InstallMode install_mode,
-                   bool force_downgrade, const LocalUpdateSource *local_update_source, PullMode pull_mode) {
+                   bool force_downgrade, const LocalUpdateSource *local_update_source, PullMode pull_mode,
+                   CheckMode check_mode) {
   return pullAndInstall(client, version, target_name, install_mode, force_downgrade, local_update_source, pull_mode,
-                        true);
+                        true, check_mode);
 }
 
 StatusCode CompleteInstall(AkliteClient &client) {

--- a/tests/apiclient_test.cc
+++ b/tests/apiclient_test.cc
@@ -563,7 +563,8 @@ TEST_F(ApiClientTest, ExtApiRollback) {
   update(*liteclient, getInitialTarget(), new_target);
 
   AkliteClientExt client(liteclient);
-  auto result = client.GetTargetToInstall();
+  auto ci_res = client.CheckIn();
+  auto result = client.GetTargetToInstall(ci_res);
   ASSERT_EQ(GetTargetToInstallResult::Status::Ok, result.status);
   ASSERT_FALSE(result.selected_target.IsUnknown());
   ASSERT_FALSE(client.IsRollback(result.selected_target));
@@ -580,7 +581,8 @@ TEST_F(ApiClientTest, ExtApiRollback) {
   ASSERT_EQ(rebooted_client.GetCurrent().Sha256Hash(), getInitialTarget().sha256Hash());
 
   // Verify that GetTargetToInstall returns no target, because the latest one was already tried, and rolled back
-  result = client.GetTargetToInstall();
+  ci_res = rebooted_client.CheckIn();
+  result = rebooted_client.GetTargetToInstall(ci_res);
   ASSERT_TRUE(result.selected_target.IsUnknown());
   ASSERT_EQ(result.status, GetTargetToInstallResult::Status::Ok);
 
@@ -599,7 +601,8 @@ TEST_F(ApiClientTest, ExtApiInstallationInProgress) {
   auto target2 = createTarget();
   AkliteClientExt client(liteclient);
   client.CompleteInstallation();
-  auto result = client.GetTargetToInstall();
+  auto ci_res = client.CheckIn();
+  auto result = client.GetTargetToInstall(ci_res);
   ASSERT_EQ(GetTargetToInstallResult::Status::Ok, result.status);
   ASSERT_FALSE(result.selected_target.IsUnknown());
   ASSERT_EQ(target2.filename(), result.selected_target.Name());
@@ -622,7 +625,8 @@ TEST_F(ApiClientTest, ExtApiInstallationInProgress) {
 
   auto current = rebooted_client.GetCurrent();
   ASSERT_EQ(current.Sha256Hash(), target2.sha256Hash());
-  result = rebooted_client.GetTargetToInstall();
+  ci_res = rebooted_client.CheckIn();
+  result = rebooted_client.GetTargetToInstall(ci_res);
   ASSERT_TRUE(result.selected_target.IsUnknown());
   ASSERT_EQ(result.status, GetTargetToInstallResult::Status::Ok);
 }
@@ -639,7 +643,8 @@ TEST_F(ApiClientTest, ExtApiSeparatePullAndInstall) {
   auto target2 = createTarget();
   AkliteClientExt client(liteclient);
   client.CompleteInstallation();
-  auto result = client.GetTargetToInstall();
+  auto ci_res = client.CheckIn();
+  auto result = client.GetTargetToInstall(ci_res);
   ASSERT_EQ(GetTargetToInstallResult::Status::Ok, result.status);
   ASSERT_FALSE(result.selected_target.IsUnknown());
   ASSERT_EQ(target2.filename(), result.selected_target.Name());
@@ -669,7 +674,8 @@ TEST_F(ApiClientTest, ExtApiSeparatePullAndInstall) {
 
   auto current = rebooted_client.GetCurrent();
   ASSERT_EQ(current.Sha256Hash(), target2.sha256Hash());
-  result = rebooted_client.GetTargetToInstall();
+  ci_res = rebooted_client.CheckIn();
+  result = rebooted_client.GetTargetToInstall(ci_res);
   ASSERT_TRUE(result.selected_target.IsUnknown());
   ASSERT_EQ(result.status, GetTargetToInstallResult::Status::Ok);
 }

--- a/tests/nospace_test.cc
+++ b/tests/nospace_test.cc
@@ -546,7 +546,8 @@ TEST_F(NoSpaceTest, ExtApiOstreeUpdateNoSpaceBeforeUpdate) {
     // 50% reserved, 49% free -> 0% available
     SetFreeBlockNumb(49, 100);
     AkliteClientExt client(liteclient);
-    auto result = client.GetTargetToInstall();
+    auto ci_res = client.CheckIn();
+    auto result = client.GetTargetToInstall(ci_res);
     ASSERT_FALSE(result.selected_target.IsUnknown());
     ASSERT_EQ(result.status, GetTargetToInstallResult::Status::Ok);
 
@@ -573,7 +574,8 @@ TEST_P(AkliteNoSpaceTest, ExtApiNotEnoughSpaceForApps) {
     SetFreeBlockNumb(20, 100);
 
     AkliteClientExt akclient(client);
-    auto result = akclient.GetTargetToInstall();
+    auto ci_res = akclient.CheckIn();
+    auto result = akclient.GetTargetToInstall(ci_res);
     ASSERT_FALSE(result.selected_target.IsUnknown());
     ASSERT_EQ(result.status, GetTargetToInstallResult::Status::Ok);
 


### PR DESCRIPTION
@mike-sul please take a look at the overall set of changes. I will probably still improve the code, and also, it was not tested yet.

Main concerns:
- Make sure we do want to change the cli interface at that level. See how in the unit tests we now need to call `cli::CheckIn` explicitly most of the times before we call `cli::Install`;

- The `check-for-update-post` success callback is a bit of a problem. The original daemon behavior is to call it at the end of `GetTargetsToInstall` (like it was before the recent changes), and IMO we should keep that same behavior where possible. However, if we call the `CheckIn` method exclusively, `check-for-update-post` success should be called at the end of `CheckIn`, and, when calling the standalone pull or install operations, `GetTargetToInstall` should never call `check-for-update-post` (not even on errors). The expected behavior is defined by setting a new boolean parameter in the `AkLiteClientExt` constructor.
