### PR TITLE
daemon: Fix setting of parameters for target installation

### DIFF
--- a/src/daemon.cc
+++ b/src/daemon.cc
@@ -42,7 +42,7 @@ int run_daemon(LiteClient& client, uint64_t interval, bool return_on_sleep, bool
         LOG_INFO << "Going to install " << gti_res.selected_target.Name() << ". Reason: " << gti_res.reason;
         // A target is supposed to be installed
         auto install_result =
-            akclient.PullAndInstall(gti_res.selected_target, gti_res.reason, "", InstallMode::All, nullptr, true,
+            akclient.PullAndInstall(gti_res.selected_target, gti_res.reason, "", InstallMode::All, nullptr, true, true,
                                     gti_res.status == GetTargetToInstallResult::Status::UpdateNewVersion);
         if (akclient.RebootIfRequired()) {
           // no point to continue running TUF cycle (check for update, download, install)


### PR DESCRIPTION
Commit ba7d665 (api: Fix rollback to target that is not in TUF metadata) added additional parameters to PullAndInstall call within the daemon, but there was one (optional) parameter missing, leading to incorrectly setting `do_install` based on `GetTargetToInstall` result instead of `require_target_in_tuf`.

This commit adds the missing `do_install=true` parameter.

---

Cherry-picking 4ece08a97fe2aacfe8994a9cf692d61b22cba831 into `v95`