### PR TITLE
e2e-tests: Use tag for referencing aklite-dev image

### DIFF
--- a/docker-e2e-test/Dockerfile
+++ b/docker-e2e-test/Dockerfile
@@ -17,7 +17,7 @@ RUN git clone https://github.com/foundriesio/composeapp.git && cd composeapp \
 #     && cp ./bin/fioctl-linux-amd64 /usr/bin/fioctl
 
 
-FROM foundries/aklite-dev AS aklite
+FROM foundries/aklite-dev:ubuntu-22.04 AS aklite
 
 # Install composectl
 COPY --from=composeapp /build/composeapp/bin/composectl /usr/bin/


### PR DESCRIPTION
Docker commands used for creating the e2e test docker image may vary depending on the aklite-dev image version it is based on. Specifying the proper tag helps keeping consistency.