### PR TITLE
composeappmanager: Make app stopping configurable

### DIFF
--- a/src/composeappmanager.h
+++ b/src/composeappmanager.h
@@ -35,6 +35,7 @@ class ComposeAppManager : public RootfsTreeManager {
     std::string docker_images_reload_cmd{"systemctl reload docker"};
     std::string hub_auth_creds_endpoint{Docker::RegistryClient::DefAuthCredsEndpoint};
     bool create_containers_before_reboot{true};
+    bool stop_apps_before_update{true};
     int storage_watermark{80};
   };
 


### PR DESCRIPTION
Introduce a new configuration var, `[pacman].stop_apps_before_update`, to control whether apps should be forcibly stopped just before their update during an "app-only" update (when no OSTree update is involved).

By default, this variable is set to true, meaning apps are stopped before their update even if no OSTree update occurs.

If there is OSTree update too, then apps are stopped unconditionally; the new conf var is ignored.