### PR TITLE
e2e-tests: Pin composeapp version to v95.1

### DIFF
--- a/docker-e2e-test/Dockerfile
+++ b/docker-e2e-test/Dockerfile
@@ -2,6 +2,7 @@ FROM golang:1.22.2-bookworm AS composeapp
 # Build composeapp
 WORKDIR /build
 RUN git clone https://github.com/foundriesio/composeapp.git && cd composeapp \
+    && git checkout v95.1 \
     && STOREROOT=/var/sota/reset-apps COMPOSEROOT=/var/sota/compose-apps BASESYSTEMCONFIG=/usr/lib/docker make \
     && cp ./bin/composectl /usr/bin/
 


### PR DESCRIPTION
@mike-sul The recent merge in composeapp broke the build in our test env, due to the update in  golang required version. We can update the golang version in the Dockerfile as well, but I think we can pin the composeapp first, and then decide how to manage the golang version / composeapp version properly later.