### PR TITLE
Improve end-to-end tests

### DIFF
--- a/docker-e2e-test/e2e-test.py
+++ b/docker-e2e-test/e2e-test.py
@@ -249,7 +249,7 @@ compose_apps = "{apps_str}"
         sota_toml_content = f.read()
 
     if not "callback_program" in sota_toml_content:
-        sota_toml_content = sota_toml_content.replace("[pacman]", '[pacman]\ncallback_program = "/var/sota/callback.sh"')
+        sota_toml_content = sota_toml_content.replace("[pacman]", '[pacman]\ncallback_program = "/var/sota/callback.sh"\nstorage_watermark = "95"')
         with open("/var/sota/sota.toml", "w") as f:
             f.write(sota_toml_content)
 


### PR DESCRIPTION
Some additions to the e2e-test script, including tests for:
- Tags switching
- Automatic downgrade prevention
- `delay-app-install` mode (which detects the issue fixed in #409)

The PR also contains general code improvements, that made it easier to expand the tests.