### PR TITLE
api: Don't start newly enabled apps during finalization

### DIFF
--- a/src/api.cc
+++ b/src/api.cc
@@ -591,6 +591,19 @@ class LiteInstall : public InstallContext {
       return InstallResult{InstallResult::Status::DownloadFailed, ""};
     }
 
+    // Update the target's custom data with a list of apps considered for an update taking into account
+    // the target's app list and the current .toml configuration.
+    auto custom{target_->custom_data()};
+    Json::Value app_list_json;
+    for (const auto& app :
+         ComposeAppManager::getRequiredApps(ComposeAppManager::Config(client_->config.pacman), *target_)) {
+      app_list_json[app.first] = app.second;
+    }
+    if (!app_list_json.empty()) {
+      custom["install-context"]["apps"] = app_list_json;
+    }
+    target_->updateCustom(custom);
+
     auto rc = client_->install(*target_, mode_);
     auto status = InstallResult::Status::Failed;
     if (rc == data::ResultCode::Numeric::kNeedCompletion) {


### PR DESCRIPTION
- Store a list of required apps in context of the target being installed

- Avoid starting of the app that was not fetched before reboot while running the update finalization after reboot. It can happen if the `compose_apps` list value changes in the ostree-based rootfs during the given target

- The following "sync" update fetches, installs, and starts the newly enabled