### PR TITLE
Support for Boost >= 1.88.0

### DIFF
--- a/src/aklite_client_ext.cc
+++ b/src/aklite_client_ext.cc
@@ -3,7 +3,6 @@
 #include <sys/file.h>
 #include <unistd.h>
 #include <boost/format.hpp>
-#include <boost/process.hpp>
 #include <boost/property_tree/ini_parser.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>

--- a/src/api.cc
+++ b/src/api.cc
@@ -2,8 +2,8 @@
 
 #include <sys/file.h>
 #include <unistd.h>
+#include <boost/algorithm/string.hpp>
 #include <boost/format.hpp>
-#include <boost/process.hpp>
 #include <boost/property_tree/ini_parser.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
@@ -980,9 +980,8 @@ class LocalLiteInstall : public LiteInstall {
     }
 
     std::string docker_host{"unix:///var/run/docker.sock"};
-    auto env{boost::this_process::environment()};
-    if (env.end() != env.find("DOCKER_HOST")) {
-      docker_host = env.get("DOCKER_HOST");
+    if (std::getenv("DOCKER_HOST") != nullptr) {
+      docker_host = std::getenv("DOCKER_HOST");
     }
 
     auto docker_client{local_update_source_.docker_client_ptr != nullptr

--- a/src/composeapp/appengine.cc
+++ b/src/composeapp/appengine.cc
@@ -1,7 +1,6 @@
 #include "appengine.h"
 
 #include <boost/format.hpp>
-#include <boost/process.hpp>
 
 #include "aktualizr-lite/storage/stat.h"
 #include "exec.h"
@@ -70,7 +69,7 @@ bool AppEngine::isRunning(const App& app) const {
     std::future<std::string> output;
     exec(boost::format{"%s --store %s --compose %s ps %s --format json"} % composectl_cmd_ % storeRoot() %
              installRoot() % app.uri,
-         "", boost::process::std_out > output);
+         "", bp::std_out > output);
     const auto app_status{Utils::parseJSON(output.get())};
     // Make sure app images and bundle are properly installed
     res = checkAppInstallationStatus(app, app_status);
@@ -88,8 +87,7 @@ Json::Value AppEngine::getRunningAppsInfo() const {
   Json::Value app_statuses;
   try {
     std::future<std::string> output;
-    exec(boost::format{"%s --store %s ps --format json"} % composectl_cmd_ % storeRoot(), "",
-         boost::process::std_out > output);
+    exec(boost::format{"%s --store %s ps --format json"} % composectl_cmd_ % storeRoot(), "", bp::std_out > output);
     const auto output_str{output.get()};
     app_statuses = Utils::parseJSON(output_str);
   } catch (const std::exception& exc) {
@@ -104,7 +102,7 @@ void AppEngine::prune(const Apps& app_shortlist) {
     // Remove apps that are not in the shortlist
     std::future<std::string> output;
     exec(boost::format{"%s --store %s ls --format json"} % composectl_cmd_ % storeRoot(), "failed to list apps",
-         boost::process::std_out > output);
+         bp::std_out > output);
     const std::string output_str{output.get()};
     const auto app_list{Utils::parseJSON(output_str)};
 
@@ -138,7 +136,7 @@ void AppEngine::prune(const Apps& app_shortlist) {
     // Pruning unused store blobs
     std::future<std::string> output;
     exec(boost::format{"%s --store %s prune --format=json"} % composectl_cmd_ % storeRoot(),
-         "failed to prune app blobs", boost::process::std_out > output);
+         "failed to prune app blobs", bp::std_out > output);
     const std::string output_str{output.get()};
     const auto pruned_blobs{Utils::parseJSON(output_str)};
 
@@ -163,7 +161,7 @@ bool AppEngine::isAppFetched(const App& app) const {
   try {
     std::future<std::string> output;
     exec(boost::format{"%s --store %s check %s --local --format json"} % composectl_cmd_ % storeRoot() % app.uri, "",
-         boost::process::std_out > output);
+         bp::std_out > output);
     const std::string output_str{output.get()};
     const auto app_fetch_status{Utils::parseJSON(output_str)};
     if (app_fetch_status.isMember("fetch_check") && app_fetch_status["fetch_check"].isMember("missing_blobs") &&
@@ -186,7 +184,7 @@ bool AppEngine::isAppInstalled(const App& app) const {
     std::future<std::string> output;
     exec(boost::format{"%s --store %s check %s --local --install --format json"} % composectl_cmd_ % storeRoot() %
              app.uri,
-         "", boost::process::std_out > output);
+         "", bp::std_out > output);
     const std::string output_str{output.get()};
     const auto app_fetch_status{Utils::parseJSON(output_str)};
     if (app_fetch_status.isMember("install_check") && app_fetch_status["install_check"].isMember(app.uri) &&

--- a/src/composeappmanager.cc
+++ b/src/composeappmanager.cc
@@ -2,8 +2,8 @@
 
 #include <set>
 
+#include <boost/algorithm/string.hpp>
 #include <boost/format.hpp>
-#include <boost/process.hpp>
 #include <boost/range/iterator_range_core.hpp>
 
 #include "bootloader/bootloaderlite.h"
@@ -140,9 +140,8 @@ ComposeAppManager::ComposeAppManager(const PackageConfig& pconfig, const Bootloa
     std::string docker_host{"unix:///var/run/docker.sock"};
 
     if (!!cfg_.reset_apps) {
-      auto env{boost::this_process::environment()};
-      if (env.end() != env.find("DOCKER_HOST")) {
-        docker_host = env.get("DOCKER_HOST");
+      if (std::getenv("DOCKER_HOST") != nullptr) {
+        docker_host = std::getenv("DOCKER_HOST");
       }
 #ifdef USE_COMPOSEAPP_ENGINE
       const auto composectl_cmd{boost::filesystem::canonical(cfg_.composectl_bin).string()};

--- a/src/docker/composeappengine.cc
+++ b/src/docker/composeappengine.cc
@@ -3,7 +3,6 @@
 #include "dockerclient.h"
 
 #include <sys/statvfs.h>
-#include <boost/process.hpp>
 #include <filesystem>
 
 #include "exec.h"
@@ -401,18 +400,18 @@ bool ComposeAppEngine::checkAvailableStorageSpace(const boost::filesystem::path&
 void ComposeAppEngine::verifyAppArchive(const App& app, const std::string& archive_file_name) {
   try {
     exec("tar -tf " + archive_file_name + " " + ComposeFile, "no compose file found in archive",
-         boost::process::start_dir = appRoot(app));
+         bp::start_dir = appRoot(app));
   } catch (const std::exception&) {
     exec("tar -tf " + archive_file_name + " ./" + ComposeFile, "no compose file found in archive",
-         boost::process::start_dir = appRoot(app));
+         bp::start_dir = appRoot(app));
   }
 }
 
 void ComposeAppEngine::extractAppArchive(const App& app, const std::string& archive_file_name,
                                          bool delete_after_extraction) {
-  exec("tar -xzf " + archive_file_name, "failed to extract App archive", boost::process::start_dir = appRoot(app));
+  exec("tar -xzf " + archive_file_name, "failed to extract App archive", bp::start_dir = appRoot(app));
   if (delete_after_extraction) {
-    exec("rm -f " + archive_file_name, "failed to delete App archive", boost::process::start_dir = appRoot(app));
+    exec("rm -f " + archive_file_name, "failed to delete App archive", bp::start_dir = appRoot(app));
   }
 }
 
@@ -515,7 +514,7 @@ void ComposeAppEngine::AppState::File::read(void* data, ssize_t size) const {
 }
 
 void ComposeAppEngine::runComposeCmd(const App& app, const std::string& cmd, const std::string& err_msg) const {
-  exec(compose_ + cmd, err_msg, boost::process::start_dir = appRoot(app));
+  exec(compose_ + cmd, err_msg, bp::start_dir = appRoot(app));
 }
 
 }  // namespace Docker

--- a/src/docker/restorableappengine.cc
+++ b/src/docker/restorableappengine.cc
@@ -10,7 +10,6 @@
 #include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 #include <boost/lexical_cast.hpp>
-#include <boost/process.hpp>
 #include <boost/range/iterator_range_core.hpp>
 
 #include "crypto/crypto.h"
@@ -145,7 +144,7 @@ AppEngine::Result RestorableAppEngine::verify(const App& app) {
 
     LOG_DEBUG << app.name << ": verifying App: " << app_dir << " --> " << app_dir;
     exec(boost::format("%s config %s") % compose_cmd_ % "-q", "compose file verification failed",
-         boost::process::start_dir = app_dir);
+         bp::start_dir = app_dir);
   } catch (const std::exception& exc) {
     LOG_ERROR << "failed to verify App; app: " + app.name + "; uri: " + app.uri + "; err: " + exc.what();
     res = {false, exc.what()};
@@ -557,7 +556,7 @@ void RestorableAppEngine::installApp(const boost::filesystem::path& app_dir, con
 
   boost::filesystem::create_directories(dst_dir);
   exec(boost::format{"tar --overwrite -xzf %s"} % archive_full_path.string(), "failed to install Compose App",
-       boost::process::start_dir = dst_dir);
+       bp::start_dir = dst_dir);
 }
 
 void RestorableAppEngine::installAppImages(const boost::filesystem::path& app_dir) {
@@ -851,26 +850,22 @@ void RestorableAppEngine::loadImageToDockerStore(Docker::DockerClient::Ptr& dock
 }
 
 void RestorableAppEngine::verifyComposeApp(const std::string& compose_cmd, const boost::filesystem::path& app_dir) {
-  exec(boost::format{"%s config"} % compose_cmd, "Compose App verification failed",
-       boost::process::start_dir = app_dir);
+  exec(boost::format{"%s config"} % compose_cmd, "Compose App verification failed", bp::start_dir = app_dir);
 }
 
 void RestorableAppEngine::pullComposeAppImages(const std::string& compose_cmd, const boost::filesystem::path& app_dir,
                                                const std::string& flags) {
-  exec(boost::format{"%s pull %s"} % compose_cmd % flags, "failed to pull Compose App images",
-       boost::process::start_dir = app_dir);
+  exec(boost::format{"%s pull %s"} % compose_cmd % flags, "failed to pull Compose App images", bp::start_dir = app_dir);
 }
 
 void RestorableAppEngine::startComposeApp(const std::string& compose_cmd, const boost::filesystem::path& app_dir,
                                           const std::string& flags) {
-  exec(boost::format{"%s up %s"} % compose_cmd % flags, "failed to bring Compose App up",
-       boost::process::start_dir = app_dir);
+  exec(boost::format{"%s up %s"} % compose_cmd % flags, "failed to bring Compose App up", bp::start_dir = app_dir);
 }
 
 void RestorableAppEngine::stopComposeApp(const std::string& compose_cmd, const boost::filesystem::path& app_dir) {
   if (boost::filesystem::exists(app_dir)) {
-    exec(boost::format{"%s down"} % compose_cmd, "failed to bring Compose App down",
-         boost::process::start_dir = app_dir);
+    exec(boost::format{"%s down"} % compose_cmd, "failed to bring Compose App down", bp::start_dir = app_dir);
   }
 }
 

--- a/src/docker/restorableappengine.cc
+++ b/src/docker/restorableappengine.cc
@@ -6,6 +6,7 @@
 #include <unordered_set>
 
 #include <boost/algorithm/hex.hpp>
+#include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 #include <boost/lexical_cast.hpp>

--- a/src/exec.h
+++ b/src/exec.h
@@ -4,7 +4,33 @@
 #include <boost/asio/io_context.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/format.hpp>
+
+#include <boost/version.hpp>
+
+#if BOOST_VERSION >= 108800
+#include <boost/process/v1/args.hpp>
+#include <boost/process/v1/async.hpp>
+#include <boost/process/v1/async_system.hpp>
+#include <boost/process/v1/child.hpp>
+#include <boost/process/v1/cmd.hpp>
+#include <boost/process/v1/env.hpp>
+#include <boost/process/v1/environment.hpp>
+#include <boost/process/v1/error.hpp>
+#include <boost/process/v1/exe.hpp>
+#include <boost/process/v1/group.hpp>
+#include <boost/process/v1/handles.hpp>
+#include <boost/process/v1/io.hpp>
+#include <boost/process/v1/pipe.hpp>
+#include <boost/process/v1/search_path.hpp>
+#include <boost/process/v1/shell.hpp>
+#include <boost/process/v1/spawn.hpp>
+#include <boost/process/v1/start_dir.hpp>
+#include <boost/process/v1/system.hpp>
+namespace bp = boost::process::v1;
+#else
 #include <boost/process.hpp>
+namespace bp = boost::process;
+#endif
 #include "logging/logging.h"
 
 struct ExecError : std::runtime_error {
@@ -25,9 +51,8 @@ static void exec(const std::string& cmd, const std::string& err_msg_prefix, Args
 
   try {
     LOG_DEBUG << "Running: `" << cmd << "`";
-    boost::process::child child_process(cmd, boost::process::std_err > err_output,
-                                        boost::process::on_exit = child_process_exit_code, io_context,
-                                        std::forward<Args>(args)...);
+    bp::child child_process(cmd, bp::std_err > err_output, bp::on_exit = child_process_exit_code, io_context,
+                            std::forward<Args>(args)...);
 
     io_context.run();
 

--- a/src/liteclient.cc
+++ b/src/liteclient.cc
@@ -1,8 +1,10 @@
 #include "liteclient.h"
 
+#include <cstdlib>
 #include <fcntl.h>
 #include <sys/file.h>
 
+#include <boost/algorithm/string.hpp>
 #include <boost/process.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>

--- a/src/liteclient.cc
+++ b/src/liteclient.cc
@@ -1,8 +1,8 @@
 #include "liteclient.h"
 
-#include <cstdlib>
 #include <fcntl.h>
 #include <sys/file.h>
+#include <cstdlib>
 
 #include <boost/algorithm/string.hpp>
 #include <boost/process.hpp>
@@ -13,6 +13,7 @@
 #include "composeappmanager.h"
 #include "crypto/keymanager.h"
 #include "crypto/p11engine.h"
+#include "exec.h"
 #include "helpers.h"
 #include "http/httpclient.h"
 #include "primary/reportqueue.h"
@@ -262,7 +263,7 @@ void LiteClient::callback(const char* msg, const Uptane::Target& install_target,
     return;
   }
   auto env = boost::this_process::environment();
-  boost::process::environment env_copy = env;
+  bp::environment env_copy = env;
   env_copy["MESSAGE"] = msg;
   env_copy["CURRENT_TARGET"] = (config.storage.path / "current-target").string();
   auto current = getCurrent();
@@ -277,7 +278,7 @@ void LiteClient::callback(const char* msg, const Uptane::Target& install_target,
     env_copy["RESULT"] = result;
   }
 
-  int rc = boost::process::system(callback_program, env_copy);
+  int rc = bp::system(callback_program, env_copy);
   if (rc != 0) {
     LOG_ERROR << "Error with callback: " << rc;
   }

--- a/tests/aklite_offline_test.cc
+++ b/tests/aklite_offline_test.cc
@@ -161,9 +161,8 @@ class AkliteOffline : public ::testing::Test {
     }
 
     std::string docker_host{"unix:///var/run/docker.sock"};
-    auto env{boost::this_process::environment()};
-    if (env.end() != env.find("DOCKER_HOST")) {
-      docker_host = env.get("DOCKER_HOST");
+    if (std::getenv("DOCKER_HOST") != nullptr) {
+      docker_host = std::getenv("DOCKER_HOST");
     }
 
     auto docker_client{local_update_source_.docker_client_ptr != nullptr

--- a/tests/aklite_offline_test.cc
+++ b/tests/aklite_offline_test.cc
@@ -1,7 +1,6 @@
 #include <gtest/gtest.h>
 #include <boost/filesystem.hpp>
 #include <boost/format.hpp>
-#include <boost/process.hpp>
 #include <fstream>
 
 #include "test_utils.h"

--- a/tests/aklite_rollback_ext_test.cc
+++ b/tests/aklite_rollback_ext_test.cc
@@ -2,8 +2,6 @@
 #include <gtest/gtest.h>
 
 #include <boost/filesystem.hpp>
-#include <boost/process.hpp>
-#include <boost/process/env.hpp>
 
 #include "test_utils.h"
 #include "utilities/utils.h"

--- a/tests/aklite_rollback_test.cc
+++ b/tests/aklite_rollback_test.cc
@@ -2,8 +2,6 @@
 #include <gtest/gtest.h>
 
 #include <boost/filesystem.hpp>
-#include <boost/process.hpp>
-#include <boost/process/env.hpp>
 
 #include "test_utils.h"
 #include "utilities/utils.h"

--- a/tests/aklite_test.cc
+++ b/tests/aklite_test.cc
@@ -2,8 +2,6 @@
 #include <gtest/gtest.h>
 
 #include <boost/filesystem.hpp>
-#include <boost/process.hpp>
-#include <boost/process/env.hpp>
 
 #include "test_utils.h"
 #include "utilities/utils.h"

--- a/tests/apiclient_test.cc
+++ b/tests/apiclient_test.cc
@@ -2,8 +2,6 @@
 #include <gtest/gtest.h>
 
 #include <boost/filesystem.hpp>
-#include <boost/process.hpp>
-#include <boost/process/env.hpp>
 
 #include "libaktualizr/types.h"
 #include "logging/logging.h"

--- a/tests/boot_flag_mgmt_test.cc
+++ b/tests/boot_flag_mgmt_test.cc
@@ -1,7 +1,6 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <boost/algorithm/string.hpp>
-#include <boost/process.hpp>
 
 #include "test_utils.h"
 #include "uptane_generator/image_repo.h"

--- a/tests/cli_test.cc
+++ b/tests/cli_test.cc
@@ -2,7 +2,6 @@
 #include <gtest/gtest.h>
 
 #include <boost/format.hpp>
-#include <boost/process.hpp>
 
 #include "aktualizr-lite/aklite_client_ext.h"
 #include "aktualizr-lite/cli/cli.h"

--- a/tests/composeapp_test.cc
+++ b/tests/composeapp_test.cc
@@ -2,8 +2,8 @@
 
 #include <algorithm>
 #include <boost/filesystem.hpp>
-#include <boost/process.hpp>
 #include <boost/algorithm/hex.hpp>
+#include <boost/algorithm/string.hpp>
 
 #include "http/httpclient.h"
 #include "test_utils.h"
@@ -15,6 +15,7 @@
 
 #include "composeappmanager.h"
 #include "docker/composeappengine.h"
+#include "exec.h"
 #include "target.h"
 #include "fixtures/dockerdaemon.cc"
 
@@ -35,7 +36,7 @@ class FakeRegistry {
       Utils::writeFile(docker_file, app_content);
       tgz_path_ = root_dir_ / app_name / (app_name + ".tgz");
       std::string stdout_msg;
-      boost::process::system("tar -czf " + tgz_path_.string() + " " + file_name, boost::process::start_dir = (root_dir_ / app_name));
+      bp::system("tar -czf " + tgz_path_.string() + " " + file_name, bp::start_dir = (root_dir_ / app_name));
       std::string tgz_content = Utils::readFile(tgz_path_);
       auto hash = boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha256digest(tgz_content)));
       // TODO: it should be in ComposeAppEngine::Manifest::Manifest()

--- a/tests/composeappengine_test.cc
+++ b/tests/composeappengine_test.cc
@@ -4,8 +4,6 @@
 
 #include <boost/filesystem.hpp>
 #include <boost/format.hpp>
-#include <boost/process.hpp>
-
 #include "crypto/crypto.h"
 #include "test_utils.h"
 

--- a/tests/daemon_test.cc
+++ b/tests/daemon_test.cc
@@ -2,8 +2,6 @@
 #include <gtest/gtest.h>
 
 #include <boost/filesystem.hpp>
-#include <boost/process.hpp>
-#include <boost/process/env.hpp>
 
 #include "libaktualizr/types.h"
 #include "logging/logging.h"

--- a/tests/docker_test.cc
+++ b/tests/docker_test.cc
@@ -1,7 +1,6 @@
 #include <gtest/gtest.h>
 
 #include <boost/format.hpp>
-#include <boost/process.hpp>
 #include "boost/format.hpp"
 
 #include "docker/docker.h"

--- a/tests/exec_test.cc
+++ b/tests/exec_test.cc
@@ -6,7 +6,7 @@
 TEST(Exec, SuccessfulExec) {
   TemporaryDirectory test_dir;
   const auto test_file{test_dir / "test-file"};
-  exec("touch " + test_file.string(), "touch failed", boost::process::start_dir = test_dir.Path());
+  exec("touch " + test_file.string(), "touch failed", bp::start_dir = test_dir.Path());
   ASSERT_TRUE(boost::filesystem::exists(test_file));
 }
 

--- a/tests/fixtures/composeapp.cc
+++ b/tests/fixtures/composeapp.cc
@@ -3,6 +3,7 @@
 
 #include <boost/optional.hpp>
 #include <boost/algorithm/hex.hpp>
+#include <boost/algorithm/string.hpp>
 #include "libaktualizr/crypto/crypto.h"
 
 

--- a/tests/fixtures/composeapp.cc
+++ b/tests/fixtures/composeapp.cc
@@ -5,7 +5,7 @@
 #include <boost/algorithm/hex.hpp>
 #include <boost/algorithm/string.hpp>
 #include "libaktualizr/crypto/crypto.h"
-
+#include "exec.h"
 
 namespace fixtures {
 
@@ -130,7 +130,7 @@ class ComposeApp {
 
     Utils::writeFile(app_dir.Path() / compose_file_, std::string(content_));
     auto cmd = std::string("tar -czf ") + arch_file.Path().string() + " " + compose_file_;
-    if (0 != boost::process::system(cmd, boost::process::start_dir = app_dir.Path())) {
+    if (0 != bp::system(cmd, bp::start_dir = app_dir.Path())) {
       throw std::runtime_error("failed to create App archive: " + name());
     }
     arch_ = Utils::readFile(arch_file.Path());

--- a/tests/fixtures/dockerdaemon.cc
+++ b/tests/fixtures/dockerdaemon.cc
@@ -101,8 +101,8 @@ class DockerDaemon {
   const std::string none_containers_{"[]"};
   boost::filesystem::path dir_;
   const std::string port_;
-  boost::process::child unix_process_;
-  boost::process::child process_;
+  bp::child unix_process_;
+  bp::child process_;
 };
 
 std::string DockerDaemon::RunCmd{"./tests/docker-daemon_fake.py"};

--- a/tests/fixtures/dockerdaemon.cc
+++ b/tests/fixtures/dockerdaemon.cc
@@ -1,6 +1,7 @@
 #include "fixtures/basehttpclient.cc"
 
 #include "libaktualizr/http/httpclient.h"
+#include "boost/filesystem.hpp"
 
 namespace fixtures {
 

--- a/tests/fixtures/dockerregistry.cc
+++ b/tests/fixtures/dockerregistry.cc
@@ -224,7 +224,7 @@ class DockerRegistry {
   const std::string repo_; // repo, aka Factory name
 
   const std::string port_;
-  boost::process::child process_;
+  bp::child process_;
 
   std::unordered_map<std::string, std::string> hash2manifest_;
   std::unordered_map<std::string, int> manifest2pull_numb_;

--- a/tests/fixtures/liteclient/devicegatewaymock.cc
+++ b/tests/fixtures/liteclient/devicegatewaymock.cc
@@ -73,7 +73,7 @@ class DeviceGatewayMock {
   const std::string req_headers_file_;
   const std::string events_file_;
   const std::string sota_toml_file_;
-  boost::process::child process_;
+  bp::child process_;
 };
 
 std::string DeviceGatewayMock::RunCmd;

--- a/tests/fixtures/liteclienttest.cc
+++ b/tests/fixtures/liteclienttest.cc
@@ -1,6 +1,7 @@
 #include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 #include <boost/algorithm/hex.hpp>
+#include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/lexical_cast.hpp>

--- a/tests/liteclientHSM_test.cc
+++ b/tests/liteclientHSM_test.cc
@@ -3,8 +3,6 @@
 
 #include <boost/filesystem.hpp>
 #include <boost/format.hpp>
-#include <boost/process.hpp>
-#include <boost/process/env.hpp>
 
 #include "crypto/p11engine.h"
 #include "libaktualizr/types.h"

--- a/tests/liteclient_test.cc
+++ b/tests/liteclient_test.cc
@@ -2,8 +2,6 @@
 #include <gtest/gtest.h>
 
 #include <boost/filesystem.hpp>
-#include <boost/process.hpp>
-#include <boost/process/env.hpp>
 
 #include "libaktualizr/types.h"
 #include "logging/logging.h"

--- a/tests/nospace_test.cc
+++ b/tests/nospace_test.cc
@@ -3,8 +3,6 @@
 #include <sys/statvfs.h>
 
 #include <boost/filesystem.hpp>
-#include <boost/process.hpp>
-#include <boost/process/env.hpp>
 
 #include "test_utils.h"
 #include "uptane_generator/image_repo.h"

--- a/tests/restorableappengine_test.cc
+++ b/tests/restorableappengine_test.cc
@@ -2,7 +2,6 @@
 
 #include <boost/filesystem.hpp>
 #include <boost/format.hpp>
-#include <boost/process.hpp>
 #include <limits>
 
 #include "crypto/crypto.h"


### PR DESCRIPTION
Keep using the deprecated v1 process API, but adjust the namespace to allow the binaries to be build with Boost 1.88.0.

It is possible to reduce the reliance on the deprecated API, I did code changes in that direction, but I believe we can merge this PR first, and then gradually get other improvements integrated as we find appropriate.