### PR TITLE
Report which apps require update in DownloadStarted event

### DIFF
--- a/src/aklite_client_ext.cc
+++ b/src/aklite_client_ext.cc
@@ -120,7 +120,8 @@ GetTargetToInstallResult AkliteClientExt::GetTargetToInstall(const CheckInResult
                << " Skipping its installation.";
     }
 
-    if (force_apps_sync || !client_->appsInSync(Target::fromTufTarget(current))) {
+    auto apps_to_update = client_->appsToUpdate(Target::fromTufTarget(current));
+    if (force_apps_sync || !apps_to_update.empty()) {
       // Force installation of apps
       res.selected_target = current;
       LOG_INFO
@@ -128,7 +129,10 @@ GetTargetToInstallResult AkliteClientExt::GetTargetToInstall(const CheckInResult
           << res.selected_target.Name();
 
       res.status = GetTargetToInstallResult::Status::UpdateSyncApps;
-      res.reason = "Syncing Active Target Apps";
+      res.reason = "Syncing Active Target Apps\n";
+      for (const auto& app_to_update : apps_to_update) {
+        res.reason += "- " + app_to_update.first + ": " + app_to_update.second + "\n";
+      }
     } else {
       // No targets to install
       res.selected_target = TufTarget();

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -300,7 +300,7 @@ static StatusCode pullAndInstall(AkliteClientExt &client, int version, const std
     LOG_WARNING << "Downgrading from " << current.Version() << " to  " << gti_res.selected_target.Version() << "...";
   }
 
-  auto pi_res = client.PullAndInstall(gti_res.selected_target, "", "", install_mode, local_update_source,
+  auto pi_res = client.PullAndInstall(gti_res.selected_target, gti_res.reason, "", install_mode, local_update_source,
                                       pull_mode == PullMode::All, do_install);
   return res2StatusCode<InstallResult::Status>(i2s, pi_res.status);
 }

--- a/src/composeappmanager.h
+++ b/src/composeappmanager.h
@@ -39,6 +39,7 @@ class ComposeAppManager : public RootfsTreeManager {
   };
 
   using AppsContainer = std::unordered_map<std::string, std::string>;
+  using AppsSyncReason = std::unordered_map<std::string, std::string>;
 
   ComposeAppManager(const PackageConfig& pconfig, const BootloaderConfig& bconfig,
                     const std::shared_ptr<INvStorage>& storage, const std::shared_ptr<HttpInterface>& http,
@@ -58,8 +59,8 @@ class ComposeAppManager : public RootfsTreeManager {
   // Returns an intersection of Target's Apps and Apps listed in the config (sota.toml:compose_apps)
   // If Apps are not specified in the config then all Target's Apps are returned
   AppsContainer getApps(const Uptane::Target& t) const;
-  AppsContainer getAppsToUpdate(const Uptane::Target& t) const;
-  bool checkForAppsToUpdate(const Uptane::Target& target);
+  AppsContainer getAppsToUpdate(const Uptane::Target& t, AppsSyncReason& apps_and_reasons) const;
+  AppsSyncReason checkForAppsToUpdate(const Uptane::Target& target);
   void setAppsNotChecked() { are_apps_checked_ = false; }
   void handleRemovedApps(const Uptane::Target& target) const;
   Json::Value getAppsState() const;

--- a/src/liteclient.h
+++ b/src/liteclient.h
@@ -1,6 +1,7 @@
 #ifndef AKTUALIZR_LITE_CLIENT_H_
 #define AKTUALIZR_LITE_CLIENT_H_
 
+#include "composeappmanager.h"
 #include "downloader.h"
 #include "gtest/gtest_prod.h"
 #include "libaktualizr/config.h"
@@ -68,6 +69,7 @@ class LiteClient {
   void reportAppsState();
   bool isTargetActive(const Uptane::Target& target) const;
   bool appsInSync(const Uptane::Target& target) const;
+  ComposeAppManager::AppsSyncReason appsToUpdate(const Uptane::Target& target) const;
   void setAppsNotChecked();
   std::string getDeviceID() const;
   static void update_request_headers(std::shared_ptr<HttpClient>& http_client, const Uptane::Target& target,


### PR DESCRIPTION
This is what the DonwloadStarted event details look like for an "apps sync" update operation:
```
Syncing Active Target Apps
- shellhttpd2: missing installation, to be re-installed
```
*(updated the above example after the latest force push)*

I've started by only adding the app name, but decided to go a little further by adding the specific reason as well, so I created a new patch on top of the original implementation.