### PR TITLE
composeappmanager: Force app installation if enabled

### DIFF
--- a/src/composeappmanager.cc
+++ b/src/composeappmanager.cc
@@ -249,7 +249,13 @@ ComposeAppManager::AppsContainer ComposeAppManager::getAppsToUpdate(const Uptane
 ComposeAppManager::AppsSyncReason ComposeAppManager::checkForAppsToUpdate(const Uptane::Target& target) {
   AppsSyncReason apps_and_reasons;
   std::set<std::string> fetched_apps;
-  cur_apps_to_fetch_and_update_ = getAppsToUpdate(target, apps_and_reasons, fetched_apps);
+  if (!cfg_.force_update) {
+    cur_apps_to_fetch_and_update_ = getAppsToUpdate(target, apps_and_reasons, fetched_apps);
+  } else {
+    LOG_INFO << "All Apps are forced to be updated...";
+    cur_apps_to_fetch_and_update_ = getApps(target);
+  }
+
   if (!!cfg_.reset_apps) {
     cur_apps_to_fetch_ = getAppsToFetch(target, true, &cur_apps_to_fetch_and_update_, &fetched_apps);
   }


### PR DESCRIPTION
Force all enabled app installation if the `force_update` is set to `"1"`. Consequently, it leads to apps stopping before installation even if they are not changed/updated.