### PR TITLE
appengine: Check only if app installed and running

### DIFF
--- a/src/docker/restorableappengine.cc
+++ b/src/docker/restorableappengine.cc
@@ -242,8 +242,7 @@ bool RestorableAppEngine::isRunning(const App& app) const {
   bool res{false};
 
   try {
-    res = isAppFetched(app) && isAppInstalled(app) &&
-          isRunning(app, (install_root_ / app.name / ComposeFile).string(), docker_client_);
+    res = isAppInstalled(app) && isRunning(app, (install_root_ / app.name / ComposeFile).string(), docker_client_);
   } catch (const std::exception& exc) {
     LOG_WARNING << "App: " << app.name << ", cannot check whether App is running: " << exc.what();
   }


### PR DESCRIPTION
Check only if app is installed and running at the "is app running" check at the beginning of each update cycle.
Whether app blobs are present&OK or not does NOT impact a properly installed and running app. Moreover, after "is app running" check, the aklite daemon checks whether all enabled apps (including the "reset" apps) are fully fetched. We need this check to make sure a user can switch (turn on/off) apps even in offline mode.
Therefore, this change removes the redundant check whether all app blobs are fetched&OK called at the "is app running" check.