### PR TITLE
composeappmanager: Fix app health deducing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     name: Clang Format And Tidy
     runs-on: ubuntu-latest
     container:
-      image: foundries/aklite-dev
+      image: foundries/aklite-dev:ubuntu-22.04
       env:
         CXX: clang++
         CC: clang
@@ -37,7 +37,7 @@ jobs:
     name: Build Garage Tools
     runs-on: ubuntu-latest
     container:
-      image: foundries/aklite-dev
+      image: foundries/aklite-dev:ubuntu-22.04
       env:
         CXX: clang++
         CC: clang
@@ -64,7 +64,7 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     container:
-      image: foundries/aklite-dev
+      image: foundries/aklite-dev:ubuntu-22.04
       env:
         CXX: clang++
         CC: clang

--- a/dev-shell
+++ b/dev-shell
@@ -2,7 +2,7 @@
 
 ## A simple wrapper to allow development to occur in a container.
 
-container="foundries/aklite-dev"
+container="foundries/aklite-dev:ubuntu-22.04"
 DEF_COMPILER_ARGS="-e CC=clang -e CXX=clang++"
 
 here=$(dirname $(readlink -f $0))

--- a/docker-e2e-test/Dockerfile
+++ b/docker-e2e-test/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.22.2-bookworm AS composeapp
 # Build composeapp
 WORKDIR /build
-RUN git clone https://github.com/foundriesio/composeapp.git && cd composeapp \
+RUN git clone https://github.com/foundriesio/composeapp.git && cd composeapp &&  git checkout v95.1 \
     && STOREROOT=/var/sota/reset-apps COMPOSEROOT=/var/sota/compose-apps BASESYSTEMCONFIG=/usr/lib/docker make \
     && cp ./bin/composectl /usr/bin/
 
@@ -17,7 +17,7 @@ RUN git clone https://github.com/foundriesio/composeapp.git && cd composeapp \
 #     && cp ./bin/fioctl-linux-amd64 /usr/bin/fioctl
 
 
-FROM foundries/aklite-dev AS aklite
+FROM foundries/aklite-dev:ubuntu-22.04 AS aklite
 
 # Install composectl
 COPY --from=composeapp /build/composeapp/bin/composectl /usr/bin/


### PR DESCRIPTION
- App service health must be equal to "healthy" to consider it healthy, not just != "unhealthy" because the health value set by docker can be equal to "starting" or "none" which indicates that a service is not healthy.

- If the health is not specified then deduce service health based on its state.

- If a service health is not set in app status returned by the app engine then deduce it based on a service state and set it in the service status json.