### PR TITLE
ci: Use ccache in CI and manual workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,9 @@ jobs:
       env:
         CXX: clang++
         CC: clang
-        CCACHE_DIR: /tmp/ccache
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: git config --global --add safe.directory /__w/aktualizr-lite/aktualizr-lite
       - run: git submodule update --init --recursive
       - name: config
@@ -33,20 +32,87 @@ jobs:
       - name: tidy
         run: make -f dev-flow.mk tidy
 
-  garage-tools:
-    name: Build Garage Tools
+  refresh-ccache-dev:
+    name: Refresh ccache for development environment
     runs-on: ubuntu-latest
     container:
       image: foundries/aklite-dev
       env:
         CXX: clang++
         CC: clang
-        CCACHE_DIR: /tmp/ccache
+        CCACHE_DIR: /__w/aktualizr-lite/aktualizr-lite/.ccache
+
+    steps:
+      - uses: actions/checkout@v4
+      - run: git config --global --add safe.directory /__w/aktualizr-lite/aktualizr-lite
+      - run: git submodule update --init --recursive
+      - name: Restore ccache
+        uses: actions/cache@v4
+        with:
+          path: /__w/aktualizr-lite/aktualizr-lite/.ccache
+          key: dev-ccache-${{ github.sha }}
+          restore-keys: |
+            dev-ccache-
+      - name: build
+        run: make -f dev-flow.mk config build
+
+  refresh-ccache-e2e:
+    name: Refresh ccache for e2e tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - run: git config --global --add safe.directory ${{ github.workspace }}
+      - run: git submodule update --init --recursive
+      
+      - name: Restore ccache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.ccache
+          key: e2e-ccache-${{ github.sha }}
+          restore-keys: |
+            e2e-ccache-
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check if image exists # Fallback to master image if branch-specific image doesn't exist
+        id: check_image
+        run: |
+          if docker manifest inspect ghcr.io/${{ github.repository }}/aklite-e2e-test:${{ github.ref_name }} > /dev/null 2>&1; then
+            echo "AKLITE_E2E_IMAGE=ghcr.io/${{ github.repository }}/aklite-e2e-test:${{ github.ref_name }}" >> $GITHUB_ENV
+          else
+            echo "AKLITE_E2E_IMAGE=ghcr.io/${{ github.repository }}/aklite-e2e-test:master" >> $GITHUB_ENV
+          fi
+      - run: ./dev-shell-e2e-test.sh make -f dev-flow.mk config build
+        env:
+          AKLITE_E2E_IMAGE: ${{ env.AKLITE_E2E_IMAGE }}
+
+  garage-tools:
+    name: Build Garage Tools
+    runs-on: ubuntu-latest
+    needs: refresh-ccache-dev
+    container:
+      image: foundries/aklite-dev
+      env:
+        CXX: clang++
+        CC: clang
+        CCACHE_DIR: /__w/aktualizr-lite/aktualizr-lite/.ccache
 
     steps:
       - uses: actions/checkout@v3
       - run: git config --global --add safe.directory /__w/aktualizr-lite/aktualizr-lite
       - run: git submodule update --init --recursive
+      - name: Restore ccache
+        uses: actions/cache@v4
+        with:
+          path: /__w/aktualizr-lite/aktualizr-lite/.ccache
+          key: dev-ccache-garage-${{ github.sha }}
+          restore-keys: |
+            dev-ccache-garage-
+            dev-ccache-
       - name: build garage tools
         run: make -f dev-flow.mk garage-tools
       - name: check garage tools
@@ -62,28 +128,45 @@ jobs:
 
   test:
     name: Tests
+    needs: refresh-ccache-dev
     runs-on: ubuntu-latest
     container:
       image: foundries/aklite-dev
       env:
         CXX: clang++
         CC: clang
-        CCACHE_DIR: /tmp/ccache
+        CCACHE_DIR: /__w/aktualizr-lite/aktualizr-lite/.ccache
     steps:
       - uses: actions/checkout@v3
       - run: git config --global --add safe.directory /__w/aktualizr-lite/aktualizr-lite
       - run: git submodule update --init --recursive
+      - name: Restore ccache
+        uses: actions/cache@v4
+        with:
+          path: /__w/aktualizr-lite/aktualizr-lite/.ccache
+          key: dev-ccache-${{ github.sha }}
+          restore-keys: |
+            dev-ccache-
       - name: test
         run: make -f dev-flow.mk config build test
 
   e2e-test-basic-online-single-step:
     name: Basic online, single step end-to-end tests
     runs-on: ubuntu-latest
+    needs: refresh-ccache-e2e
 
     steps:
       - uses: actions/checkout@v4
-      - run: git config --global --add safe.directory /__w/aktualizr-lite/aktualizr-lite
+      - run: git config --global --add safe.directory ${{ github.workspace }}
       - run: git submodule update --init --recursive
+      
+      - name: Restore ccache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.ccache
+          key: e2e-ccache-${{ github.sha }}
+          restore-keys: |
+            e2e-ccache-
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -112,11 +195,20 @@ jobs:
   e2e-test-basic-online-granular-steps:
     name: Basic online, granular steps end-to-end tests
     runs-on: ubuntu-latest
+    needs: refresh-ccache-e2e
 
     steps:
       - uses: actions/checkout@v4
-      - run: git config --global --add safe.directory /__w/aktualizr-lite/aktualizr-lite
+      - run: git config --global --add safe.directory ${{ github.workspace }}
       - run: git submodule update --init --recursive
+      - name: Restore ccache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.ccache
+          key: e2e-ccache-${{ github.sha }}
+          restore-keys: |
+            e2e-ccache-
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -142,15 +234,22 @@ jobs:
           USER_TOKEN: ${{ secrets.E2E_TEST_USER_TOKEN }}
           TAG: ${{secrets.E2E_TEST_TAG}}
 
-
   e2e-test-basic-offline-single-step:
     name: Basic offline, single step end-to-end tests
     runs-on: ubuntu-latest
+    needs: refresh-ccache-e2e
 
     steps:
       - uses: actions/checkout@v4
-      - run: git config --global --add safe.directory /__w/aktualizr-lite/aktualizr-lite
+      - run: git config --global --add safe.directory ${{ github.workspace }}
       - run: git submodule update --init --recursive
+      - name: Restore ccache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.ccache
+          key: e2e-ccache-${{ github.sha }}
+          restore-keys: |
+            e2e-ccache-
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -180,11 +279,19 @@ jobs:
   e2e-test-basic-offline-granular-steps:
     name: Basic offline, granular steps end-to-end tests
     runs-on: ubuntu-latest
+    needs: refresh-ccache-e2e
 
     steps:
       - uses: actions/checkout@v4
-      - run: git config --global --add safe.directory /__w/aktualizr-lite/aktualizr-lite
+      - run: git config --global --add safe.directory ${{ github.workspace }}
       - run: git submodule update --init --recursive
+      - name: Restore ccache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.ccache
+          key: e2e-ccache-${{ github.sha }}
+          restore-keys: |
+            e2e-ccache-
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -214,11 +321,19 @@ jobs:
   e2e-test-1:
     name: End-to-end tests additional set
     runs-on: ubuntu-latest
+    needs: refresh-ccache-e2e
 
     steps:
       - uses: actions/checkout@v4
-      - run: git config --global --add safe.directory /__w/aktualizr-lite/aktualizr-lite
+      - run: git config --global --add safe.directory ${{ github.workspace }}
       - run: git submodule update --init --recursive
+      - name: Restore ccache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.ccache
+          key: e2e-ccache-${{ github.sha }}
+          restore-keys: |
+            e2e-ccache-
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -43,7 +43,8 @@ jobs:
           python-version: '3.12.3'
 
       - uses: actions/checkout@v4
-      - run: git config --global --add safe.directory /__w/aktualizr-lite/aktualizr-lite
+      - run: git config --global --add safe.directory ${{ github.workspace }}
+      - run: git submodule update --init --recursive
 
       - name: Install dependencies
         run: |
@@ -69,9 +70,13 @@ jobs:
           USER_TOKEN: ${{ secrets.GEN_TARGETS_E2E_TEST_USER_TOKEN }}
           TAG: ${{secrets.GEN_TARGETS_E2E_TEST_SECONDARY_TAG }}
 
-      - uses: actions/checkout@v4
-      - run: git config --global --add safe.directory /__w/aktualizr-lite/aktualizr-lite
-      - run: git submodule update --init --recursive
+      - name: Restore ccache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.ccache
+          key: e2e-ccache-${{ github.sha }}
+          restore-keys: |
+            e2e-ccache-
 
       - name: Check if image exists # Fallback to master image if branch-specific image doesn't exist
         id: check_image

--- a/dev-shell-e2e-test.sh
+++ b/dev-shell-e2e-test.sh
@@ -27,4 +27,11 @@ if [ ! -d "$PWD/.device/sysroot" ]; then
     fi
 fi
 
-docker compose --env-file=${docker_path}/.env.dev -f ${docker_path}/docker-compose.yml run -e DEV_USER=$(id -u) -e DEV_GROUP=$(id -g) -e BASE_TARGET_VERSION=${BASE_TARGET_VERSION} -e USER_TOKEN=${USER_TOKEN} -e TAG=${TAG} -e E2E_TEST_OSTREE_TGZ="${E2E_TEST_OSTREE_TGZ}" -e SECONDARY_TAG=${SECONDARY_TAG} -e SECONDARY_BASE_TARGET_VERSION="${SECONDARY_BASE_TARGET_VERSION}" -e SECONDARY_E2E_TEST_OSTREE_TGZ="${SECONDARY_E2E_TEST_OSTREE_TGZ}" -e AKLITE_E2E_IMAGE=${AKLITE_E2E_IMAGE} aklite-e2e-test "$@"
+if [ -n "$CCACHE_DIR" ] ; then
+        CCACHE_DIR=$(readlink -f $CCACHE_DIR)
+        CCACHE_ARGS="-e CCACHE_DIR=$CCACHE_DIR"
+else
+        CCACHE_ARGS="-e CCACHE_DIR=$PWD/.ccache"
+fi
+
+docker compose --env-file=${docker_path}/.env.dev -f ${docker_path}/docker-compose.yml run $CCACHE_ARGS -e DEV_USER=$(id -u) -e DEV_GROUP=$(id -g) -e BASE_TARGET_VERSION=${BASE_TARGET_VERSION} -e USER_TOKEN=${USER_TOKEN} -e TAG=${TAG} -e E2E_TEST_OSTREE_TGZ="${E2E_TEST_OSTREE_TGZ}" -e SECONDARY_TAG=${SECONDARY_TAG} -e SECONDARY_BASE_TARGET_VERSION="${SECONDARY_BASE_TARGET_VERSION}" -e SECONDARY_E2E_TEST_OSTREE_TGZ="${SECONDARY_E2E_TEST_OSTREE_TGZ}" -e AKLITE_E2E_IMAGE=${AKLITE_E2E_IMAGE} aklite-e2e-test "$@"

--- a/docker-e2e-test/docker-compose.yml
+++ b/docker-e2e-test/docker-compose.yml
@@ -28,6 +28,7 @@ services:
         - ${ETC_SOTA_DIR}:/etc/sota/conf.d
         - ${DOCKER_DATA_ROOT}:/var/lib/docker
         - docker-runtime:/var/run/docker
+        - ${CCACHE_DIR:-${PWD}/.ccache}:${CCACHE_DIR:-${PWD}/.ccache}
       working_dir: "${PWD}"
       hostname: device
       user: "root"


### PR DESCRIPTION
Ccache is now active for both aklite-dev and aklite-dev-e2e images, so we can use it in CI and manual workflows to speed up builds.

Each image has a different cache key. The key also contains the git commit hash, to allow updates to the cache when the code changes. If the specific hash is not found, the cache will be restored using the latest cache.

Two new jobs where added to refresh the cache for both images, and are set as dependencies for the other jobs. This avoids multiple jobs having to perform the same compilation in parallel.

When using ccache effectively, the current CI workflow time is reduced from about 22.5 minutes to about 19.5 minutes. Additional reduction is expected once we split the jobs further, which makes more sense now that each job does not need to perform the same compilation.