### PR TITLE
api: extended: Select target with all apps when running an apps sync

### DIFF
--- a/src/aklite_client_ext.cc
+++ b/src/aklite_client_ext.cc
@@ -123,7 +123,7 @@ GetTargetToInstallResult AkliteClientExt::GetTargetToInstall(const CheckInResult
     auto apps_to_update = client_->appsToUpdate(Target::fromTufTarget(current));
     if (force_apps_sync || !apps_to_update.empty()) {
       // Force installation of apps
-      res.selected_target = current;
+      res.selected_target = checkin_res.SelectTarget(current.Version());
       LOG_INFO
           << "The specified Target is already installed, enforcing installation to make sure it's synced and running:"
           << res.selected_target.Name();


### PR DESCRIPTION
Previous code was using the current target object, which is based on the current running system, and may not contain all available apps. This could lead to an issue where the apps sync update fails later on in the online case, since equality between the latest available and selected target is checked, and all apps must be included.