### PR TITLE
apps: Avoid pruning unused apps on every check operation

### DIFF
--- a/src/liteclient.cc
+++ b/src/liteclient.cc
@@ -757,7 +757,7 @@ bool LiteClient::isTargetActive(const Uptane::Target& target) const {
   return target.filename() == current.filename() && target.sha256Hash() == current.sha256Hash();
 }
 
-bool LiteClient::appsInSync(const Uptane::Target& target) const {
+bool LiteClient::appsInSync(const Uptane::Target& target, bool cleanup_removed_apps) const {
   if (package_manager_->name() == ComposeAppManager::Name) {
     auto* compose_pacman = dynamic_cast<ComposeAppManager*>(package_manager_.get());
     if (compose_pacman == nullptr) {
@@ -766,7 +766,7 @@ bool LiteClient::appsInSync(const Uptane::Target& target) const {
     }
     LOG_INFO << "Checking Active Target status...";
     auto no_any_app_to_update = compose_pacman->checkForAppsToUpdate(target);
-    if (no_any_app_to_update) {
+    if (cleanup_removed_apps && no_any_app_to_update) {
       compose_pacman->handleRemovedApps(getCurrent());
     }
 

--- a/src/liteclient.h
+++ b/src/liteclient.h
@@ -67,7 +67,7 @@ class LiteClient {
   void reportHwInfo();
   void reportAppsState();
   bool isTargetActive(const Uptane::Target& target) const;
-  bool appsInSync(const Uptane::Target& target) const;
+  bool appsInSync(const Uptane::Target& target, bool cleanup_removed_apps = true) const;
   void setAppsNotChecked();
   std::string getDeviceID() const;
   static void update_request_headers(std::shared_ptr<HttpClient>& http_client, const Uptane::Target& target,


### PR DESCRIPTION
Only prune on startup, or when an installation is being finalized.