### PR TITLE
apps: Avoid pruning unused apps on every check operation

### DIFF
--- a/include/aktualizr-lite/aklite_client_ext.h
+++ b/include/aktualizr-lite/aklite_client_ext.h
@@ -86,6 +86,9 @@ class AkliteClientExt : public AkliteClient {
                                bool do_install = true);
 
   bool RebootIfRequired();
+
+ private:
+  bool cleanup_removed_apps_{true};
 };
 
 #endif

--- a/src/aklite_client_ext.cc
+++ b/src/aklite_client_ext.cc
@@ -120,7 +120,9 @@ GetTargetToInstallResult AkliteClientExt::GetTargetToInstall(const CheckInResult
                << " Skipping its installation.";
     }
 
-    auto apps_to_update = client_->appsToUpdate(Target::fromTufTarget(current));
+    auto apps_to_update = client_->appsToUpdate(Target::fromTufTarget(current), cleanup_removed_apps_);
+    // Automatically cleanup during check only once. A cleanup will also occur after a new target is installed
+    cleanup_removed_apps_ = false;
     if (force_apps_sync || !apps_to_update.empty()) {
       // Force installation of apps
       res.selected_target = checkin_res.SelectTarget(current.Version());

--- a/src/liteclient.cc
+++ b/src/liteclient.cc
@@ -773,7 +773,8 @@ bool LiteClient::isTargetActive(const Uptane::Target& target) const {
 
 bool LiteClient::appsInSync(const Uptane::Target& target) const { return appsToUpdate(target).empty(); }
 
-ComposeAppManager::AppsSyncReason LiteClient::appsToUpdate(const Uptane::Target& target) const {
+ComposeAppManager::AppsSyncReason LiteClient::appsToUpdate(const Uptane::Target& target,
+                                                           bool cleanup_removed_apps) const {
   if (package_manager_->name() == ComposeAppManager::Name) {
     auto* compose_pacman = dynamic_cast<ComposeAppManager*>(package_manager_.get());
     if (compose_pacman == nullptr) {
@@ -782,7 +783,7 @@ ComposeAppManager::AppsSyncReason LiteClient::appsToUpdate(const Uptane::Target&
     }
     LOG_INFO << "Checking status of Active Target (" << target.filename() << ")";
     auto apps_to_update = compose_pacman->checkForAppsToUpdate(target);
-    if (apps_to_update.empty()) {
+    if (cleanup_removed_apps && apps_to_update.empty()) {
       compose_pacman->handleRemovedApps(getCurrent());
     }
 

--- a/src/liteclient.h
+++ b/src/liteclient.h
@@ -69,7 +69,7 @@ class LiteClient {
   void reportAppsState();
   bool isTargetActive(const Uptane::Target& target) const;
   bool appsInSync(const Uptane::Target& target) const;
-  ComposeAppManager::AppsSyncReason appsToUpdate(const Uptane::Target& target) const;
+  ComposeAppManager::AppsSyncReason appsToUpdate(const Uptane::Target& target, bool cleanup_removed_apps = true) const;
   void setAppsNotChecked();
   std::string getDeviceID() const;
   static void update_request_headers(std::shared_ptr<HttpClient>& http_client, const Uptane::Target& target,


### PR DESCRIPTION
Only prune on startup, or when an installation is being finalized.
