### PR TITLE
Revert changes that introduced use of `composectl ps` to verify apps status

### DIFF
--- a/src/composeapp/appengine.cc
+++ b/src/composeapp/appengine.cc
@@ -71,21 +71,6 @@ bool AppEngine::isRunning(const App& app) const {
   return res;
 }
 
-Json::Value AppEngine::getRunningAppsInfo() const {
-  Json::Value app_statuses;
-  try {
-    std::future<std::string> output;
-    exec(boost::format{"%s --store %s ps --format json"} % composectl_cmd_ % storeRoot(), "",
-         boost::process::std_out > output);
-    const auto output_str{output.get()};
-    app_statuses = Utils::parseJSON(output_str);
-  } catch (const std::exception& exc) {
-    LOG_WARNING << "Failed to get an info about running containers: " << exc.what();
-  }
-
-  return app_statuses;
-}
-
 void AppEngine::prune(const Apps& app_shortlist) {
   try {
     // Remove apps that are not in the shortlist

--- a/src/composeapp/appengine.cc
+++ b/src/composeapp/appengine.cc
@@ -9,8 +9,6 @@
 namespace composeapp {
 enum class ExitCode { ExitCodeInsufficientSpace = 100 };
 
-static bool checkAppStatus(const AppEngine::App& app, const Json::Value& status);
-
 AppEngine::Result AppEngine::fetch(const App& app) {
   Result res{false};
   try {
@@ -55,20 +53,6 @@ void AppEngine::remove(const App& app) {
   } catch (const std::exception& exc) {
     LOG_WARNING << "App: " << app.name << ", failed to remove: " << exc.what();
   }
-}
-
-bool AppEngine::isRunning(const App& app) const {
-  bool res{false};
-  try {
-    std::future<std::string> output;
-    exec(boost::format{"%s --store %s ps %s --format json"} % composectl_cmd_ % storeRoot() % app.uri, "",
-         boost::process::std_out > output);
-    const auto app_status{Utils::parseJSON(output.get())};
-    res = checkAppStatus(app, app_status);
-  } catch (const std::exception& exc) {
-    LOG_ERROR << "failed to verify whether app is running; app: " << app.name << ", err: " << exc.what();
-  }
-  return res;
 }
 
 void AppEngine::prune(const Apps& app_shortlist) {
@@ -175,31 +159,6 @@ void AppEngine::installAppAndImages(const App& app) {
   exec(boost::format{"%s --store %s --compose %s --host %s install %s"} % composectl_cmd_ % storeRoot() %
            installRoot() % dockerHost() % app.uri,
        "failed to installl compose app");
-}
-
-static bool checkAppStatus(const AppEngine::App& app, const Json::Value& status) {
-  if (!status.isMember(app.uri)) {
-    LOG_ERROR << "could not get app status; uri: " << app.uri;
-    return false;
-  }
-  if (!status[app.uri].isMember("services") || status[app.uri]["services"].isNull()) {
-    LOG_INFO << app.name << " is not running; uri: " << app.uri;
-    return false;
-  }
-
-  bool is_running{true};
-  const std::set<std::string> broken_states{"created", "missing", "unknown"};
-  for (const auto& s : status[app.uri]["services"]) {
-    if (broken_states.count(s["state"].asString()) > 0) {
-      is_running = false;
-      break;
-    }
-  }
-  if (!is_running) {
-    LOG_INFO << app.name << " is not running; uri: " << app.uri;
-    LOG_INFO << status[app.uri];
-  }
-  return is_running;
 }
 
 }  // namespace composeapp

--- a/src/composeapp/appengine.h
+++ b/src/composeapp/appengine.h
@@ -26,7 +26,6 @@ class AppEngine : public Docker::RestorableAppEngine {
   Result fetch(const App& app) override;
   void remove(const App& app) override;
   bool isRunning(const App& app) const override;
-  Json::Value getRunningAppsInfo() const override;
   void prune(const Apps& app_shortlist) override;
 
  private:

--- a/src/composeapp/appengine.h
+++ b/src/composeapp/appengine.h
@@ -25,7 +25,6 @@ class AppEngine : public Docker::RestorableAppEngine {
 
   Result fetch(const App& app) override;
   void remove(const App& app) override;
-  bool isRunning(const App& app) const override;
   void prune(const Apps& app_shortlist) override;
 
  private:

--- a/src/composeappmanager.cc
+++ b/src/composeappmanager.cc
@@ -226,7 +226,7 @@ ComposeAppManager::AppsContainer ComposeAppManager::getAppsToUpdate(const Uptane
     }
 
     LOG_DEBUG << app_name << " performing full status check";
-    if (!app_engine_->isFetched({app_name, app_pair.second}) || !app_engine_->isRunning({app_name, app_pair.second})) {
+    if (!app_engine_->isRunning({app_name, app_pair.second})) {
       // an App that is supposed to be installed and running is not fully installed or running
       apps_to_update.insert(app_pair);
       LOG_INFO << app_name << " update will be re-installed or completed";

--- a/tests/docker-compose_fake.py
+++ b/tests/docker-compose_fake.py
@@ -71,7 +71,6 @@ def up(out_dir, app_name, compose, flags):
                                       " since the networking is down")
             container = {"Labels": {}}
             container["Labels"]["com.docker.compose.project"] = app_name
-            container["Labels"]["com.docker.compose.project.working_dir"] = os.getcwd()
             container["Labels"]["com.docker.compose.service"] = service
             container["Labels"]["io.compose-spec.config-hash"] = compose["services"][service]["labels"][
                 "io.compose-spec.config-hash"]

--- a/tests/docker-compose_fake.py
+++ b/tests/docker-compose_fake.py
@@ -76,11 +76,9 @@ def up(out_dir, app_name, compose, flags):
                 "io.compose-spec.config-hash"]
             container["Image"] = compose["services"][service]["image"]
             container["State"] = "running" if "-d" in flags else "created"
-            container["Status"] = "Up 1 minute" if "-d" in flags else "Ready"
             containers.append(container)
         else:
             container["State"] = "running" if "-d" in flags else "created"
-            container["Status"] = "Up 1 minute" if "-d" in flags else "Ready"
 
     with open(os.path.join(out_dir, "containers.json"), "w") as f:
         json.dump(containers, f)

--- a/tests/docker-daemon_fake.py
+++ b/tests/docker-daemon_fake.py
@@ -48,23 +48,6 @@ class Handler(SimpleHTTPRequestHandler):
             self.send_header('Content-Type', 'application/json')
             self.end_headers()
             self.wfile.write(json.dumps(dockerd_response).encode())
-        elif self.path.find('/containers/json') != -1:
-            dockerd_response = []
-            try:
-                with open(os.path.join(self.server.root_dir, "containers.json"), "r") as f:
-                    dockerd_response = json.load(f)
-            except FileNotFoundError:
-                pass
-            except Exception as exc:
-                logger.error(exc)
-
-            logger.info(">>> sending response  %s" % json.dumps(dockerd_response))
-            self.send_response(200)
-            self.send_header('Content-Type', 'application/json')
-            data_to_send = json.dumps(dockerd_response).encode()
-            self.send_header('Content-Length', len(data_to_send))
-            self.end_headers()
-            self.wfile.write(json.dumps(dockerd_response).encode())
         else:
             self.send_response(200)
             self.send_header('Api-Version:', API_VERSION)


### PR DESCRIPTION
`composectl ps <app>` is not working correctly when:
 - System contains multiple versions of a same application; or
 - There are multiple docker containers running using the same image.

Revert it's use for now, while we prepare and test the required changes.
