### PR TITLE
docker: Bump composectl to ab20bf9

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.22.2-bookworm AS composeapp
 # Build composeapp
 WORKDIR /build
 RUN git clone https://github.com/foundriesio/composeapp.git && \
-    cd composeapp && make && cp ./bin/composectl /usr/bin/
+    cd composeapp && git checkout v95 && make && cp ./bin/composectl /usr/bin/
 
 
 FROM ubuntu:jammy


### PR DESCRIPTION
Relevant changes:
- 97ea634 check: Make app install status public
- 333acad root: Add function to expose composectl config
- 91443c5 test: Prune app images when uninstalling app
- 1c89b6b uninstall: Add flag to optionally prune images
- 5e8d9ed test: Make app publishing self-contained
- 8e897c2 test: Remove image just after upload to registry
- 593cad5 test: Remove bash usage in shell script
- 363ff36 check: Unify app installation check
- c45d8ea ps: Mark app as present in store if its tree is loaded
- 71c8316 check:  Add a quick way to check if app is fetched
- 220e51c ps: Check bundle integrity of running app
- cf7c427 install: Check installed app bundle integrity
- 5c7da30 app: Attach app index node to app tree if present
- 720031e publish: Limit size of app bundle
- 5bb0f02 publish: Checksum app bundle content