### PR TITLE
restorableappengine: Log app start

### DIFF
--- a/src/docker/restorableappengine.cc
+++ b/src/docker/restorableappengine.cc
@@ -181,7 +181,9 @@ AppEngine::Result RestorableAppEngine::installAndCreateOrRunContainers(const App
   try {
     const auto app_install_root{install_root_ / app.name};
     const std::string flags{run ? "--remove-orphans -d" : "--remove-orphans --no-start"};
+    LOG_INFO << "Starting " << app.name << " -> " << app.uri;
     startComposeApp(compose_cmd_, app_install_root, flags);
+    LOG_INFO << app.name << " has been successfully started";
     res = true;
   } catch (const std::exception& exc) {
     return {false, exc.what()};


### PR DESCRIPTION
Print logs about an app start and successful completion.

Logs printed to stdout by processes/utilities spawned by aklite are supressed since some of the utilities do odd/crazy stuff in the std output which makes aklite logs messy. As drawback, it makes successful execution some of utilities invisible, in particular `docker compose up` which is an important to see in the logs. This change prints logs before starting an app and just after successfull execution, so it becomes visible when an app was started. Note: if an app start failure occurs, then aklite will add the stderr output of the command to the aklite's logs.