### PR TITLE
Unify and optimize apps status check

### DIFF
--- a/include/aktualizr-lite/aklite_client_ext.h
+++ b/include/aktualizr-lite/aklite_client_ext.h
@@ -99,9 +99,6 @@ class AkliteClientExt : public AkliteClient {
   bool RebootIfRequired();
 
   bool IsAppRunning(const std::string &name, const std::string &uri) const;
-
- private:
-  bool cleanup_removed_apps_{true};
 };
 
 #endif

--- a/include/aktualizr-lite/api.h
+++ b/include/aktualizr-lite/api.h
@@ -382,7 +382,7 @@ class AkliteClient {
    * @param reason String containing reason for each app to be updated
    * @return The map of app names to their update reasons
    */
-  AppsUpdateReason checkAndSetAppsForUpdate(const TufTarget &target, std::string &reason);
+  AppsUpdateReason checkAndSetAppsForUpdate(const TufTarget &target, std::string &reason) const;
 
   /* check-for-update-post success callback may be called at the end of CheckIn, or the end of GetTargetToInstall */
   bool invoke_post_cb_at_checkin_{true};
@@ -408,7 +408,7 @@ class AkliteClient {
    * For example, if an app from the current target is removed from the
    * configuration, the next daemon restart should remove that app.
    */
-  bool cleanup_removed_apps_{true};
+  mutable bool cleanup_removed_apps_{true};
 };
 
 #endif  // AKTUALIZR_LITE_API_H_

--- a/include/aktualizr-lite/api.h
+++ b/include/aktualizr-lite/api.h
@@ -326,7 +326,7 @@ class AkliteClient {
   std::unique_ptr<InstallContext> Installer(const TufTarget &t, std::string reason = "",
                                             std::string correlation_id = "", InstallMode = InstallMode::All,
                                             const LocalUpdateSource *local_update_source = nullptr,
-                                            bool require_target_in_tuf = true) const;
+                                            bool require_target_in_tuf = true, bool are_apps_checked = false) const;
 
   /**
    * @brief Complete a pending installation

--- a/include/aktualizr-lite/api.h
+++ b/include/aktualizr-lite/api.h
@@ -371,6 +371,19 @@ class AkliteClient {
   static const std::vector<boost::filesystem::path> CONFIG_DIRS;
 
  protected:
+  /**
+   *  @brief AppsUpdateReason A map of app names to their update reasons
+   */
+  using AppsUpdateReason = std::unordered_map<std::string, std::string>;
+
+  /**
+   * @brief checkAndSetAppsForUpdate Checks and sets apps for an update
+   * @param target Target containing apps to be checked and set for an update
+   * @param reason String containing reason for each app to be updated
+   * @return The map of app names to their update reasons
+   */
+  AppsUpdateReason checkAndSetAppsForUpdate(const TufTarget &target, std::string &reason);
+
   /* check-for-update-post success callback may be called at the end of CheckIn, or the end of GetTargetToInstall */
   bool invoke_post_cb_at_checkin_{true};
   bool is_booted_env{true};
@@ -384,6 +397,18 @@ class AkliteClient {
   std::string hw_id_;
   std::vector<std::string> secondary_hwids_;
   mutable bool configUploaded_{false};
+
+  /**
+   * @brief Controls pruning of apps removed from configuration.
+   *
+   * When the app list in the `.toml` configuration changes and no update or
+   * sync is required, apps removed from `pacman.compose_apps` or
+   * `pacman.reset_apps` should be pruned immediately after the update check.
+   *
+   * For example, if an app from the current target is removed from the
+   * configuration, the next daemon restart should remove that app.
+   */
+  bool cleanup_removed_apps_{true};
 };
 
 #endif  // AKTUALIZR_LITE_API_H_

--- a/src/aklite_client_ext.cc
+++ b/src/aklite_client_ext.cc
@@ -133,9 +133,9 @@ GetTargetToInstallResult AkliteClientExt::GetTargetToInstall(const CheckInResult
                << " Skipping its installation.";
     }
 
-    auto apps_to_update = client_->appsToUpdate(Target::fromTufTarget(current), cleanup_removed_apps_);
-    // Automatically cleanup during check only once. A cleanup will also occur after a new target is installed
-    cleanup_removed_apps_ = false;
+    res.reason = "Syncing Active Target Apps";
+    auto apps_to_update = checkAndSetAppsForUpdate(current, res.reason);
+
     if (force_apps_sync || !apps_to_update.empty()) {
       // Force installation of apps
       res.selected_target = checkin_res.SelectTarget(current.Version());
@@ -149,7 +149,6 @@ GetTargetToInstallResult AkliteClientExt::GetTargetToInstall(const CheckInResult
           << res.selected_target.Name();
 
       res.status = GetTargetToInstallResult::Status::UpdateSyncApps;
-      res.reason = "Syncing Active Target Apps\n";
       for (const auto& app_to_update : apps_to_update) {
         res.reason += "- " + app_to_update.first + ": " + app_to_update.second + "\n";
       }

--- a/src/aklite_client_ext.cc
+++ b/src/aklite_client_ext.cc
@@ -31,8 +31,6 @@ GetTargetToInstallResult AkliteClientExt::GetTargetToInstall(const CheckInResult
                                                              const std::string& target_name, bool allow_bad_target,
                                                              bool force_apps_sync, bool is_offline_mode,
                                                              bool auto_downgrade) {
-  client_->setAppsNotChecked();
-
   std::string err;
   if (!checkin_res) {
     err = "Can't select target to install using a failed check-in result";
@@ -165,7 +163,6 @@ GetTargetToInstallResult AkliteClientExt::GetTargetToInstall(const CheckInResult
         res.status = GetTargetToInstallResult::Status::TargetAlreadyInstalled;
       }
     }
-    client_->setAppsNotChecked();
   }
 
   if (!invoke_post_cb_at_checkin_) {

--- a/src/aklite_client_ext.cc
+++ b/src/aklite_client_ext.cc
@@ -221,7 +221,8 @@ InstallResult AkliteClientExt::PullAndInstall(const TufTarget& target, const std
   }
   state_when_download_failed = {"", "", {.err = "undefined"}};
 
-  auto installer = Installer(target, reason, correlation_id, install_mode, local_update_source, require_target_in_tuf);
+  auto installer =
+      Installer(target, reason, correlation_id, install_mode, local_update_source, require_target_in_tuf, true);
   if (installer == nullptr) {
     LOG_ERROR << "Unexpected error: installer couldn't find Target in the DB; try again later";
     return InstallResult{InstallResult::Status::UnknownError};

--- a/src/aklite_client_ext.cc
+++ b/src/aklite_client_ext.cc
@@ -126,6 +126,7 @@ GetTargetToInstallResult AkliteClientExt::GetTargetToInstall(const CheckInResult
     res.selected_target = candidate_target;
     res.reason = std::string(rollback_operation ? "Rolling back" : "Updating") + " from " + current.Name() + " to " +
                  res.selected_target.Name();
+    checkAndSetAppsForUpdate(candidate_target, res.reason);
 
   } else {
     if (is_bad_target) {

--- a/src/api.cc
+++ b/src/api.cc
@@ -669,10 +669,6 @@ class LiteInstall : public InstallContext {
   InstallResult Install() override {
     client_->logTarget("Installing: ", *target_);
 
-    // Call appsInSync to update applications list inside the package manager
-    client_->appsInSync(*target_);
-    // setAppsNotChecked is required to force a re-load of apps list in case of a new Download operation
-    client_->setAppsNotChecked();
     if (client_->VerifyTarget(*target_) != TargetStatus::kGood) {
       return InstallResult{InstallResult::Status::DownloadFailed,
                            "Target verification failed, it may not have been pulled"};

--- a/src/api.cc
+++ b/src/api.cc
@@ -1051,7 +1051,7 @@ std::unique_ptr<InstallContext> AkliteClient::CheckAppsInSync() const {
 std::unique_ptr<InstallContext> AkliteClient::Installer(const TufTarget& t, std::string reason,
                                                         std::string correlation_id, InstallMode install_mode,
                                                         const LocalUpdateSource* local_update_source,
-                                                        bool require_target_in_tuf) const {
+                                                        bool require_target_in_tuf, bool are_apps_checked) const {
   if (read_only_) {
     throw std::runtime_error("Can't perform this operation from read-only mode");
   }
@@ -1094,6 +1094,9 @@ std::unique_ptr<InstallContext> AkliteClient::Installer(const TufTarget& t, std:
     throw std::runtime_error("Correlation ID's must be less than 64 bytes");
   }
   target->setCorrelationId(correlation_id);
+  if (!are_apps_checked) {
+    checkAndSetAppsForUpdate(Target::toTufTarget(*target), reason);
+  }
   if (local_update_source == nullptr) {
     return std::make_unique<LiteInstall>(client_, std::move(target), reason, install_mode);
   } else {

--- a/src/api.cc
+++ b/src/api.cc
@@ -1164,6 +1164,22 @@ InstallResult AkliteClient::SetSecondaries(const std::vector<SecondaryEcu>& ecus
 
 boost::optional<std::vector<std::string>> AkliteClient::GetAppShortlist() const { return client_->getAppShortlist(); }
 
+AkliteClient::AppsUpdateReason AkliteClient::checkAndSetAppsForUpdate(const TufTarget& target, std::string& reason) {
+  auto apps_to_update = client_->appsToUpdate(Target::fromTufTarget(target), cleanup_removed_apps_);
+  cleanup_removed_apps_ = false;
+
+  if (!apps_to_update.empty()) {
+    if (!reason.empty()) {
+      reason += "\n";
+    }
+    for (const auto& app_to_update : apps_to_update) {
+      reason += " - " + app_to_update.first + ": " + app_to_update.second + "\n";
+    }
+  }
+
+  return apps_to_update;
+}
+
 static Json::Value checkAndGetRootMeta(const std::shared_ptr<aklite::tuf::Repo>& device_tuf_repo,
                                        const boost::filesystem::path& bundle_tuf_repo_path) {
   auto latest_root{device_tuf_repo->GetRoot(-1)};

--- a/src/api.cc
+++ b/src/api.cc
@@ -1038,13 +1038,15 @@ TufTarget AkliteClient::GetPendingTarget() const { return Target::toTufTarget(cl
 
 std::unique_ptr<InstallContext> AkliteClient::CheckAppsInSync() const {
   std::unique_ptr<InstallContext> installer = nullptr;
-  auto target = std::make_unique<Uptane::Target>(client_->getCurrent());
-  if (!client_->appsInSync(*target)) {
+  const auto target{GetCurrent()};
+  std::string reason = "Sync active target apps";
+  const auto apps_to_update = checkAndSetAppsForUpdate(target, reason);
+  if (!apps_to_update.empty()) {
     boost::uuids::uuid tmp = boost::uuids::random_generator()();
-    auto correlation_id = target->custom_version() + "-" + boost::uuids::to_string(tmp);
-    target->setCorrelationId(correlation_id);
-    std::string reason = "Sync active target apps";
-    installer = std::make_unique<LiteInstall>(client_, std::move(target), reason, InstallMode::All);
+    auto correlation_id = std::to_string(target.Version()) + "-" + boost::uuids::to_string(tmp);
+    auto t = std::make_unique<Uptane::Target>(Target::fromTufTarget(target));
+    t->setCorrelationId(correlation_id);
+    installer = std::make_unique<LiteInstall>(client_, std::move(t), reason, InstallMode::All);
   }
   client_->setAppsNotChecked();
   return installer;
@@ -1164,7 +1166,8 @@ InstallResult AkliteClient::SetSecondaries(const std::vector<SecondaryEcu>& ecus
 
 boost::optional<std::vector<std::string>> AkliteClient::GetAppShortlist() const { return client_->getAppShortlist(); }
 
-AkliteClient::AppsUpdateReason AkliteClient::checkAndSetAppsForUpdate(const TufTarget& target, std::string& reason) {
+AkliteClient::AppsUpdateReason AkliteClient::checkAndSetAppsForUpdate(const TufTarget& target,
+                                                                      std::string& reason) const {
   auto apps_to_update = client_->appsToUpdate(Target::fromTufTarget(target), cleanup_removed_apps_);
   cleanup_removed_apps_ = false;
 

--- a/src/api.cc
+++ b/src/api.cc
@@ -1049,7 +1049,6 @@ std::unique_ptr<InstallContext> AkliteClient::CheckAppsInSync() const {
     t->setCorrelationId(correlation_id);
     installer = std::make_unique<LiteInstall>(client_, std::move(t), reason, InstallMode::All);
   }
-  client_->setAppsNotChecked();
   return installer;
 }
 
@@ -1172,8 +1171,10 @@ boost::optional<std::vector<std::string>> AkliteClient::GetAppShortlist() const 
 
 AkliteClient::AppsUpdateReason AkliteClient::checkAndSetAppsForUpdate(const TufTarget& target,
                                                                       std::string& reason) const {
+  client_->setAppsNotChecked();
   auto apps_to_update = client_->appsToUpdate(Target::fromTufTarget(target), cleanup_removed_apps_);
   cleanup_removed_apps_ = false;
+  client_->setAppsNotChecked();
 
   if (!apps_to_update.empty()) {
     if (!reason.empty()) {

--- a/src/api.cc
+++ b/src/api.cc
@@ -1016,8 +1016,13 @@ class LocalLiteInstall : public LiteInstall {
         )};
 #endif
 
-    return std::make_unique<ComposeAppManager>(offline_update_config_.pacman, offline_update_config_.bootloader,
-                                               storage_, nullptr, ostree_sysroot_, *nulled_key_manager_, app_engine);
+    auto pacman =
+        std::make_unique<ComposeAppManager>(offline_update_config_.pacman, offline_update_config_.bootloader, storage_,
+                                            nullptr, ostree_sysroot_, *nulled_key_manager_, app_engine);
+    if (pacman != nullptr) {
+      pacman->checkForAppsToUpdate(*target_);
+    }
+    return pacman;
   }
 
   const LocalUpdateSource local_update_source_;

--- a/src/composeappmanager.cc
+++ b/src/composeappmanager.cc
@@ -302,14 +302,6 @@ DownloadResult ComposeAppManager::Download(const TufTarget& target) {
   }
 
   DownloadResult res{ostree_download_res};
-  const Uptane::Target uptane_target{Target::fromTufTarget(target)};
-
-  if (!areAppsChecked()) {
-    LOG_INFO << "Checking for Apps to be installed or updated...";
-    checkForAppsToUpdate(uptane_target);
-  }
-  setAppsCheckFlag(false);
-
   AppsContainer all_apps_to_fetch;
   all_apps_to_fetch.insert(cur_apps_to_fetch_and_update_.begin(), cur_apps_to_fetch_and_update_.end());
   all_apps_to_fetch.insert(cur_apps_to_fetch_.begin(), cur_apps_to_fetch_.end());

--- a/tests/composeapp_test.cc
+++ b/tests/composeapp_test.cc
@@ -380,6 +380,7 @@ TEST(ComposeApp, fetch) {
 
   TestClient client("app2 doesnotexist", nullptr, &registry);  // only app2 can be fetched
   LOG_ERROR << target_json;
+  client.pacman->checkForAppsToUpdate(target);
   const auto result = client.downloader->Download(Target::toTufTarget(target));
   ASSERT_TRUE(result);
   const std::string expected_file = (client.apps_root / "app2"/ app_file_name).string();
@@ -413,6 +414,7 @@ TEST(ComposeApp, fetchNegative) {
   // Now do a quick check that we can handle a simple download failure
   target_json["custom"]["docker_compose_apps"]["app2"]["uri"] = "FAILTEST";
   target = Uptane::Target("pull", target_json);
+  client.pacman->checkForAppsToUpdate(target);
   auto result = client.downloader->Download(Target::toTufTarget(target));
   ASSERT_FALSE(result);
 

--- a/tests/fixtures/liteclienttest.cc
+++ b/tests/fixtures/liteclienttest.cc
@@ -341,6 +341,9 @@ class ClientTest :virtual public ::testing::Test {
     // TODO: remove it once aklite is moved to the newer version of LiteClient that exposes update() method
     ASSERT_TRUE(client.checkForUpdatesBegin());
 
+    // Emulate an update triggered through the API flow, which performs an apps status check and determines which apps need updating.
+    client.appsToUpdate(to, true);
+
     // TODO: call client->getTarget() once the method is moved to LiteClient
     const auto download_result{client.download(to, "")};
     ASSERT_EQ(download_result.status, expected_download_result.status);
@@ -377,6 +380,9 @@ class ClientTest :virtual public ::testing::Test {
     device_gateway_.resetEvents(client.http_client);
     // TODO: remove it once aklite is moved to the newer version of LiteClient that exposes update() method
     ASSERT_TRUE(client.checkForUpdatesBegin());
+
+    // Emulate an update triggered through the API flow, which performs an apps status check and determines which apps need updating.
+    client.appsToUpdate(to, true);
 
     // TODO: call client->getTarget() once the method is moved to LiteClient
     const DownloadResult dr{client.download(to, "")};


### PR DESCRIPTION
This PR refactors apps update handling so apps state/status is checked once per update flow instead of from multiple scattered call sites.

It centralizes apps status evaluation in a common helper used by API, daemon, sync, and local install paths, removes redundant checks from `ComposeAppManager::Download()` and install paths, and aligns tests with the new API-driven flow.

As a result, update logic becomes simpler, more consistent, and avoids duplicate app checks while preserving forced-update and removed-app cleanup behavior.

It also clears the path for a follow-up cleanup: removing the app-selection state from `ComposeAppManager` entirely (`cur_apps_to_fetch_and_update_` and `cur_apps_to_fetch_`) and passing the resolved lists of apps to fetch&update as part of the target instance. Hence, `ComposeAppManager` becomes stateless then.