### PR TITLE
daemon: Ensure target installation is invoked when apps need syncing

### DIFF
--- a/src/daemon.cc
+++ b/src/daemon.cc
@@ -43,7 +43,8 @@ int run_daemon(LiteClient& client, uint64_t interval, bool return_on_sleep, bool
         // A target is supposed to be installed
         auto install_result =
             akclient.PullAndInstall(gti_res.selected_target, gti_res.reason, "", InstallMode::All, nullptr, true,
-                                    gti_res.status == GetTargetToInstallResult::Status::UpdateNewVersion);
+                                    gti_res.status == GetTargetToInstallResult::Status::UpdateNewVersion ||
+                                        gti_res.status == GetTargetToInstallResult::Status::UpdateSyncApps);
         if (akclient.RebootIfRequired()) {
           // no point to continue running TUF cycle (check for update, download, install)
           // since reboot is required to apply/finalize the currently installed update (aka pending update)


### PR DESCRIPTION
Previously, the target installation was only triggered if a new target was present. Now, it is also invoked when there are apps to be synced.