### PR TITLE
ci: Split longer jobs in 2 jobs each

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,8 +192,8 @@ jobs:
           USER_TOKEN: ${{ secrets.E2E_TEST_USER_TOKEN }}
           TAG: ${{secrets.E2E_TEST_TAG}}
 
-  e2e-test-basic-online-granular-steps:
-    name: Basic online, granular steps end-to-end tests
+  e2e-test-basic-online-granular-steps-no-delay-apps:
+    name: Basic online, granular steps, no delay start apps end-to-end tests
     runs-on: ubuntu-latest
     needs: refresh-ccache-e2e
 
@@ -226,7 +226,7 @@ jobs:
       - run: ./dev-shell-e2e-test.sh make -f dev-flow.mk config build
         env:
           AKLITE_E2E_IMAGE: ${{ env.AKLITE_E2E_IMAGE }}
-      - run: ./dev-shell-e2e-test.sh pytest docker-e2e-test/e2e-test.py -k 'test_incremental_updates[False-False or test_update_to_latest[False-False'
+      - run: ./dev-shell-e2e-test.sh pytest docker-e2e-test/e2e-test.py -k 'test_incremental_updates[False-False-False or test_update_to_latest[False-False'
         env:
           AKLITE_E2E_IMAGE: ${{ env.AKLITE_E2E_IMAGE }}
           FACTORY: ${{ secrets.E2E_TEST_FACTORY }}
@@ -234,6 +234,48 @@ jobs:
           USER_TOKEN: ${{ secrets.E2E_TEST_USER_TOKEN }}
           TAG: ${{secrets.E2E_TEST_TAG}}
 
+  e2e-test-basic-online-granular-steps-delay-apps:
+    name: Basic online, granular steps, delay start apps end-to-end tests
+    runs-on: ubuntu-latest
+    needs: refresh-ccache-e2e
+
+    steps:
+      - uses: actions/checkout@v4
+      - run: git config --global --add safe.directory ${{ github.workspace }}
+      - run: git submodule update --init --recursive
+      - name: Restore ccache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.ccache
+          key: e2e-ccache-${{ github.sha }}
+          restore-keys: |
+            e2e-ccache-
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check if image exists # Fallback to master image if branch-specific image doesn't exist
+        id: check_image
+        run: |
+          if docker manifest inspect ghcr.io/${{ github.repository }}/aklite-e2e-test:${{ github.ref_name }} > /dev/null 2>&1; then
+            echo "AKLITE_E2E_IMAGE=ghcr.io/${{ github.repository }}/aklite-e2e-test:${{ github.ref_name }}" >> $GITHUB_ENV
+          else
+            echo "AKLITE_E2E_IMAGE=ghcr.io/${{ github.repository }}/aklite-e2e-test:master" >> $GITHUB_ENV
+          fi
+      - run: ./dev-shell-e2e-test.sh make -f dev-flow.mk config build
+        env:
+          AKLITE_E2E_IMAGE: ${{ env.AKLITE_E2E_IMAGE }}
+      - run: ./dev-shell-e2e-test.sh pytest docker-e2e-test/e2e-test.py -k 'test_incremental_updates[False-False-True'
+        env:
+          AKLITE_E2E_IMAGE: ${{ env.AKLITE_E2E_IMAGE }}
+          FACTORY: ${{ secrets.E2E_TEST_FACTORY }}
+          BASE_TARGET_VERSION: ${{ secrets.E2E_TEST_BASE_TARGET_VERSION }}
+          USER_TOKEN: ${{ secrets.E2E_TEST_USER_TOKEN }}
+          TAG: ${{secrets.E2E_TEST_TAG}}
+          
   e2e-test-basic-offline-single-step:
     name: Basic offline, single step end-to-end tests
     runs-on: ubuntu-latest
@@ -276,8 +318,8 @@ jobs:
           TAG: ${{secrets.E2E_TEST_TAG}}
           E2E_TEST_OSTREE_TGZ: ${{ secrets.E2E_TEST_OSTREE_TGZ }}
 
-  e2e-test-basic-offline-granular-steps:
-    name: Basic offline, granular steps end-to-end tests
+  e2e-test-basic-offline-granular-steps-no-delay-apps:
+    name: Basic offline, granular steps, no delay start apps end-to-end tests
     runs-on: ubuntu-latest
     needs: refresh-ccache-e2e
 
@@ -309,7 +351,7 @@ jobs:
       - run: ./dev-shell-e2e-test.sh make -f dev-flow.mk config build
         env:
           AKLITE_E2E_IMAGE: ${{ env.AKLITE_E2E_IMAGE }}
-      - run: ./dev-shell-e2e-test.sh pytest docker-e2e-test/e2e-test.py -k 'test_incremental_updates[True-False or test_update_to_latest[True-False'
+      - run: ./dev-shell-e2e-test.sh pytest docker-e2e-test/e2e-test.py -k 'test_incremental_updates[True-False-False or test_update_to_latest[True-False'
         env:
           AKLITE_E2E_IMAGE: ${{ env.AKLITE_E2E_IMAGE }}
           FACTORY: ${{ secrets.E2E_TEST_FACTORY }}
@@ -318,6 +360,48 @@ jobs:
           TAG: ${{secrets.E2E_TEST_TAG}}
           E2E_TEST_OSTREE_TGZ: ${{ secrets.E2E_TEST_OSTREE_TGZ }}
 
+  e2e-test-basic-offline-granular-steps-delay-apps:
+    name: Basic offline, granular steps, delay start apps end-to-end tests
+    runs-on: ubuntu-latest
+    needs: refresh-ccache-e2e
+
+    steps:
+      - uses: actions/checkout@v4
+      - run: git config --global --add safe.directory ${{ github.workspace }}
+      - run: git submodule update --init --recursive
+      - name: Restore ccache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.ccache
+          key: e2e-ccache-${{ github.sha }}
+          restore-keys: |
+            e2e-ccache-
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check if image exists # Fallback to master image if branch-specific image doesn't exist
+        id: check_image
+        run: |
+          if docker manifest inspect ghcr.io/${{ github.repository }}/aklite-e2e-test:${{ github.ref_name }} > /dev/null 2>&1; then
+            echo "AKLITE_E2E_IMAGE=ghcr.io/${{ github.repository }}/aklite-e2e-test:${{ github.ref_name }}" >> $GITHUB_ENV
+          else
+            echo "AKLITE_E2E_IMAGE=ghcr.io/${{ github.repository }}/aklite-e2e-test:master" >> $GITHUB_ENV
+          fi
+      - run: ./dev-shell-e2e-test.sh make -f dev-flow.mk config build
+        env:
+          AKLITE_E2E_IMAGE: ${{ env.AKLITE_E2E_IMAGE }}
+      - run: ./dev-shell-e2e-test.sh pytest docker-e2e-test/e2e-test.py -k 'test_incremental_updates[True-False-True'
+        env:
+          AKLITE_E2E_IMAGE: ${{ env.AKLITE_E2E_IMAGE }}
+          FACTORY: ${{ secrets.E2E_TEST_FACTORY }}
+          BASE_TARGET_VERSION: ${{ secrets.E2E_TEST_BASE_TARGET_VERSION }}
+          USER_TOKEN: ${{ secrets.E2E_TEST_USER_TOKEN }}
+          TAG: ${{secrets.E2E_TEST_TAG}}
+          E2E_TEST_OSTREE_TGZ: ${{ secrets.E2E_TEST_OSTREE_TGZ }}
+          
   e2e-test-1:
     name: End-to-end tests additional set
     runs-on: ubuntu-latest


### PR DESCRIPTION
CI workflow execution now takes about 12 minutes, down from 19.5 minutes before this change.
