### PR TITLE
appengine: Add required header to use std::find

### DIFF
--- a/src/appengine.cc
+++ b/src/appengine.cc
@@ -1,4 +1,5 @@
 #include "appengine.h"
+#include <algorithm>
 
 bool operator&(const AppEngine::Apps& apps, const AppEngine::App& app) {
   return apps.end() != std::find(apps.begin(), apps.end(), app);


### PR DESCRIPTION
It turned out that g++ v14.1.1 requires explicit inclusion of the `algorithm` header to use `std::find`.