### PR TITLE
Fix running app status check

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.22.2-bookworm AS composeapp
 # Build composeapp
 WORKDIR /build
 RUN git clone https://github.com/foundriesio/composeapp.git && \
-    cd composeapp && git checkout 1b6f1f2d8f55d40fef10c8ddfef224a9a58caa27 && make && cp ./bin/composectl /usr/bin/
+    cd composeapp && git checkout c62494f56b123a411f7221f4ee87ed839d0930bd && make && cp ./bin/composectl /usr/bin/
 
 
 FROM ubuntu:jammy


### PR DESCRIPTION
This PR restores back the functionality that utilizes `composectl` to check app running status (`composectl ps <uri>`) as well as obtaining status of all currently running apps `composectl ps`.

The functionality was reverted because of the issue in the `composectl`. Since the `composectl` issue has been fixed it makes sense to restore the reverted commits. See the corresponding PR for more details https://github.com/foundriesio/composeapp/pull/24.