### PR TITLE
tests: Replace LiteCLient with LiteClientMock, and add improve CheckIn tests

### DIFF
--- a/tests/apiclient_test.cc
+++ b/tests/apiclient_test.cc
@@ -23,6 +23,9 @@
 
 #include "fixtures/liteclienttest.cc"
 
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
 using ::testing::NiceMock;
 
 class ApiClientTest : public fixtures::ClientTest {
@@ -80,7 +83,10 @@ TEST_F(ApiClientTest, GetDevice) {
 }
 
 TEST_F(ApiClientTest, CheckIn) {
-  AkliteClient client(createLiteClient(InitialVersion::kOn));
+  auto lite_client = createLiteClient(InitialVersion::kOn);
+  AkliteClient client(lite_client);
+  EXPECT_CALL(*lite_client, callback(testing::StrEq("check-for-update-pre"), testing::_, testing::StrEq(""))).Times(1);
+  EXPECT_CALL(*lite_client, callback(testing::StrEq("check-for-update-post"), testing::_, testing::StrEq("OK")));
 
   auto result = client.CheckIn();
 
@@ -96,6 +102,9 @@ TEST_F(ApiClientTest, CheckIn) {
   ASSERT_TRUE(resetEvents());
 
   auto new_target = createTarget();
+
+  EXPECT_CALL(*lite_client, callback(testing::StrEq("check-for-update-pre"), testing::_, testing::StrEq(""))).Times(1);
+  EXPECT_CALL(*lite_client, callback(testing::StrEq("check-for-update-post"), testing::_, testing::StrEq("OK")));
   result = client.CheckIn();
   ASSERT_EQ(0, getDeviceGateway().getEvents().size());
   ASSERT_EQ("", getDeviceGateway().readSotaToml());

--- a/tests/apiclient_test.cc
+++ b/tests/apiclient_test.cc
@@ -27,9 +27,9 @@ using ::testing::NiceMock;
 
 class ApiClientTest : public fixtures::ClientTest {
  protected:
-  std::shared_ptr<LiteClient> createLiteClient(InitialVersion initial_version = InitialVersion::kOn,
-                                               boost::optional<std::vector<std::string>> apps = boost::none,
-                                               bool finalize = true) override {
+  std::shared_ptr<fixtures::LiteClientMock> createLiteClient(
+      InitialVersion initial_version = InitialVersion::kOn,
+      boost::optional<std::vector<std::string>> apps = boost::none, bool finalize = true) override {
     app_engine_mock_ = std::make_shared<NiceMock<fixtures::MockAppEngine>>();
     lite_client_ = ClientTest::createLiteClient(app_engine_mock_, initial_version, apps);
     return lite_client_;
@@ -54,7 +54,7 @@ class ApiClientTest : public fixtures::ClientTest {
 
  private:
   std::shared_ptr<NiceMock<fixtures::MockAppEngine>> app_engine_mock_;
-  std::shared_ptr<LiteClient> lite_client_;
+  std::shared_ptr<fixtures::LiteClientMock> lite_client_;
   std::string pacman_type_;
 };
 

--- a/tests/boot_flag_mgmt_test.cc
+++ b/tests/boot_flag_mgmt_test.cc
@@ -17,9 +17,9 @@ using ::testing::NiceMock;
 
 class BootFlagMgmtTest : public fixtures::ClientTest {
  protected:
-  std::shared_ptr<LiteClient> createLiteClient(InitialVersion initial_version = InitialVersion::kOn,
-                                               boost::optional<std::vector<std::string>> apps = boost::none,
-                                               bool finalize = true) override {
+  std::shared_ptr<fixtures::LiteClientMock> createLiteClient(
+      InitialVersion initial_version = InitialVersion::kOn,
+      boost::optional<std::vector<std::string>> apps = boost::none, bool finalize = true) override {
     app_engine_mock_ = std::make_shared<NiceMock<fixtures::MockAppEngine>>();
 
     auto client =

--- a/tests/daemon_test.cc
+++ b/tests/daemon_test.cc
@@ -22,9 +22,9 @@ using ::testing::NiceMock;
 
 class DaemonTest : public fixtures::ClientTest {
  protected:
-  std::shared_ptr<LiteClient> createLiteClient(InitialVersion initial_version = InitialVersion::kOn,
-                                               boost::optional<std::vector<std::string>> apps = boost::none,
-                                               bool finalize = true) override {
+  std::shared_ptr<fixtures::LiteClientMock> createLiteClient(
+      InitialVersion initial_version = InitialVersion::kOn,
+      boost::optional<std::vector<std::string>> apps = boost::none, bool finalize = true) override {
     app_engine_mock_ = std::make_shared<NiceMock<fixtures::MockAppEngine>>();
     lite_client_ = ClientTest::createLiteClient(app_engine_mock_, initial_version, apps);
     return lite_client_;
@@ -32,7 +32,7 @@ class DaemonTest : public fixtures::ClientTest {
 
  private:
   std::shared_ptr<NiceMock<fixtures::MockAppEngine>> app_engine_mock_;
-  std::shared_ptr<LiteClient> lite_client_;
+  std::shared_ptr<fixtures::LiteClientMock> lite_client_;
   std::string pacman_type_;
 };
 

--- a/tests/fixtures/aklitetest.cc
+++ b/tests/fixtures/aklitetest.cc
@@ -22,7 +22,7 @@ class AkliteTest : public fixtures::ClientTest,
     }
   }
 
-  std::shared_ptr<LiteClient> createLiteClient(InitialVersion initial_version = InitialVersion::kOn,
+  std::shared_ptr<fixtures::LiteClientMock> createLiteClient(InitialVersion initial_version = InitialVersion::kOn,
                                                boost::optional<std::vector<std::string>> apps = boost::none,
                                                bool finalize = true) override {
     const auto app_engine_type{GetParam()};

--- a/tests/fixtures/liteclienthsmtest.cc
+++ b/tests/fixtures/liteclienthsmtest.cc
@@ -148,7 +148,7 @@ class ClientHSMTest : public ClientTest {
   ClientHSMTest() : ClientTest(hsm_->path_) {
   }
 
-  std::shared_ptr<LiteClient> createLiteClient(const std::shared_ptr<AppEngine>& app_engine,
+  std::shared_ptr<fixtures::LiteClientMock> createLiteClient(const std::shared_ptr<AppEngine>& app_engine,
                                                InitialVersion version = InitialVersion::kOn,
                                                boost::optional<std::vector<std::string>> apps = boost::none,
                                                const std::string& compose_apps_root = "") {
@@ -173,7 +173,7 @@ class ClientHSMTest : public ClientTest {
       addTarget(conf, version);
     }
 
-    auto lite_client = std::make_shared<LiteClient>(conf, app_engine, p11_);
+    auto lite_client = std::make_shared<fixtures::LiteClientMock>(conf, app_engine, p11_);
     lite_client->importRootMetaIfNeededAndPresent();
     lite_client->finalizeInstall();
     return lite_client;

--- a/tests/liteclientHSM_test.cc
+++ b/tests/liteclientHSM_test.cc
@@ -29,9 +29,9 @@ using ::testing::NiceMock;
 
 class LiteClientHSMTest : public fixtures::ClientHSMTest {
  protected:
-  std::shared_ptr<LiteClient> createLiteClient(InitialVersion initial_version = InitialVersion::kOn,
-                                               boost::optional<std::vector<std::string>> apps = boost::none,
-                                               bool finalize = true) override {
+  std::shared_ptr<fixtures::LiteClientMock> createLiteClient(
+      InitialVersion initial_version = InitialVersion::kOn,
+      boost::optional<std::vector<std::string>> apps = boost::none, bool finalize = true) override {
     app_engine_mock_ = std::make_shared<NiceMock<fixtures::MockAppEngine>>();
     return ClientHSMTest::createLiteClient(app_engine_mock_, initial_version, apps);
   }

--- a/tests/liteclient_test.cc
+++ b/tests/liteclient_test.cc
@@ -31,9 +31,9 @@ using ::testing::Return;
 
 class LiteClientTest : public fixtures::ClientTest {
  protected:
-  std::shared_ptr<LiteClient> createLiteClient(InitialVersion initial_version = InitialVersion::kOn,
-                                               boost::optional<std::vector<std::string>> apps = boost::none,
-                                               bool finalize = true) override {
+  std::shared_ptr<fixtures::LiteClientMock> createLiteClient(
+      InitialVersion initial_version = InitialVersion::kOn,
+      boost::optional<std::vector<std::string>> apps = boost::none, bool finalize = true) override {
     app_engine_mock_ = std::make_shared<NiceMock<fixtures::MockAppEngine>>();
     return ClientTest::createLiteClient(app_engine_mock_, initial_version, apps, "", boost::none, true, finalize);
   }

--- a/tests/nospace_test.cc
+++ b/tests/nospace_test.cc
@@ -27,9 +27,9 @@ using ::testing::NiceMock;
 
 class NoSpaceTest : public fixtures::ClientTest {
  protected:
-  std::shared_ptr<LiteClient> createLiteClient(InitialVersion initial_version = InitialVersion::kOn,
-                                               boost::optional<std::vector<std::string>> apps = boost::none,
-                                               bool finalize = true) override {
+  std::shared_ptr<fixtures::LiteClientMock> createLiteClient(
+      InitialVersion initial_version = InitialVersion::kOn,
+      boost::optional<std::vector<std::string>> apps = boost::none, bool finalize = true) override {
     app_engine_mock_ = std::make_shared<NiceMock<fixtures::MockAppEngine>>();
     return ClientTest::createLiteClient(app_engine_mock_, initial_version, apps, "", boost::none, true, finalize);
   }


### PR DESCRIPTION
@mike-sul I'm ok with dropping the changes if you don't think it is worth to replace `LiteCLient` with `LiteClientMock` globally in the tests. But I believe it will bring some additional tests possibilities that can justify the change.