### PR TITLE
makefile: Fix make update command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ check:
 	${BIN} check
 
 update:
-	${BIN} check
+	${BIN} check || true
 	@ostree config set core.mode bare-user
 	${BIN} pull
 	@ostree config set core.mode bare-user-only


### PR DESCRIPTION
The additional aktualizr-lite check command added in commit b628f99 (makefile: Add check operation on make update) introduced an issue where the `make update` command stops before trying the aktualizr-lite pull and install commands when there is an update to be performed, since in that case, the check command returns an exit code != 0.

This commit ignores the return code of the check command, allowing the `make update` command to always proceed to pull + install.