### PR TITLE
cli: Use read-only storage for `list` and `status` commands

### DIFF
--- a/src/api.cc
+++ b/src/api.cc
@@ -161,7 +161,7 @@ void AkliteClient::Init(Config& config, bool finalize, bool apply_lock) {
     }
   }
 
-  tuf_repo_ = std::make_unique<aklite::tuf::AkRepo>(client_->config);
+  tuf_repo_ = std::make_unique<aklite::tuf::AkRepo>(client_->config, read_only_);
   hw_id_ = client_->primary_ecu.second.ToString();
 }
 

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -448,7 +448,7 @@ Json::Value GetStatusJson(AkliteClientExt &akclient) {
   StorageConfig sc;
   sc.updateFromPropertyTree(config.get_child("storage"));
 
-  auto storage = INvStorage::newStorage(sc, false);
+  auto storage = INvStorage::newStorage(sc, true);
   storage->loadPrimaryInstalledVersions(&applied_target, &pending_target);
 
   auto app_shortlist = akclient.GetAppShortlist();

--- a/src/liteclient.cc
+++ b/src/liteclient.cc
@@ -53,11 +53,11 @@ class OfflineMetaFetcher : public Uptane::IMetadataFetcher {
 };
 
 LiteClient::LiteClient(Config config_in, const AppEngine::Ptr& app_engine, const std::shared_ptr<P11EngineGuard>& p11,
-                       std::shared_ptr<Uptane::IMetadataFetcher> meta_fetcher)
+                       std::shared_ptr<Uptane::IMetadataFetcher> meta_fetcher, bool read_only_storage)
     : config{std::move(config_in)},
       primary_ecu{Uptane::EcuSerial::Unknown(), ""},
       uptane_fetcher_{std::move(meta_fetcher)} {
-  storage = INvStorage::newStorage(config.storage, false, StorageClient::kTUF);
+  storage = INvStorage::newStorage(config.storage, read_only_storage, StorageClient::kTUF);
   storage->importData(config.import);
 
   std::map<std::string, std::string>& raw = config.pacman.extra;

--- a/src/liteclient.h
+++ b/src/liteclient.h
@@ -31,7 +31,7 @@ class LiteClient {
 
   explicit LiteClient(Config config_in, const std::shared_ptr<AppEngine>& app_engine = nullptr,
                       const std::shared_ptr<P11EngineGuard>& p11 = nullptr,
-                      std::shared_ptr<Uptane::IMetadataFetcher> meta_fetcher = nullptr);
+                      std::shared_ptr<Uptane::IMetadataFetcher> meta_fetcher = nullptr, bool read_only_storage = false);
   ~LiteClient();
   LiteClient(const LiteClient&) = delete;
   LiteClient& operator=(const LiteClient&) = delete;

--- a/src/tuf/akrepo.cc
+++ b/src/tuf/akrepo.cc
@@ -6,8 +6,8 @@ namespace aklite::tuf {
 // AkRepo
 AkRepo::AkRepo(const boost::filesystem::path& storage_path) { init(storage_path); }
 
-AkRepo::AkRepo(const Config& config) {
-  storage_ = INvStorage::newStorage(config.storage, false, StorageClient::kTUF);
+AkRepo::AkRepo(const Config& config, bool read_only_storage) {
+  storage_ = INvStorage::newStorage(config.storage, read_only_storage, StorageClient::kTUF);
   storage_->importData(config.import);
 }
 

--- a/src/tuf/akrepo.h
+++ b/src/tuf/akrepo.h
@@ -15,7 +15,7 @@ namespace aklite::tuf {
 class AkRepo : public Repo {
  public:
   explicit AkRepo(const boost::filesystem::path& storage_path);
-  explicit AkRepo(const Config& config);
+  explicit AkRepo(const Config& config, bool read_only_storage = false);
   std::vector<TufTarget> GetTargets() override;
   std::string GetRoot(int version) override;
   void UpdateMeta(std::shared_ptr<RepoSource> repo_src) override;


### PR DESCRIPTION
Also avoid enforce locking when running these commands. The changes prevent unnecessary warning messages to be show, and execution to be blocked by the lock file.