### PR TITLE
appengine: Optimize app fetch check

### DIFF
--- a/src/composeapp/appengine.h
+++ b/src/composeapp/appengine.h
@@ -34,6 +34,7 @@ class AppEngine : public Docker::RestorableAppEngine {
   const std::string composectl_cmd_;
   const int storage_watermark_;
   const std::string local_source_path_;
+  mutable std::set<std::string> fetched_apps_;
 };
 
 }  // namespace composeapp


### PR DESCRIPTION
If an app is successfully fetched and checked then mark it as "fetched" so the next time the app fetch check is called no need to invoke the full blown check performed by `composectl`.