### PR TITLE
Revert `composectl` usage for checking whether app is installed

### DIFF
--- a/src/composeapp/appengine.cc
+++ b/src/composeapp/appengine.cc
@@ -131,30 +131,6 @@ bool AppEngine::isAppFetched(const App& app) const {
   return res;
 }
 
-bool AppEngine::isAppInstalled(const App& app) const {
-  bool res{false};
-  try {
-    std::future<std::string> output;
-    exec(boost::format{"%s --store %s check %s --local --install --format json"} % composectl_cmd_ % storeRoot() %
-             app.uri,
-         "", boost::process::std_out > output);
-    const std::string output_str{output.get()};
-    const auto app_fetch_status{Utils::parseJSON(output_str)};
-    if (app_fetch_status.isMember("install_check") && app_fetch_status["install_check"].isMember(app.uri) &&
-        app_fetch_status["install_check"][app.uri].isMember("missing_images") &&
-        (app_fetch_status["install_check"][app.uri]["missing_images"].isNull() ||
-         app_fetch_status["install_check"][app.uri]["missing_images"].empty())) {
-      res = true;
-    }
-  } catch (const ExecError& exc) {
-    LOG_DEBUG << "app is not fully fetched or installed; app: " << app.name << ", status: " << exc.what();
-  } catch (const std::exception& exc) {
-    LOG_ERROR << "failed to verify whether app is installed; app: " << app.name << ", err: " << exc.what();
-    throw;
-  }
-  return res;
-}
-
 void AppEngine::installAppAndImages(const App& app) {
   exec(boost::format{"%s --store %s --compose %s --host %s install %s"} % composectl_cmd_ % storeRoot() %
            installRoot() % dockerHost() % app.uri,

--- a/src/composeapp/appengine.h
+++ b/src/composeapp/appengine.h
@@ -29,7 +29,6 @@ class AppEngine : public Docker::RestorableAppEngine {
 
  private:
   bool isAppFetched(const App& app) const override;
-  bool isAppInstalled(const App& app) const override;
   void installAppAndImages(const App& app) override;
 
   const std::string composectl_cmd_;

--- a/src/docker/restorableappengine.h
+++ b/src/docker/restorableappengine.h
@@ -118,7 +118,6 @@ class RestorableAppEngine : public AppEngine {
   const StorageSpaceFunc& storageSpaceFunc() const { return storage_space_func_; }
 
   virtual bool isAppFetched(const App& app) const;
-  virtual bool isAppInstalled(const App& app) const;
   virtual void installAppAndImages(const App& app);
 
  private:
@@ -139,6 +138,7 @@ class RestorableAppEngine : public AppEngine {
   void installAppImages(const boost::filesystem::path& app_dir);
 
   bool areAppImagesFetched(const App& app) const;
+  bool isAppInstalled(const App& app) const;
 
   // check if App&Images are running
   static bool isRunning(const App& app, const std::string& compose_file,

--- a/src/liteclient.cc
+++ b/src/liteclient.cc
@@ -153,9 +153,7 @@ LiteClient::LiteClient(Config config_in, const AppEngine::Ptr& app_engine, const
   } else {
     throw std::runtime_error("Unsupported package manager type: " + config.pacman.type);
   }
-  if (config.pacman.extra.count("x-fio-test-no-init-target") == 0) {
-    basepacman->setInitialTargetIfNeeded(config.provision.primary_ecu_hardware_id);
-  }
+  basepacman->setInitialTargetIfNeeded(config.provision.primary_ecu_hardware_id);
   package_manager_ = basepacman;
   // After running `setInitialTargetIfNeeded` details of the current target are available, so
   // we should update value of the request headers that are related to the current Target description

--- a/tests/docker-daemon_fake.py
+++ b/tests/docker-daemon_fake.py
@@ -29,25 +29,6 @@ class Handler(SimpleHTTPRequestHandler):
             self.send_header('Content-type', 'text/plain; charset=utf-8')
             self.send_header('Api-Version:', API_VERSION)
             self.end_headers()
-        elif self.path.find('/images/json') != -1:
-            dockerd_response = []
-            try:
-                with open(os.path.join(self.server.root_dir, "images.json"), "r") as f:
-                    images = json.load(f)
-                    for image in images:
-                        dockerd_response.append({
-                            "RepoDigests": [image]
-                        })
-            except FileNotFoundError:
-                pass
-            except Exception as exc:
-                logger.error(exc)
-
-            logger.info(">>> sending response  %s" % json.dumps(dockerd_response))
-            self.send_response(200)
-            self.send_header('Content-Type', 'application/json')
-            self.end_headers()
-            self.wfile.write(json.dumps(dockerd_response).encode())
         else:
             self.send_response(200)
             self.send_header('Api-Version:', API_VERSION)


### PR DESCRIPTION
This reverts commit 37c0249d94ae1d399e170549acdb33bb5194a704.

The given functionality does not work if images hosted in docker.io are specified in a docker compose project file in a full format. For example, "docker.io/library/nginx:stable-alpine" or "docker.io/homeassistant/home-assistant:stable".

The dockerd removes the "docker.io" or "docker.io/library" prefix when stores such images in its store and as result returns the image URIs in the shorten format in a response to "http://localhost/images/json?all=1" request. For example, "nginx@sha256:<hash>" or "homeassistant/home-assistant@sha256:<hash>".

Therefore, it is not possible to map images listed in the compose project to images reported by dockerd unless the dockerd's URI shortening rules are taken in the "isAppInstalled" logic.