### PR TITLE
Optimize app fetch check

### DIFF
--- a/src/composeappmanager.cc
+++ b/src/composeappmanager.cc
@@ -230,18 +230,18 @@ ComposeAppManager::AppsContainer ComposeAppManager::getAppsToUpdate(const Uptane
     }
 
     LOG_DEBUG << app_name << " performing full status check";
-    if (!app_engine_->isFetched({app_name, app_pair.second})) {
-      // an App that is supposed to be installed is not fully installed
-      apps_to_update.insert(app_pair);
-      apps_and_reasons[app_pair.first] = "not fetched";
-      LOG_INFO << app_name << " is not fully fetched; missing blobs will be fetched";
-      continue;
-    }
     if (!app_engine_->isRunning({app_name, app_pair.second})) {
       // an App that is supposed to running is not running
       apps_to_update.insert(app_pair);
       apps_and_reasons[app_pair.first] = "not running";
       LOG_INFO << app_name << " is not installed or not running; will be installed and started";
+      continue;
+    }
+    if (!app_engine_->isFetched({app_name, app_pair.second})) {
+      // an App that is supposed to be installed is not fully installed
+      apps_to_update.insert(app_pair);
+      apps_and_reasons[app_pair.first] = "not fetched";
+      LOG_INFO << app_name << " is not fully fetched; missing blobs will be fetched";
       continue;
     }
   }

--- a/src/composeappmanager.h
+++ b/src/composeappmanager.h
@@ -3,6 +3,7 @@
 
 #include <functional>
 #include <memory>
+#include <set>
 #include <unordered_map>
 
 #include "docker/composeappengine.h"
@@ -59,7 +60,8 @@ class ComposeAppManager : public RootfsTreeManager {
   // Returns an intersection of Target's Apps and Apps listed in the config (sota.toml:compose_apps)
   // If Apps are not specified in the config then all Target's Apps are returned
   AppsContainer getApps(const Uptane::Target& t) const;
-  AppsContainer getAppsToUpdate(const Uptane::Target& t, AppsSyncReason& apps_and_reasons) const;
+  AppsContainer getAppsToUpdate(const Uptane::Target& t, AppsSyncReason& apps_and_reasons,
+                                std::set<std::string>& fetched_apps) const;
   AppsSyncReason checkForAppsToUpdate(const Uptane::Target& target);
   void setAppsNotChecked() { are_apps_checked_ = false; }
   void handleRemovedApps(const Uptane::Target& target) const;
@@ -72,7 +74,9 @@ class ComposeAppManager : public RootfsTreeManager {
   Json::Value getRunningAppsInfo() const;
   std::string getRunningAppsInfoForReport() const;
 
-  AppsContainer getAppsToFetch(const Uptane::Target& target, bool check_store = true) const;
+  AppsContainer getAppsToFetch(const Uptane::Target& target, bool check_store = true,
+                               const AppsContainer* checked_apps = nullptr,
+                               const std::set<std::string>* fetched_apps = nullptr) const;
   void stopDisabledComposeApps(const Uptane::Target& target) const;
   void removeDisabledComposeApps(const Uptane::Target& target) const;
   void forEachRemovedApp(const Uptane::Target& target,

--- a/src/docker/restorableappengine.cc
+++ b/src/docker/restorableappengine.cc
@@ -244,8 +244,7 @@ bool RestorableAppEngine::isRunning(const App& app) const {
   bool res{false};
 
   try {
-    res = isAppFetched(app) && isAppInstalled(app) &&
-          isRunning(app, (install_root_ / app.name / ComposeFile).string(), docker_client_);
+    res = isAppInstalled(app) && isRunning(app, (install_root_ / app.name / ComposeFile).string(), docker_client_);
   } catch (const std::exception& exc) {
     LOG_WARNING << "App: " << app.name << ", cannot check whether App is running: " << exc.what();
   }


### PR DESCRIPTION
Make sure that the check whether app is fetched is performed only once
during a single update cycle.

- If app is not running then don't check if it is fetched since it going
  to be re-updated anyway which implies checking for missing app blobs
  and pulling them if any.

- If app is enabled for running and is running then whether it is fetched
  or not is done before checking the "reset" apps fetch, so the later is skipped.