### PR TITLE
e2e-tests: Fix format of yaml files generated by entrypoint.sh

### DIFF
--- a/docker-e2e-test/entrypoint.sh
+++ b/docker-e2e-test/entrypoint.sh
@@ -49,12 +49,12 @@ ln -sfn ${PWD}/build/aktualizr/src/aktualizr_get/aktualizr-get /usr/local/bin/ak
 # Initialize default toml config
 sysroot_cfg=/usr/lib/sota/conf.d/z-90-sysroot.toml
 if [ ! -f $sysroot_cfg ]; then
-    echo "[pacman]\nbooted = 0\nos = lmp" > $sysroot_cfg
+    echo "[pacman]\nbooted = 0\nos = \"lmp\"" > $sysroot_cfg
 fi
 
 bootloader_cfg=/usr/lib/sota/conf.d/z-91-bootloader.toml
 if [ ! -f $bootloader_cfg ]; then
-    echo "[bootloader]\nreboot_command = /usr/bin/true" > $bootloader_cfg
+    echo "[bootloader]\nreboot_command = \"/usr/bin/true\"" > $bootloader_cfg
 fi
 
 # Set directory used for reboot indication, the `need_reboot` file is created under this dir


### PR DESCRIPTION
There were a few double quotation marks missing.