### PR TITLE
tuf: Add missing include guards in internal tuf headers

### DIFF
--- a/src/tuf/akhttpsreposource.h
+++ b/src/tuf/akhttpsreposource.h
@@ -1,3 +1,6 @@
+#ifndef AKTUALIZR_LITE_AK_HTTP_REPO_SOURCE_H_
+#define AKTUALIZR_LITE_AK_HTTP_REPO_SOURCE_H_
+
 #include "uptane/fetcher.h"
 
 #include "aktualizr-lite/tuf/tuf.h"
@@ -25,3 +28,4 @@ class AkHttpsRepoSource : public RepoSource {
 };
 
 }  // namespace aklite::tuf
+#endif

--- a/src/tuf/akrepo.h
+++ b/src/tuf/akrepo.h
@@ -1,3 +1,6 @@
+#ifndef AKTUALIZR_LITE_REPO_H_
+#define AKTUALIZR_LITE_REPO_H_
+
 #include "libaktualizr/config.h"
 #include "storage/invstorage.h"
 #include "uptane/fetcher.h"
@@ -41,3 +44,5 @@ class AkRepo : public Repo {
 };
 
 }  // namespace aklite::tuf
+
+#endif

--- a/src/tuf/localreposource.h
+++ b/src/tuf/localreposource.h
@@ -1,3 +1,6 @@
+#ifndef AKTUALIZR_LITE_AK_LOCAL_REPO_SOURCE_H_
+#define AKTUALIZR_LITE_AK_LOCAL_REPO_SOURCE_H_
+
 #include "boost/filesystem.hpp"
 
 #include "aktualizr-lite/tuf/tuf.h"
@@ -22,3 +25,5 @@ class LocalRepoSource : public RepoSource {
 };
 
 }  // namespace aklite::tuf
+
+#endif


### PR DESCRIPTION
Three internal header files added by commit baf54fa (tuf: Create a new API to encapsulate TUF operations, 2023-10-19) lacked the file guards. It did not lead to any apparent issue.