### PR TITLE
composeappmanager: Force app installation if enabled

### DIFF
--- a/src/composeappmanager.cc
+++ b/src/composeappmanager.cc
@@ -242,7 +242,13 @@ ComposeAppManager::AppsContainer ComposeAppManager::getAppsToUpdate(const Uptane
 }
 
 bool ComposeAppManager::checkForAppsToUpdate(const Uptane::Target& target) {
-  cur_apps_to_fetch_and_update_ = getAppsToUpdate(target);
+  if (!cfg_.force_update) {
+    cur_apps_to_fetch_and_update_ = getAppsToUpdate(target);
+  } else {
+    LOG_INFO << "All Apps are forced to be updated...";
+    cur_apps_to_fetch_and_update_ = getApps(target);
+  }
+
   if (!!cfg_.reset_apps) {
     cur_apps_to_fetch_ = getAppsToFetch(target);
   }


### PR DESCRIPTION
Force all enabled app installation if the `force_update` is set to `"1"`. Consequently, it leads to apps stopping before installation even if they are not changed/updated.