### PR TITLE
api: extended: Fix rollback to unlisted target

### DIFF
--- a/src/aklite_client_ext.cc
+++ b/src/aklite_client_ext.cc
@@ -249,7 +249,8 @@ InstallResult AkliteClientExt::PullAndInstall(const TufTarget& target, const std
     LOG_ERROR << "Failed to install Target; target: " << target.Name() << ", err: " << ir;
     if (ir.status == InstallResult::Status::Failed) {
       LOG_INFO << "Rolling back to the previous target: " << current.Name() << "...";
-      const auto installer = Installer(current);
+      const auto installer =
+          Installer(current, ir.description, correlation_id, InstallMode::All, local_update_source, false);
       if (installer == nullptr) {
         LOG_ERROR << "Failed to find the previous target in the TUF Targets DB";
         return InstallResult{InstallResult::Status::InstallRollbackFailed, ir.description};


### PR DESCRIPTION
This fix complements ba7d665 (api: Fix rollback to target that is not in TUF metadata) for the case when a rollback is initiated during the install operation.

---
Cherry-picking 1d7da48f6e6acbdeb3a122fa6194629fad17d820 into `v95`  