### PR TITLE
e2e-tests: Add end-to-end test script and docker compose app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,3 +69,18 @@ jobs:
       - run: git submodule update --init --recursive
       - name: test
         run: make -f dev-flow.mk config build test
+
+  e2e-test:
+    name: End-to-end tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - run: git config --global --add safe.directory /__w/aktualizr-lite/aktualizr-lite
+      - run: git submodule update --init --recursive
+      - run: ./dev-shell-e2e-test.sh make -f dev-flow.mk config build
+      - run: ./dev-shell-e2e-test.sh pytest e2e-test.py -k 'test_incremental_updates[True-False] or test_incremental_updates[False-False] or test_update_to_latest[False-False] or test_update_to_latest[True-False]'
+        env:
+          FACTORY: ${{ secrets.E2E_TEST_FACTORY }}
+          BASE_TARGET_VERSION: ${{ secrets.E2E_TEST_BASE_TARGET_VERSION }}
+          USER_TOKEN: ${{ secrets.E2E_TEST_USER_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,36 @@ all $(TASKS) config-coverage test-coverage-html:
 
 test:
 	docker run --init -u $(shell id -u):$(shell id -g) --rm -v $(PWD):$(PWD) -w $(PWD) -eTEST_LABEL=$(TEST_LABEL) -eCTEST_ARGS=$(CTEST_ARGS) -eBUILD_DIR=$(BUILD_DIR) -eGTEST_FILTER=$(GTEST_FILTER) $(CONTAINER) make -f dev-flow.mk $@
+
+# Commands to be used inside the aklite-e2e-test docker
+BIN ?= build/src/aktualizr-lite
+SOTA_DIR = /var/sota
+DEVICE_FACTORY ?= ${FACTORY}
+DEVICE_TOKEN ?= ${AUTH_TOKEN}
+DEVICE_TAG ?= main
+
+${SOTA_DIR}:
+	mkdir -p ${SOTA_DIR}/reset-apps
+	mkdir -p ${SOTA_DIR}/compose-apps
+
+register: ${SOTA_DIR}
+	DEVICE_FACTORY=${DEVICE_FACTORY} lmp-device-register -T ${DEVICE_TOKEN} --start-daemon 0 -d ${SOTA_DIR} -t ${DEVICE_TAG}
+
+unregister:
+	@rm -rf ${SOTA_DIR}/sql.db
+	@rm ${SOTA_DIR}/*.toml
+
+check:
+	${BIN} check
+
+update:
+	@ostree config set core.mode bare-user
+	${BIN} pull
+	@ostree config set core.mode bare-user-only
+	${BIN} install
+
+reboot:
+	@rm -f /var/run/aktualizr-session/need_reboot
+
+run:
+	${BIN} run

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The make environment variables are:
 If `-f dev-flow.mk` is specified, then the `make` command is executed on a host, otherwise the `foundries/aklite-dev` container is used.
 A user can specify their own container to run the commands in by overriding `CONTAINER` environment variable.
 
-### Test
+### Unit Test
 
 ```
 [<MAKE ENV VARS>] make [-f dev-flow.mk] test
@@ -51,7 +51,67 @@ The make environment variables are:
 *  `CTEST_ARGS` - additional `ctest` parameters, by default is set to `--output-on-failure`.
 *  `GTEST_FILTER` - a regexp to filter tests within gtest suits, e.g. `GTEST_FILTER="*OstreeUpdateNoSpaceRetry*" TEST_LABEL="aklite:liteclient" make`.
 
-### Usage
+### Development Test Environment
+
+aktualizr-lite can be executed inside a development container that contains all the required library and tools.
+It works in conjunction with a container running dockerd,
+providing an environment where most of the functional aspects can be tested.
+It allows the communication with an actual factory instance, getting updates and sending back events.
+
+#### Prerequisites
+1. Linux host/VM (tested on Ubuntu and Arch Linux)
+2. Docker engine and client, version >= 20.10.xx
+3. Docker compose, version >= 2.22.0
+
+#### Set required environment variables
+1. `FACTORY` - Name of your FoundriesFactory.
+2. `USER_TOKEN` - Token to access your FoundriesFactory obtained from [Foundries.io settings page](https://app.foundries.io/settings/tokens/).
+
+#### Development in the development container
+Run `./dev-shell-e2e-test.sh`. The initial/first run may take some time as necessary container images are downloaded and built. Subsequent runs will be faster.
+
+##### Register/Unregister device
+Inside the development container, run `make register` or `make unregister` to register or unregister a device, respectively.
+Override the `DEVICE_TAG` environment variable if you need to register a device and set its tag to a non-default value (`main`).
+For example, `DEVICE_TAG=devel make register`.
+
+##### Build aktualizr-lite
+Run `make -f dev-flow.mk` to build the aktualizr-lite client.
+
+##### Configure your development device
+You can add additional configuration `*.toml` snippets to the default device configuration by placing them in `<sota-project-home-dir>/.device/etc.sota`.
+
+For example, a subset of applications that should to be started automatically can be set by creating a `<sota-project-home-dir>/.device/etc.sota/z-90-apps.toml` file with the following content:
+```
+[pacman]
+compose_apps="myapp1,myapp2"
+```
+
+##### Check/Update local TUF metadata
+Run `make check` to update the local TUF (The Update Framework) repository and get a list of available targets. Alternatively, run `./build/src/atualizr-lite check`.
+
+##### Update your development device
+1. Run `make update` to update your development device to the latest available target. The initial update may take some time since it pulls the target's ostree repository from scratch. Subsequent updates are faster as they pull only the differences between two commits.
+2. If a device reboot is required, run `make reboot`.
+3. Finalize the update and run updated apps, if any, by running `make run`.
+
+##### Develop and debug aktualizr-lite
+After the initial update, you can continue developing and debugging aktualizr-lite:
+1. Make code changes.
+2. Build the code with `make -f dev-flow.mk`.
+3. Run or debug one of the SOTA client commands, for example:
+   ```bash
+   ./build/src/atualizr-lite check               # Check for TUF metadata changes and update local TUF repository if any changes are found
+   ./build/src/atualizr-lite pull [<target>]     # Pull the specified target content (ostree and/or apps)
+   ./build/src/atualizr-lite install [<target>]  # Install the pulled target
+   ./build/src/atualizr-lite run                 # Finalize target installation if required after a device reboot
+
+   gdb --args ./build/src/atualizr-lite [<command&params>]   # Debug
+
+###### Emulating device reboot
+To emulate a device reboot in the development container, remove the `/var/run/aktualizr-session/need_reboot` file if it exists.
+
+### Usage on Local Environment
 
 [Run aktualizr-lite locally against your Factory](./how-to-run-locally.md)
 

--- a/README.md
+++ b/README.md
@@ -39,14 +39,6 @@ The make environment variables are:
 If `-f dev-flow.mk` is specified, then the `make` command is executed on a host, otherwise the `foundries/aklite-dev` container is used.
 A user can specify their own container to run the commands in by overriding `CONTAINER` environment variable.
 
-#### Build Custom Client Example
-
-[The example of the custom client](./examples/custom-client-cxx/main.cc) depends on the `libaktualizr` and `libaktualizr_lite` libraries,
-therefore they should be built prior to building of the example. Then, run:
-```
-make [-f dev-flow.mk] custom-client
-```
-
 ### Test
 
 ```
@@ -63,18 +55,7 @@ The make environment variables are:
 
 [Run aktualizr-lite locally against your Factory](./how-to-run-locally.md)
 
-#### Run Custom Client Example
+### Custom Client Example
 
-Prior to running of the custom client example, a user should execute all steps listed in [the how to run locally guide](./how-to-run-locally.md).
-Then, the following command will start the custom client:
-```
-LD_LIBRARY_PATH="$LD_LIBRARY_PATH:./build/aktualizr/src/libaktualizr/:./build/src"  \
-            AKLITE_CONFIG_DIR=<device config dir | sota.toml> ./build-custom/custom-sota-client
-```
-or in the dev container:
-
-```
-docker run --rm -v $PWD:$PWD -w $PWD \
-    -e LD_LIBRARY_PATH="$LD_LIBRARY_PATH:./build-cont/aktualizr/src/libaktualizr/:./build-cont/src" \
-    -e AKLITE_CONFIG_DIR="<device config dir | sota.toml>"  foundries/aklite-dev ./build-cont-custom/custom-sota-client
-```
+Aktualizr-lite provides an API that can be used for creating a custom update client.
+An example of such client is available at https://github.com/foundriesio/sotactl

--- a/dev-flow.mk
+++ b/dev-flow.mk
@@ -2,7 +2,7 @@
 
 CCACHE_DIR = $(shell pwd)/.ccache
 BUILD_DIR ?= build
-TARGET ?= aklite-tests
+TARGET ?= aklite-tests aktualizr-get
 TEST_LABEL ?= aklite
 CTEST_ARGS ?= --output-on-failure
 CXX ?= clang++

--- a/dev-shell-e2e-test.sh
+++ b/dev-shell-e2e-test.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+docker_dir=docker-e2e-test
+docker_path=${PWD}/${docker_dir}
+
+# Function to execute custom commands before exiting
+down() {
+	docker compose --env-file=${docker_path}/.env.dev -f ${docker_path}/docker-compose.yml down --remove-orphans
+	# remove the docker runtime part
+    docker volume rm ${docker_dir}_docker-runtime
+}
+
+# Register the cleanup function to be called on EXIT
+trap down EXIT
+
+mkdir -p $PWD/.device/sysroot
+docker compose --env-file=${docker_path}/.env.dev -f ${docker_path}/docker-compose.yml run -e DEV_USER=$(id -u) -e DEV_GROUP=$(id -g) -e BASE_TARGET_VERSION=${BASE_TARGET_VERSION} -e USER_TOKEN=${USER_TOKEN} aklite-e2e-test "$@"

--- a/docker-e2e-test/.env.dev
+++ b/docker-e2e-test/.env.dev
@@ -1,0 +1,19 @@
+FACTORY=$FACTORY
+AUTH_TOKEN=$USER_TOKEN
+DEVICE_TAG=main
+
+DEV_DIR=$PWD/.device
+SOTA_DIR=$DEV_DIR/sota
+USR_SOTA_DIR=$DEV_DIR/usr.sota
+ETC_SOTA_DIR=$DEV_DIR/etc.sota
+DOCKER_DIR=$DEV_DIR/docker
+
+# /sysroot dir containing ostree repo in /sysroot/ostree/repo
+SYSROOT=$DEV_DIR/sysroot
+BOOTDIR=$DEV_DIR/boot
+
+# /var/lib/docker
+DOCKER_DATA_ROOT=$DOCKER_DIR/data
+
+# Dir containing Dockerfile and build context to build the "aklite-test" image
+AKLITE_E2E_TEST_DOCKER_DIR=$PWD/docker-e2e-test

--- a/docker-e2e-test/Dockerfile
+++ b/docker-e2e-test/Dockerfile
@@ -1,0 +1,73 @@
+FROM golang:1.22.2-bookworm AS composeapp
+# Build composeapp
+WORKDIR /build
+RUN git clone https://github.com/foundriesio/composeapp.git && cd composeapp \
+    && STOREROOT=/var/sota/reset-apps COMPOSEROOT=/var/sota/compose-apps BASESYSTEMCONFIG=/usr/lib/docker make \
+    && cp ./bin/composectl /usr/bin/
+
+# We may add fioctl and fioconfig to the test sequence. For now, we don't use them
+# WORKDIR /build
+# RUN git clone https://github.com/foundriesio/fioconfig.git && cd fioconfig \
+#     && make bin/fioconfig-linux-amd64 \
+#     && cp ./bin/fioconfig-linux-amd64 /usr/bin/fioconfig
+
+# WORKDIR /build
+# RUN git clone https://github.com/foundriesio/fioctl.git && cd fioctl \
+#     && make fioctl-linux-amd64 \
+#     && cp ./bin/fioctl-linux-amd64 /usr/bin/fioctl
+
+
+FROM foundries/aklite-dev AS aklite
+
+# Install composectl
+COPY --from=composeapp /build/composeapp/bin/composectl /usr/bin/
+
+# # Install fioconfig
+# COPY --from=composeapp /build/fioconfig/bin/fioconfig-linux-amd64 /usr/bin/fioconfig
+
+# # Install fioctl
+# COPY --from=composeapp /build/fioctl/bin/fioctl-linux-amd64 /usr/bin/fioctl
+
+
+# Install lmp-device-register
+RUN  apt-get install -y libboost-iostreams-dev
+
+RUN git clone https://github.com/foundriesio/lmp-device-register \
+  && cd lmp-device-register && git checkout mp-90 \
+  && cmake -S . -B ./build -DDOCKER_COMPOSE_APP=ON -DHARDWARE_ID=intel-corei7-64 && cmake --build ./build --target install
+
+
+# Add Docker's official GPG key:
+RUN apt-get update && apt-get install -y ca-certificates curl
+RUN install -m 0755 -d /etc/apt/keyrings
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+RUN chmod a+r /etc/apt/keyrings/docker.asc
+
+# Add the repository to Apt sources:
+RUN echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+RUN apt-get update && apt-get install -y docker-ce-cli docker-compose-plugin
+
+# Install docker credential helper and auth configuration
+COPY config.json /usr/lib/docker/config.json
+COPY docker-credential-fio-helper /usr/bin/docker-credential-fio-helper
+
+# Install gosu required for the entry/startup script to add a user and group in the container
+RUN wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.14/gosu-amd64" && \
+    chmod +x /usr/local/bin/gosu && \
+    gosu nobody true
+
+# Install pytest
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir pytest
+
+    # Copy the entrypoint script
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Set entrypoint
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["bash"]

--- a/docker-e2e-test/config.json
+++ b/docker-e2e-test/config.json
@@ -1,0 +1,6 @@
+{
+        "credHelpers": {
+                "hub.foundries.io": "fio-helper"
+        }
+}
+

--- a/docker-e2e-test/docker-compose.yml
+++ b/docker-e2e-test/docker-compose.yml
@@ -1,0 +1,46 @@
+version: '3.8'
+
+services:
+  dockerd:
+    image: ghcr.io/foundriesio/moby:25.0.3_fio
+    command: ["dockerd", "-H", "unix:///var/run/docker/docker.sock"]
+    volumes:
+      - ${DOCKER_DATA_ROOT}:/var/lib/docker
+      - docker-runtime:/var/run/docker
+      - ${SOTA_DIR}:/var/sota
+    privileged: true
+
+  aklite-e2e-test:
+      build:
+        context: ${AKLITE_E2E_TEST_DOCKER_DIR}
+        args:
+          AKLITE_VER: master
+        dockerfile: Dockerfile
+
+      image: aklite-e2e-test
+      volumes:
+        - "${PWD}:${PWD}"
+        - ${SYSROOT}:/sysroot
+        - ${SYSROOT}/ostree:/ostree
+        - ${BOOTDIR}:/boot
+        - ${SOTA_DIR}:/var/sota
+        - ${USR_SOTA_DIR}:/usr/lib/sota/conf.d
+        - ${ETC_SOTA_DIR}:/etc/sota/conf.d
+        - ${DOCKER_DATA_ROOT}:/var/lib/docker
+        - docker-runtime:/var/run/docker
+      working_dir: "${PWD}"
+      hostname: device
+      user: "root"
+      environment:
+        - FACTORY=${FACTORY}
+        - AUTH_TOKEN=${AUTH_TOKEN}
+        - DEVICE_TAG=${DEVICE_TAG}
+        - DOCKER_HOST=unix:///var/run/docker/docker.sock
+        - DOCKER_CONFIG=/usr/lib/docker
+        - CXX=clang++
+        - CC=clang
+      depends_on:
+      - dockerd
+
+volumes:
+  docker-runtime:

--- a/docker-e2e-test/docker-credential-fio-helper
+++ b/docker-e2e-test/docker-credential-fio-helper
@@ -1,0 +1,19 @@
+#!/bin/sh -e
+
+# Use stderr for logging err output in libaktualizr
+export LOG_STDERR=1
+SOTA_DIR="${SOTA_DIR-/var/sota}"
+
+LOGLEVEL="${CREDS_LOGLEVEL-4}"
+
+if [ "$1" = "get" ] ; then
+    if [ ! -f ${SOTA_DIR}/sota.toml ] ; then
+        echo "ERROR: Device does not appear to be registered under $SOTA_DIR"
+        exit 1
+    fi
+    server=$(grep -m1 '^[[:space:]]*server' ${SOTA_DIR}/sota.toml | cut -d\" -f2)
+    if [ -z $server ] ; then
+        server="https://ota-lite.foundries.io:8443"
+    fi
+    exec /usr/local/bin/aktualizr-get --loglevel $LOGLEVEL -u ${server}/hub-creds/
+fi

--- a/docker-e2e-test/entrypoint.sh
+++ b/docker-e2e-test/entrypoint.sh
@@ -1,0 +1,68 @@
+#!/bin/sh -e
+
+if [ -z $DEV_USER ] || [ -z $DEV_GROUP ]; then
+    echo "DEV_USER and DEV_GROUP environment variables must be set."
+    exit 1
+fi
+
+# Create a group with the specified GID if it doesn't already exist
+if ! getent group $DEV_GROUP >/dev/null; then
+    groupadd -g $DEV_GROUP devgrp
+fi
+
+# Create a user with the specified UID and GID if it doesn't already exist
+if ! getent passwd $DEV_USER >/dev/null; then
+    useradd -u $DEV_USER -g $DEV_GROUP -m dev
+fi
+
+# Change ownership of the home directory to the appuser
+chown -R dev:devgrp /home/dev
+
+chown dev:devgrp /var/run/docker/docker.sock
+
+chown -R dev:devgrp /var/sota
+chown -R dev:devgrp /usr/lib/sota/conf.d
+chown -R dev:devgrp /etc/sota/conf.d
+chown -R dev:devgrp /var/lib/docker
+
+# Initialize ostree
+if [ ! -d /sysroot/ostree/repo ]; then
+    echo "Initializing sysroot ostree..."
+    ostree admin init-fs /sysroot
+    ostree admin os-init lmp
+    ostree config set core.mode bare-user
+    ${PWD}/tests/make_sys_rootfs.sh initfs lmp intel-corei7-64 lmp
+    commit=$(ostree commit initfs --branch lmp)
+    ostree admin deploy --os=lmp $commit
+    rm -rf initfs
+    chown -R dev:devgrp /ostree
+    ostree config set core.mode bare-user-only
+fi
+if [ ! -d /etc/ostree ]; then
+    mkdir /etc/ostree
+    chown -R dev:devgrp /etc/ostree
+    chown -R dev:devgrp /boot
+fi
+
+ln -sfn ${PWD}/build/aktualizr/src/aktualizr_get/aktualizr-get /usr/local/bin/aktualizr-get
+
+# Initialize default toml config
+sysroot_cfg=/usr/lib/sota/conf.d/z-90-sysroot.toml
+if [ ! -f $sysroot_cfg ]; then
+    echo "[pacman]\nbooted = 0\nos = lmp" > $sysroot_cfg
+fi
+
+bootloader_cfg=/usr/lib/sota/conf.d/z-91-bootloader.toml
+if [ ! -f $bootloader_cfg ]; then
+    echo "[bootloader]\nreboot_command = /usr/bin/true" > $bootloader_cfg
+fi
+
+# Set directory used for reboot indication, the `need_reboot` file is created under this dir
+if [ ! -d /var/run/aktualizr-session ]; then
+	mkdir -p /var/run/aktualizr-session
+	chown dev:devgrp /var/run/aktualizr-session
+	chmod 700 /var/run/aktualizr-session
+fi
+
+# Run the command as the created user
+exec gosu $DEV_USER:$DEV_GROUP "$@"

--- a/e2e-test.py
+++ b/e2e-test.py
@@ -1,0 +1,595 @@
+import json
+import logging
+import os
+import pytest
+import requests
+import stat
+import subprocess
+import sys
+
+# Aklite CLI return codes:
+class ReturnCodes:
+  UnknownError = 1
+  Ok = 0
+  CheckinOkCached = 3
+  CheckinFailure = 4
+  OkNeedsRebootForBootFw = 5
+  CheckinNoMatchingTargets = 6
+  CheckinNoTargetContent = 8
+  InstallAppsNeedFinalization = 10
+  CheckinSecurityError = 11
+  CheckinExpiredMetadata = 12
+  CheckinMetadataFetchFailure = 13
+  CheckinMetadataNotFound = 14
+  CheckinInvalidBundleMetadata = 15
+  CheckinUpdateNewVersion = 16
+  CheckinUpdateSyncApps = 17
+  CheckinUpdateRollback = 18
+  TufTargetNotFound = 20
+  RollbackTargetNotFound = 21
+  InstallationInProgress = 30
+  NoPendingInstallation = 40
+  DownloadFailure = 50
+  DownloadFailureNoSpace = 60
+  DownloadFailureVerificationFailed = 70
+  InstallAlreadyInstalled = 75
+  InstallAppPullFailure = 80
+  InstallNeedsRebootForBootFw = 90
+  InstallOfflineRollbackOk = 99
+  InstallNeedsReboot = 100
+  InstallDowngradeAttempt = 102
+  InstallRollbackOk = 110
+  InstallRollbackNeedsReboot = 120
+  InstallRollbackFailed = 130
+
+logger = logging.getLogger(__name__)
+
+user_token = os.getenv("USER_TOKEN")
+if not user_token:
+    logger.error("USER_TOKEN environment variable not set")
+    sys.exit()
+
+factory_name = os.getenv("FACTORY")
+if not user_token:
+    logger.error("FACTORY environment variable not set")
+    sys.exit()
+
+base_target_version = os.getenv("BASE_TARGET_VERSION")
+if not base_target_version:
+    logger.error("BASE_TARGET_VERSION environment variable not set")
+    sys.exit()
+
+base_target_version = int(base_target_version)
+logger.info(f"Base target version: {base_target_version}")
+
+aklite_path = "./build/src/aktualizr-lite"
+composectl_path = "/usr/bin/composectl"
+callback_log_path = "/var/sota/callback_log.txt"
+
+# Test modes
+offline = False
+single_step = True
+prune = True
+
+def get_target_version(offset):
+    return base_target_version + offset
+
+class Targets:
+    First = 0
+    BrokenOstree = 1
+    WorkingOstree = 2
+    AddFirstApp = 3
+    AddMoreApps = 4
+    BreakApp = 5
+    UpdateBrokenApp = 6
+    BrokenBuild = 7
+    FixApp = 8
+    UpdateWorkingApp = 9
+    UpdateOstreeWithApps = 10
+    BrokenOstreeWithApps = 11
+
+    def __init__(self, version_offset, install_rollback, run_rollback, build_error, ostree_image_version, apps = []):
+        self.version_offset = version_offset
+        self.install_rollback = install_rollback
+        self.run_rollback = run_rollback
+        self.build_error = build_error
+        self.ostree_image_version = ostree_image_version
+        self.apps = apps
+
+    def __str__(self):
+        return f"VersionOffset={self.version_offset} InstallRollback={self.install_rollback}, RunRollback={self.run_rollback}, BuildError={self.build_error}, OSTreeImageVersion={self.ostree_image_version}"
+
+all_apps = ["shellhttpd", "shellhttpd2", "shellhttpd_base_port_30000"]
+all_targets = {
+    Targets.First: Targets(Targets.First, False, False, False, 1, []),
+    Targets.BrokenOstree: Targets(Targets.BrokenOstree, True, False, False, 2, []),
+    Targets.WorkingOstree: Targets(Targets.WorkingOstree, False, False, False, 3, []),
+    Targets.AddFirstApp: Targets(Targets.AddFirstApp, False, False, False, 3, ["shellhttpd"]),
+    Targets.AddMoreApps: Targets(Targets.AddMoreApps, False, False, False, 3, all_apps),
+    Targets.BreakApp: Targets(Targets.BreakApp, False, True, False, 3, all_apps),
+    Targets.UpdateBrokenApp: Targets(Targets.UpdateBrokenApp, False, True, False, 3, all_apps),
+    Targets.BrokenBuild: Targets(Targets.BrokenBuild, False, False, True, 3, all_apps),
+    Targets.FixApp: Targets(Targets.FixApp, False, False, False, 3, all_apps),
+    Targets.UpdateWorkingApp: Targets(Targets.UpdateWorkingApp, False, False, False, 3, all_apps),
+    Targets.UpdateOstreeWithApps: Targets(Targets.UpdateOstreeWithApps, False, False, False, 4, all_apps),
+    Targets.BrokenOstreeWithApps: Targets(Targets.BrokenOstreeWithApps, True, False, False, 5, all_apps),
+}
+
+def register_if_required():
+    if not os.path.exists("/var/sota/client.pem"):
+        user_token = os.getenv("USER_TOKEN")
+        cmd = f'DEVICE_FACTORY={factory_name} lmp-device-register --api-token "{user_token}" --start-daemon 0 --tags main'
+        logger.info(f"Registering device...")
+        output = os.popen(cmd).read().strip()
+        logger.info(output)
+    else:
+        logger.info("Device already registered")
+
+def get_device_name():
+    # os.getenv("DEVICE_NAME", "aklite-test-device")
+    cmd = "openssl x509 -noout -subject -nameopt multiline -in /var/sota/client.pem | grep commonName | sed -n 's/ *commonName *= //p'"
+    device_uuid = os.popen(cmd).read().strip()
+    assert len(device_uuid) == 36
+    # Assuming device name == uuid
+    logger.info(f"Device UUID is {device_uuid}")
+    return device_uuid
+
+register_if_required()
+device_name = get_device_name()
+
+def verify_events(target_version, expected_events = None, second_to_last_corr_id = False):
+    logger.info(f"Verifying events for version {target_version}")
+    headers = {'OSF-TOKEN': user_token}
+    r = requests.get(f'https://api.foundries.io/ota/devices/{device_name}/updates/', headers=headers)
+    d = json.loads(r.text)
+
+    if second_to_last_corr_id:
+        latest_update = d["updates"][1]
+    else:
+        latest_update = d["updates"][0]
+    corr_id = latest_update["correlation-id"]
+    assert int(latest_update["version"]) == target_version
+    r = requests.get(f'https://api.foundries.io/ota/devices/{device_name}/updates/{corr_id}/', headers=headers)
+
+    d_update = json.loads(r.text)
+    event_list = set([ (x["eventType"]["id"], x["event"]["success"]) for x in d_update ])
+    if expected_events is None:
+        expected_events = {
+            ('EcuDownloadStarted', None),
+            ('EcuDownloadCompleted', True),
+            ('EcuInstallationStarted', None),
+            ('EcuInstallationApplied', None),
+            ('EcuInstallationCompleted', True)
+        }
+    assert set(event_list) == set(expected_events)
+
+def sys_reboot():
+    need_reboot_path = "/var/run/aktualizr-session/need_reboot"
+    if os.path.isfile(need_reboot_path):
+        os.remove(need_reboot_path)
+
+def clear_callbacks_log():
+    if os.path.isfile(callback_log_path):
+         os.remove(callback_log_path)
+
+# TODO: verify additional callback variables
+def verify_callback(expected_calls):
+    logger.info(f"Verifying callbacks")
+    calls = []
+    if os.path.isfile(callback_log_path):
+        with open(callback_log_path) as f:
+            for l in f.readlines():
+                j = json.loads(l)
+                calls.append((j["MESSAGE"], j["RESULT"]))
+        clear_callbacks_log()
+    assert expected_calls == calls
+
+def aklite_current_version():
+    sp = invoke_aklite(['status'])
+    # Last line should be like this:
+    # info: Active image is: 42    sha256:1f5c2258e6e493741c719394bd267b2e163609f1cb3457ccb71fcaf770c5c116
+    lines = [ x for x in sp.stdout.decode('utf-8').splitlines() if "Active image is:" in x ]
+    assert len(lines) == 1
+    version = int(lines[0].split()[3])
+    return version
+
+def aklite_current_version_based_on_list():
+    sp = invoke_aklite(['list', '--json', '1'])
+    out_json = json.loads(sp.stdout)
+    count = sum(target.get("current", False) for target in out_json)
+    # Make sure there is only 1 "current" version
+    assert count == 1
+    curr_target = next(target for target in out_json if target.get("current", False))
+    return curr_target["version"]
+
+def invoke_aklite(options):
+    if offline:
+        options = options + [ "--src-dir", os.path.abspath("./offline-bundles/unified/") ]
+    logger.info("Running `" + " ".join([aklite_path] + options) + "`")
+    return subprocess.run([aklite_path] + options, capture_output=True)
+
+def write_settings(apps=None, prune=True):
+    logger.info(f"Updating settings. {apps=}")
+    callback_file = "/var/sota/callback.sh"
+
+    callback_content = \
+"""#!/bin/sh
+echo { \\"MESSAGE\\": \\"$MESSAGE\\", \\"CURRENT_TARGET\\": \\"$CURRENT_TARGET\\", \\"CURRENT_TARGET_NAME\\": \\"$CURRENT_TARGET_NAME\\", \\"INSTALL_TARGET_NAME\\": \\"$INSTALL_TARGET_NAME\\", \\"RESULT\\": \\"$RESULT\\" } >> /var/sota/callback_log.txt
+"""
+    with open(callback_file, "w") as f:
+        f.write(callback_content)
+    st = os.stat(callback_file)
+    os.chmod(callback_file, st.st_mode | stat.S_IEXEC)
+
+    content = \
+f"""
+[pacman]
+tags = "main"
+"""
+    if apps is not None:
+        apps_str = ",".join(apps)
+        content += f"""
+compose_apps = "{apps_str}"
+docker_apps = "{apps_str}"
+"""
+    # callback_program = "/var/sota/callback.sh"
+
+    if not prune:
+        content += "\ndocker_prune = 0\n"
+
+    with open("/etc/sota/conf.d/z-50-fioctl.toml", "w") as f:
+        f.write(content)
+
+    sota_toml_content = ""
+    with open("/var/sota/sota.toml") as f:
+        sota_toml_content = f.read()
+
+    if not "callback_program" in sota_toml_content:
+        sota_toml_content = sota_toml_content.replace("[pacman]", '[pacman]\ncallback_program = "/var/sota/callback.sh"')
+        with open("/var/sota/sota.toml", "w") as f:
+            f.write(sota_toml_content)
+
+def get_all_current_apps():
+    sp = invoke_aklite(['list', '--json', '1'])
+    out_json = json.loads(sp.stdout)
+    target_apps = [ target["apps"] for target in out_json if target.get("current", False) ]
+    # there should be only 1 current target
+    assert len(target_apps) == 1
+    if target_apps[0] is None:
+        return []
+    return [ app["name"] for app in target_apps[0] ]
+
+def get_running_apps():
+    sp = subprocess.run([composectl_path, "ps"], capture_output=True)
+    output_lines = sp.stdout.decode('utf-8').splitlines()
+    # print(output_lines)
+    running_app_names = [ l.split()[0] for l in output_lines if l.split()[1] == "(running)" ]
+    return running_app_names
+
+def check_running_apps(expected_apps=None):
+    # if no apps list is specified, all apps should be running
+    if expected_apps is None:
+        expected_apps = get_all_current_apps()
+    logger.info(f"Verifying running apps. {expected_apps=}")
+    running_apps = get_running_apps()
+    assert set(expected_apps) == set(running_apps)
+
+def cleanup_tuf_metadata():
+    os.system("""sqlite3 /var/sota/sql.db  "delete from meta where meta_type <> 0 or version >= 3;" ".exit" """)
+
+def cleanup_installed_data():
+    os.system("""sqlite3 /var/sota/sql.db  "delete from installed_versions;" ".exit" """)
+
+def install_with_separate_steps(version, requires_reboot=False, install_rollback=False, run_rollback=False, explicit_version=True):
+    cp = invoke_aklite(['check', '--json', '1'])
+    assert cp.returncode == ReturnCodes.CheckinUpdateNewVersion
+    verify_callback([("check-for-update-pre", ""), ("check-for-update-post", "OK")])
+
+    if install_rollback or run_rollback:
+        final_version = aklite_current_version()
+    else:
+        final_version = version
+
+    if explicit_version:
+        cp = invoke_aklite(['pull', str(version)])
+    else:
+        cp = invoke_aklite(['pull'])
+    assert cp.returncode == ReturnCodes.Ok
+    verify_callback([("download-pre", ""), ("download-post", "OK")])
+    verify_events(version, {
+            ('EcuDownloadStarted', None),
+            ('EcuDownloadCompleted', True),
+        })
+
+    # cp = invoke_aklite(['install', str(get_target_version(Targets.BrokenBuild))]) # not existing target
+    # assert cp.returncode == ReturnCodes.TufTargetNotFound
+    # verify_callback([])
+
+    # version = 159
+    # cp = invoke_aklite(['install', str(version)]) # not downloaded target
+    # assert cp.returncode == ReturnCodes.InstallAppPullFailure
+    # verify_callback([])
+
+    if explicit_version:
+        cp = invoke_aklite(['install', str(version)]) # OK
+    else:
+        cp = invoke_aklite(['install']) # OK
+    if install_rollback:
+        assert cp.returncode == ReturnCodes.InstallRollbackOk
+        verify_callback([("install-pre", ""), ("install-post", "FAILED"), ("install-pre", ""), ("install-post", "OK")])
+        verify_events(version, {
+            ('EcuInstallationStarted', None),
+            ('EcuInstallationCompleted', False),
+        }, True)
+        verify_events(final_version, {
+            ('EcuInstallationStarted', None),
+            ('EcuInstallationCompleted', True),
+        }, False)
+
+    elif requires_reboot:
+        assert cp.returncode == ReturnCodes.InstallNeedsReboot
+        verify_callback([("install-pre", ""), ("install-post", "NEEDS_COMPLETION")])
+        sys_reboot()
+        verify_events(version, {
+                ('EcuInstallationStarted', None),
+                ('EcuInstallationApplied', None),
+            })
+        cp = invoke_aklite(['run'])
+        verify_callback([("install-final-pre", ""), ("install-post", "OK")])
+        verify_events(version, {
+                ('EcuInstallationStarted', None),
+                ('EcuInstallationApplied', None),
+                ('EcuInstallationCompleted', True),
+            })
+    else:
+        if run_rollback:
+            assert cp.returncode == ReturnCodes.InstallRollbackOk
+            verify_callback([
+                ("install-pre", ""), ("install-post", "FAILED"),
+                ("install-pre", ""), ("install-post", "OK")
+                ])
+            verify_events(version, {
+                ('EcuInstallationStarted', None),
+                ('EcuInstallationCompleted', False),
+            }, True)
+
+            verify_events(final_version, {
+                ('EcuInstallationStarted', None),
+                ('EcuInstallationCompleted', True),
+            }, False)
+
+        else:
+            assert cp.returncode == ReturnCodes.Ok
+            verify_callback([("install-pre", ""), ("install-post", "OK")])
+            verify_events(version, {
+                ('EcuInstallationStarted', None),
+                ('EcuInstallationCompleted', True),
+            })
+
+    assert aklite_current_version() == final_version
+    if not explicit_version:
+        # Make sure we would not try a new install, after trying to install the latest one
+        cp = invoke_aklite(['check', '--json', '1'])
+        assert cp.returncode == ReturnCodes.Ok
+        verify_callback([("check-for-update-pre", ""), ("check-for-update-post", "OK")])
+
+def install_with_single_step(version, requires_reboot=False, install_rollback=False, run_rollback=False, explicit_version=True):
+    if install_rollback or run_rollback:
+        final_version = aklite_current_version()
+    else:
+        final_version = version
+
+    if explicit_version:
+        cp = invoke_aklite(['update', str(version)])
+    else:
+        cp = invoke_aklite(['update'])
+
+    if install_rollback:
+        assert cp.returncode == ReturnCodes.InstallRollbackOk
+        verify_callback([
+            ("check-for-update-pre", ""), ("check-for-update-post", "OK"),
+            ("download-pre", ""), ("download-post", "OK"),
+            ("install-pre", ""), ("install-post", "FAILED"),
+            ("install-pre", ""), ("install-post", "OK")])
+        verify_events(version, {
+            ('EcuDownloadStarted', None),
+            ('EcuDownloadCompleted', True),
+            ('EcuInstallationStarted', None),
+            ('EcuInstallationCompleted', False),
+        }, True)
+        verify_events(final_version, {
+            ('EcuInstallationStarted', None),
+            ('EcuInstallationCompleted', True),
+        }, False)
+
+    elif requires_reboot:
+        assert cp.returncode == ReturnCodes.InstallNeedsReboot
+        verify_callback([
+                ("check-for-update-pre", ""), ("check-for-update-post", "OK"),
+                ("download-pre", ""), ("download-post", "OK"),
+                ("install-pre", ""), ("install-post", "NEEDS_COMPLETION"),
+                ])
+        sys_reboot()
+        verify_events(version, {
+                ('EcuDownloadStarted', None),
+                ('EcuDownloadCompleted', True),
+                ('EcuInstallationStarted', None),
+                ('EcuInstallationApplied', None),
+            })
+        cp = invoke_aklite(['run'])
+        # TODO: handle run_rollback
+        verify_callback([("install-final-pre", ""), ("install-post", "OK")])
+        verify_events(version, {
+                ('EcuDownloadStarted', None),
+                ('EcuDownloadCompleted', True),
+                ('EcuInstallationStarted', None),
+                ('EcuInstallationApplied', None),
+                ('EcuInstallationCompleted', True),
+            })
+    else:
+        if run_rollback:
+            assert cp.returncode == ReturnCodes.InstallRollbackOk
+            verify_callback([
+                ("check-for-update-pre", ""), ("check-for-update-post", "OK"),
+                ("download-pre", ""), ("download-post", "OK"),
+                ("install-pre", ""), ("install-post", "FAILED"),
+                ("install-pre", ""), ("install-post", "OK")
+                ])
+            verify_events(version, {
+                ('EcuDownloadStarted', None),
+                ('EcuDownloadCompleted', True),
+                ('EcuInstallationStarted', None),
+                ('EcuInstallationCompleted', False),
+            }, True)
+
+            verify_events(final_version, {
+                ('EcuInstallationStarted', None),
+                ('EcuInstallationCompleted', True),
+            }, False)
+
+        else:
+            assert cp.returncode == ReturnCodes.Ok
+            verify_callback([
+                ("check-for-update-pre", ""), ("check-for-update-post", "OK"),
+                ("download-pre", ""), ("download-post", "OK"),
+                ("install-pre", ""), ("install-post", "OK")
+                ])
+            verify_events(version, {
+                ('EcuDownloadStarted', None),
+                ('EcuDownloadCompleted', True),
+                ('EcuInstallationStarted', None),
+                ('EcuInstallationCompleted', True),
+            })
+    assert aklite_current_version() == final_version
+
+    if not explicit_version:
+        # Make sure we would not try a new install, after trying to install the latest one
+        cp = invoke_aklite(['check', '--json', '1'])
+        assert cp.returncode == ReturnCodes.Ok
+        verify_callback([("check-for-update-pre", ""), ("check-for-update-post", "OK")])
+
+def install_version(version, requires_reboot=False, install_rollback=False, run_rollback=False, explicit_version=True):
+    if single_step:
+        install_with_single_step(version, requires_reboot, install_rollback, run_rollback, explicit_version)
+    else:
+        install_with_separate_steps(version, requires_reboot, install_rollback, run_rollback, explicit_version)
+
+def restore_system_state():
+    # Get to the starting point
+    logger.info(f"Restoring base environment. Offline={offline}, SingleStep={single_step}, Prune={prune}...")
+    write_settings()
+    sys_reboot()
+    cp = invoke_aklite(['run'])
+    version = get_target_version(Targets.First)
+    cleanup_installed_data()
+    cp = invoke_aklite(['update', str(version)])
+    print(cp.stdout)
+    sys_reboot()
+    cp = invoke_aklite(['run'])
+    assert aklite_current_version() == version
+    clear_callbacks_log()
+    cleanup_tuf_metadata()
+
+    logger.info("Making sure there are no targets in current DB...")
+    cp = invoke_aklite(['list', '--json', '1'])
+    assert cp.returncode == ReturnCodes.CheckinSecurityError
+
+# Incremental install order
+install_sequence_incremental = [
+    Targets.BrokenOstree,
+    Targets.WorkingOstree,
+    Targets.AddFirstApp,
+    Targets.AddMoreApps,
+    Targets.BreakApp,
+    Targets.UpdateBrokenApp,
+    Targets.BrokenBuild,
+    Targets.FixApp,
+    Targets.UpdateWorkingApp,
+    Targets.UpdateOstreeWithApps,
+    Targets.BrokenOstreeWithApps,
+]
+
+def run_test_sequence_incremental():
+    restore_system_state()
+    apps = None # All apps, for now
+    prev_ostree_image_version = 1
+    for target_version in install_sequence_incremental:
+        target = all_targets[target_version]
+        if target.build_error: # skip this one for now
+            continue
+
+        version = get_target_version(target.version_offset)
+        logger.info(f"Updating to {version} {target}. SingleStep={single_step}, Offline={offline}")
+        requires_reboot = target.ostree_image_version != prev_ostree_image_version
+        write_settings(apps, prune)
+        install_version(version, requires_reboot, target.install_rollback, target.run_rollback)
+        check_running_apps(apps)
+        if not target.install_rollback and not target.run_rollback:
+            prev_ostree_image_version = target.ostree_image_version
+
+def run_test_sequence_update_to_latest():
+    restore_system_state()
+    apps = None # All apps, for now
+    prev_ostree_image_version = 1
+
+    last_target = all_targets[Targets.BrokenOstreeWithApps]
+    target = last_target
+
+    # Try to install latest version, which will lead to a rollback
+    write_settings(apps, prune)
+    version = get_target_version(target.version_offset)
+    requires_reboot = target.ostree_image_version != prev_ostree_image_version
+    logger.info(f"Updating to latest target {version} {target} {single_step=} {offline=}")
+    install_version(version, requires_reboot, target.install_rollback, target.run_rollback, False)
+    check_running_apps(apps)
+
+def run_test_sequence_apps_selection():
+    restore_system_state()
+    apps = None # All apps, for now
+    prev_ostree_image_version = 1
+    target_version = Targets.AddMoreApps
+    target = all_targets[target_version]
+
+    version = get_target_version(target.version_offset)
+    logger.info(f"Updating to target {version} {target}. {single_step=} {offline=}")
+    requires_reboot = target.ostree_image_version != prev_ostree_image_version
+    write_settings(apps, prune)
+    install_version(version, requires_reboot, target.install_rollback, target.run_rollback)
+    check_running_apps(apps)
+    prev_ostree_image_version = target.version_offset
+
+    apps = ["shellhttpd"]
+    write_settings(apps, prune)
+    logger.info(f"Forcing apps sync for target {version} {target}. {single_step=} {offline=}")
+    cp = invoke_aklite(['update', str(version)])
+    assert cp.returncode == ReturnCodes.Ok
+    check_running_apps(apps)
+
+    apps = all_apps
+    write_settings(apps, prune)
+    logger.info(f"Forcing apps sync for target {version} {target}. {single_step=} {offline=}")
+    cp = invoke_aklite(['update', str(version)])
+    assert cp.returncode == ReturnCodes.Ok
+    check_running_apps(apps)
+
+    if not target.install_rollback and not target.run_rollback:
+        prev_ostree_image_version = target.ostree_image_version
+
+def test_apps_selection():
+    run_test_sequence_apps_selection()
+
+@pytest.mark.parametrize('offline_', [True, False])
+@pytest.mark.parametrize('single_step_', [True, False])
+def test_incremental_updates(offline_, single_step_):
+    global offline, single_step
+    offline = offline_
+    single_step = single_step_
+    run_test_sequence_incremental()
+
+@pytest.mark.parametrize('offline_', [True, False])
+@pytest.mark.parametrize('single_step_', [True, False])
+def test_update_to_latest(offline_, single_step_):
+    global offline, single_step
+    offline = offline_
+    single_step = single_step_
+    run_test_sequence_update_to_latest()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.pytest.ini_options]
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+


### PR DESCRIPTION
Preliminar PR to facilitate discussion.

@mike-sul you can run the tests using:

```
export FACTORY=detsch-aklite-test
export USER_TOKEN=<your_fio_token>
./dev-shell-e2e-test.sh python -m pytest e2e-test.py -v
```

On the first run, the device will be registered automatically.

There are some easy improvements to be done in the test script, but my next step is to try and run it as a github action.

My idea is to increase the tests combinations, perhaps having a "fast" mode that runs in github, with no more than 50 update operations, and a slower mode that goes through some unusual update sequences and variations on the apps configuration, increasing the chances to hit some new unexpected situation.

The targets in the factory where created almost automatically, but copying some applications I already had.  We can re-create them as needed, but the current concept is to keep using always the same set of targets, until we believe that we need different ones.
