### PR TITLE
composeappmanager: add reserved_storage option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -438,7 +438,7 @@ jobs:
         env:
           AKLITE_E2E_IMAGE: ${{ env.AKLITE_E2E_IMAGE }}
 
-      - run: ./dev-shell-e2e-test.sh pytest docker-e2e-test/e2e-test.py -k 'test_no_space[False or test_forced_sync or test_bad_network or test_kill_process'
+      - run: ./dev-shell-e2e-test.sh pytest docker-e2e-test/e2e-test.py -k 'test_no_space[False or test_no_space_reserved_storage[False or test_reserved_storage_low_allows_update[False or test_forced_sync or test_bad_network or test_kill_process'
         env:
           AKLITE_E2E_IMAGE: ${{ env.AKLITE_E2E_IMAGE }}
           FACTORY: ${{ secrets.E2E_TEST_FACTORY }}

--- a/docker-e2e-test/e2e-test.py
+++ b/docker-e2e-test/e2e-test.py
@@ -403,7 +403,8 @@ def invoke_aklite(options: List[str], kill_after_sec: Optional[float] = None ):
             return subprocess.CompletedProcess(proc.args, proc.returncode, outs, errs)
     return subprocess.run([cmd] + options, capture_output=True)
 
-def write_settings(apps: Optional[List[str]] = None, prune: bool = True, tag: Optional[str] = None):
+def write_settings(apps: Optional[List[str]] = None, prune: bool = True, tag: Optional[str] = None,
+                   reserved_storage: Optional[str] = None):
     logger.info(f"  Updating settings. {apps=}")
     callback_file = "/var/sota/callback.sh"
 
@@ -432,6 +433,9 @@ compose_apps = "{apps_str}"
 
     if not prune:
         content += "\ndocker_prune = 0\n"
+
+    if reserved_storage is not None:
+        content += f'\nreserved_storage = "{reserved_storage}"\n'
 
     with open("/etc/sota/conf.d/z-50-fioctl.toml", "w") as f:
         f.write(content)
@@ -1422,14 +1426,14 @@ def is_loopback_mount(path: str):
     except subprocess.CalledProcessError:
         return False
 
-def run_test_no_space():
+def run_test_no_space(reserved_storage: Optional[str] = None):
     is_loopback = is_loopback_mount('/var/sota')
     if not is_loopback:
         assert False, "/var/sota is not a loopback mount point, skipping free space test execution. Device storage must be a loopback device to run this test."
 
     restore_system_state()
     apps = None # All apps, for now
-    write_settings(apps, prune)
+    write_settings(apps, prune, reserved_storage=reserved_storage)
 
     invoke_aklite(['check'])
 
@@ -1473,6 +1477,74 @@ def test_no_space(offline_: bool, single_step_: bool):
     single_step = single_step_
     logger.info(f"Testing no space left on device")
     run_test_no_space()
+
+
+@pytest.mark.parametrize('single_step_', [True, False])
+@pytest.mark.parametrize('offline_', [True, False])
+def test_no_space_reserved_storage(offline_: bool, single_step_: bool):
+    global offline, single_step
+    offline = offline_
+    single_step = single_step_
+    # The run_test_no_space helper fills /var/sota down to ~50KB of free space. Reserving 1MiB
+    # in bytes via pacman.reserved_storage must override the percentage watermark and trigger
+    # DownloadFailureNoSpace, since available_bytes < reserved_bytes.
+    logger.info(f"Testing no space left on device with pacman.reserved_storage set in bytes")
+    run_test_no_space(reserved_storage="1MiB")
+
+
+def run_test_reserved_storage_update_ok(reserved_storage: str):
+    is_loopback = is_loopback_mount('/var/sota')
+    if not is_loopback:
+        assert False, "/var/sota is not a loopback mount point, skipping free space test execution. Device storage must be a loopback device to run this test."
+
+    restore_system_state()
+    apps = None # All apps, for now
+    write_settings(apps, prune, reserved_storage=reserved_storage)
+
+    invoke_aklite(['check'])
+
+    # Fill /var/sota the same way the no-space test does, but stop at 20000000 bytes free so the
+    # update can still proceed. Combined with a tiny reserved_storage (e.g. "1KiB") this proves
+    # the bytes-based path doesn't over-reserve: available (~20MB) - reserved (1KiB) is still
+    # enough room for the update to land.
+    statvfs = os.statvfs("/var/sota")
+    available_bytes = statvfs.f_bavail * statvfs.f_frsize
+    logger.info(f"Available space in /var/sota: {available_bytes} bytes")
+    if available_bytes > 100000000:
+        assert False, "Too much free space left, test environment should be configured to have less than 100MB free space for this test to be effective"
+
+    if available_bytes > 20000000:
+        with open("/var/sota/fill_space", "wb") as f:
+            f.write(b"\0" * (available_bytes - 20000000))
+
+    statvfs = os.statvfs("/var/sota")
+    logger.info(f"Available space in /var/sota after filling it up: {statvfs.f_bavail * statvfs.f_frsize} bytes")
+
+    if single_step:
+        cmd = ['update', str(all_primary_tag_targets[Target.UpdateOstreeWithApps].actual_version)]
+        expected_success_code = ReturnCodes.InstallNeedsReboot
+    else:
+        cmd = ['pull', str(all_primary_tag_targets[Target.UpdateOstreeWithApps].actual_version)]
+        expected_success_code = ReturnCodes.Ok
+
+    try:
+        cp = invoke_aklite(cmd)
+        assert cp.returncode == expected_success_code, cp.stdout.decode("utf-8")
+    finally:
+        if os.path.exists("/var/sota/fill_space"):
+            os.remove("/var/sota/fill_space")
+
+
+@pytest.mark.parametrize('single_step_', [True, False])
+@pytest.mark.parametrize('offline_', [True, False])
+def test_reserved_storage_low_allows_update(offline_: bool, single_step_: bool):
+    global offline, single_step
+    offline = offline_
+    single_step = single_step_
+    # A tiny pacman.reserved_storage (1KiB) is well below the actual free space on /var/sota, so
+    # the bytes-based path must not block a legitimate update.
+    logger.info(f"Testing that a low pacman.reserved_storage value still allows the update")
+    run_test_reserved_storage_update_ok(reserved_storage="1KiB")
 
 
 def run_test_kill_process():

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,6 +41,12 @@ create_containers_before_reboot = "0"
 # By default, if the configuration param is not specified, it is set to "80".
 storage_watermark = "60" (set to "80" if not specified)
 
+# Absolute amount of free storage to reserve for non-Apps usage, expressed as a byte size with
+# either a binary (e.g. "2GiB", "500MiB") or decimal (e.g. "2GB", "500MB") suffix. When set, Apps
+# may use all available storage except the reserved amount, and this option takes precedence over
+# storage_watermark (a warning is logged if both are set). Unset by default.
+# reserved_storage = "2GiB"
+
 [logger]
 # Set log level 0-5 (trace, debug, info, warning, error, fatal)
 loglevel = 2

--- a/include/aktualizr-lite/storage/stat.h
+++ b/include/aktualizr-lite/storage/stat.h
@@ -27,8 +27,11 @@ struct Volume {
     std::string str() const;
   };
 
-  static UsageInfo getUsageInfo(const std::string& path, unsigned int reserved_percentage,
-                                const std::string& reserved_by = "");
+  // Reports filesystem usage for `path` against a `reserved` watermark that bounds how much storage
+  // may be consumed. By default `reserved` is a percentage of the volume capacity; when
+  // `reserved_in_bytes` is true it is an absolute amount of free space to keep reserved (in bytes).
+  static UsageInfo getUsageInfo(const std::string& path, uint64_t reserved, const std::string& reserved_by = "",
+                                bool reserved_in_bytes = false);
 };
 
 }  // namespace storage

--- a/src/api.cc
+++ b/src/api.cc
@@ -987,10 +987,12 @@ class LocalLiteInstall : public LiteInstall {
                            : std::make_shared<Docker::DockerClient>()};
 
 #ifdef USE_COMPOSEAPP_ENGINE
+    const auto storage_limit{pacman_cfg.storageSpaceLimit()};
     AppEngine::Ptr app_engine{std::make_shared<composeapp::AppEngine>(
         pacman_cfg.reset_apps_root, pacman_cfg.apps_root, pacman_cfg.images_data_root, registry_client, docker_client,
         docker_host, compose_cmd, pacman_cfg.composectl_bin.string(), pacman_cfg.storage_watermark,
-        Docker::RestorableAppEngine::GetDefStorageSpaceFunc(),
+        pacman_cfg.reserved_storage,
+        Docker::RestorableAppEngine::GetDefStorageSpaceFunc(storage_limit.first, storage_limit.second),
         [offline_registry](const Docker::Uri& app_uri, const std::string& image_uri) {
           Docker::Uri uri{Docker::Uri::parseUri(image_uri, false)};
           return "--src-shared-blob-dir " + offline_registry->blobsDir().string() +

--- a/src/composeapp/appengine.cc
+++ b/src/composeapp/appengine.cc
@@ -31,12 +31,19 @@ AppEngine::Result AppEngine::fetch(const App& app) {
           was_proxy_set = true;
         }
       }
-      exec(boost::format{"%s --store %s pull -p %s --storage-usage-watermark %d"} % composectl_cmd_ % storeRoot() %
-               app.uri % storage_watermark_,
+      // reserved_storage, when set, forwards an absolute reserved free space; otherwise the percentage
+      // watermark is forwarded. composectl gives --reserved-storage precedence over the watermark.
+      const std::string storage_arg{
+          reserved_storage_.empty() ? (boost::format{"--storage-usage-watermark %d"} % storage_watermark_).str()
+                                    : (boost::format{"--reserved-storage %s"} % reserved_storage_).str()};
+      exec(boost::format{"%s --store %s pull -p %s %s"} % composectl_cmd_ % storeRoot() % app.uri % storage_arg,
            "failed to pull compose app", "", nullptr, "4h", true);
     } else {
-      exec(boost::format{"%s --store %s pull -p %s -l %s --storage-usage-watermark %d"} % composectl_cmd_ %
-               storeRoot() % app.uri % local_source_path_ % storage_watermark_,
+      const std::string storage_arg{
+          reserved_storage_.empty() ? (boost::format{"--storage-usage-watermark %d"} % storage_watermark_).str()
+                                    : (boost::format{"--reserved-storage %s"} % reserved_storage_).str()};
+      exec(boost::format{"%s --store %s pull -p %s -l %s %s"} % composectl_cmd_ % storeRoot() % app.uri %
+               local_source_path_ % storage_arg,
            "failed to pull compose app", "", nullptr, "4h", true);
     }
     res = true;

--- a/src/composeapp/appengine.h
+++ b/src/composeapp/appengine.h
@@ -13,7 +13,7 @@ class AppEngine : public Docker::RestorableAppEngine {
             boost::filesystem::path docker_root, Docker::RegistryClient::Ptr registry_client,
             Docker::DockerClient::Ptr docker_client, std::string docker_host = "unix:///var/run/docker.sock",
             std::string compose_cmd = "/usr/bin/docker-compose", std::string composectl_cmd = "/usr/bin/composectl",
-            int storage_watermark = 80,
+            int storage_watermark = 80, std::string reserved_storage = "",
             StorageSpaceFunc storage_space_func = RestorableAppEngine::GetDefStorageSpaceFunc(),
             ClientImageSrcFunc client_image_src_func = nullptr, bool create_containers_if_install = true,
             const std::string& local_source_path = "", ProxyProvider proxy = nullptr)
@@ -23,6 +23,7 @@ class AppEngine : public Docker::RestorableAppEngine {
             std::move(client_image_src_func), create_containers_if_install, !local_source_path.empty()),
         composectl_cmd_{std::move(composectl_cmd)},
         storage_watermark_{storage_watermark},
+        reserved_storage_{std::move(reserved_storage)},
         local_source_path_{local_source_path},
         proxy_{proxy} {}
 
@@ -39,6 +40,7 @@ class AppEngine : public Docker::RestorableAppEngine {
 
   const std::string composectl_cmd_;
   const int storage_watermark_;
+  const std::string reserved_storage_;
   const std::string local_source_path_;
   ProxyProvider proxy_;
   mutable std::set<std::string> fetched_apps_;

--- a/src/composeappmanager.cc
+++ b/src/composeappmanager.cc
@@ -1,5 +1,9 @@
 #include "composeappmanager.h"
 
+#include <cctype>
+#include <cmath>
+#include <limits>
+#include <regex>
 #include <set>
 
 #include <boost/algorithm/string.hpp>
@@ -12,6 +16,55 @@
 #ifdef USE_COMPOSEAPP_ENGINE
 #include "composeapp/appengine.h"
 #endif  // USE_COMPOSEAPP_ENGINE
+
+bool ComposeAppManager::Config::parseSizeInBytes(const std::string& value, uint64_t& bytes) {
+  static const std::regex re{R"(^\s*([0-9]+(?:\.[0-9]+)?)\s*([kKmMgGtTpP])([iI])?[bB]?\s*$)"};
+  std::smatch match;
+  if (!std::regex_match(value, match, re)) {
+    return false;
+  }
+  double num{0.0};
+  try {
+    num = std::stod(match[1].str());
+  } catch (const std::exception& exc) {
+    // Numeric literal that the regex accepted but is too large for double, or otherwise unparseable.
+    LOG_WARNING << "Cannot parse reserved_storage numeric literal: " << value << "; err: " << exc.what();
+    return false;
+  }
+  if (!std::isfinite(num) || num < 0.0) {
+    return false;
+  }
+  const uint64_t base{match[3].matched ? 1024ULL : 1000ULL};
+  uint64_t mult{1};
+  switch (std::tolower(static_cast<unsigned char>(match[2].str()[0]))) {
+    case 'k':
+      mult = base;
+      break;
+    case 'm':
+      mult = base * base;
+      break;
+    case 'g':
+      mult = base * base * base;
+      break;
+    case 't':
+      mult = base * base * base * base;
+      break;
+    case 'p':
+      mult = base * base * base * base * base;
+      break;
+    default:
+      return false;
+  }
+  const double scaled{num * static_cast<double>(mult)};
+  // Reject anything that overflows uint64_t. Casting an out-of-range double to an integer type is
+  // undefined behaviour, so the bounds check has to happen in double-precision before the cast.
+  if (!std::isfinite(scaled) || scaled < 0.0 ||
+      scaled > static_cast<double>(std::numeric_limits<uint64_t>::max())) {
+    return false;
+  }
+  bytes = static_cast<uint64_t>(scaled);
+  return true;
+}
 
 ComposeAppManager::Config::Config(const PackageConfig& pconfig) {
   const std::map<std::string, std::string> raw = pconfig.extra;
@@ -113,6 +166,25 @@ ComposeAppManager::Config::Config(const PackageConfig& pconfig) {
       throw;
     }
   }
+
+  if (raw.count("reserved_storage") > 0) {
+    // reserved_storage reserves an absolute amount of free space (e.g. "2GiB" or "500MB") and takes
+    // precedence over the percentage storage_watermark. The raw value is forwarded to composectl as-is.
+    const std::string reserved_storage_value{raw.at("reserved_storage")};
+    uint64_t bytes{0};
+    if (!parseSizeInBytes(reserved_storage_value, bytes)) {
+      LOG_ERROR
+          << "Invalid sota.toml:pacman:reserved_storage value, should be a byte size such as \"2GiB\" or \"500MB\", got "
+          << reserved_storage_value;
+      throw std::invalid_argument("invalid sota.toml:pacman:reserved_storage value: " + reserved_storage_value);
+    }
+    if (raw.count("storage_watermark") > 0) {
+      LOG_WARNING << "Both sota.toml:pacman:storage_watermark and sota.toml:pacman:reserved_storage are set; "
+                     "ignoring storage_watermark";
+    }
+    reserved_storage = reserved_storage_value;
+    reserved_storage_bytes = bytes;
+  }
 }
 
 ComposeAppManager::ComposeAppManager(const PackageConfig& pconfig, const BootloaderConfig& bconfig,
@@ -165,16 +237,20 @@ ComposeAppManager::ComposeAppManager(const PackageConfig& pconfig, const Bootloa
           return std::make_pair(proxy_url, cfg_.apps_proxy_ca);
         };
       }
+      const auto storage_limit{cfg_.storageSpaceLimit()};
       app_engine_ = std::make_shared<composeapp::AppEngine>(
           cfg_.reset_apps_root, cfg_.apps_root, cfg_.images_data_root, registry_client,
           std::make_shared<Docker::DockerClient>(), docker_host, compose_cmd, composectl_cmd, cfg_.storage_watermark,
-          Docker::RestorableAppEngine::GetDefStorageSpaceFunc(cfg_.storage_watermark), nullptr, true, "", proxy);
+          cfg_.reserved_storage,
+          Docker::RestorableAppEngine::GetDefStorageSpaceFunc(storage_limit.first, storage_limit.second), nullptr, true,
+          "", proxy);
 #else
       const std::string skopeo_cmd{boost::filesystem::canonical(cfg_.skopeo_bin).string()};
+      const auto storage_limit{cfg_.storageSpaceLimit()};
       app_engine_ = std::make_shared<Docker::RestorableAppEngine>(
           cfg_.reset_apps_root, cfg_.apps_root, cfg_.images_data_root, registry_client,
           std::make_shared<Docker::DockerClient>(), skopeo_cmd, docker_host, compose_cmd,
-          Docker::RestorableAppEngine::GetDefStorageSpaceFunc(cfg_.storage_watermark));
+          Docker::RestorableAppEngine::GetDefStorageSpaceFunc(storage_limit.first, storage_limit.second));
 #endif  // USE_COMPOSEAPP_ENGINE
       is_restorable_engine_ = true;
     } else {
@@ -805,16 +881,19 @@ ComposeAppManager::AppsContainer ComposeAppManager::getAppsToFetch(const Uptane:
 
 std::string ComposeAppManager::getAppsFsUsageInfo() const {
   std::stringstream ss;
-  auto usage_info{storage::Volume::getUsageInfo(cfg_.images_data_root.string(), (100 - cfg_.storage_watermark),
-                                                "pacman:storage_watermark")};
+  const bool in_bytes{cfg_.reserved_storage_bytes > 0};
+  const uint64_t reserved{in_bytes ? cfg_.reserved_storage_bytes
+                                   : ((100 > cfg_.storage_watermark) ? static_cast<uint64_t>(100 - cfg_.storage_watermark)
+                                                                     : 0)};
+  const std::string reserved_by{in_bytes ? "pacman:reserved_storage" : "pacman:storage_watermark"};
+  auto usage_info{storage::Volume::getUsageInfo(cfg_.images_data_root.string(), reserved, reserved_by, in_bytes)};
   if (!usage_info.isOk()) {
     LOG_ERROR << "Failed to obtain storage usage statistic: " << usage_info.err;
   }
   ss << usage_info;
   if (is_restorable_engine_ &&
       !Docker::RestorableAppEngine::areDockerAndSkopeoOnTheSameVolume(cfg_.apps_root, cfg_.images_data_root)) {
-    auto usage_info{storage::Volume::getUsageInfo(cfg_.apps_root.string(), (100 - cfg_.storage_watermark),
-                                                  "pacman:storage_watermark")};
+    auto usage_info{storage::Volume::getUsageInfo(cfg_.apps_root.string(), reserved, reserved_by, in_bytes)};
     if (!usage_info.isOk()) {
       LOG_ERROR << "Failed to obtain storage usage statistic: " << usage_info.err;
     }

--- a/src/composeappmanager.h
+++ b/src/composeappmanager.h
@@ -39,7 +39,30 @@ class ComposeAppManager : public RootfsTreeManager {
     std::string hub_auth_creds_endpoint{Docker::RegistryClient::DefAuthCredsEndpoint};
     bool create_containers_before_reboot{true};
     bool stop_apps_before_update{true};
+    // Percentage (20-95) of overall storage that Apps may use. Forwarded to composectl as
+    // --storage-usage-watermark unless reserved_storage takes over.
     int storage_watermark{80};
+    // reserved_storage, when set, reserves an absolute amount of free space (e.g. "2GiB" or "500MB")
+    // instead of a percentage and takes precedence over storage_watermark. reserved_storage holds
+    // the raw config value forwarded to composectl as --reserved-storage; reserved_storage_bytes is
+    // its parsed size in bytes (0 when reserved_storage is unset).
+    std::string reserved_storage{};
+    uint64_t reserved_storage_bytes{0};
+
+    // Returns the (limit, in-bytes) pair for the local storage-space check: the reserved free
+    // space in bytes when reserved_storage is set, otherwise the percentage watermark.
+    std::pair<uint64_t, bool> storageSpaceLimit() const {
+      if (reserved_storage_bytes > 0) {
+        return {reserved_storage_bytes, true};
+      }
+      return {static_cast<uint64_t>(storage_watermark), false};
+    }
+
+    // Parses a human-readable byte size (e.g. "2GiB", "500MiB", "2GB", "500MB") into a count of
+    // bytes. The presence of an "i" in the suffix selects the binary base (1024); otherwise the
+    // decimal base (1000) is used. Returns false when `value` lacks a recognized size unit, when
+    // the numeric literal overflows double, or when the scaled byte count would overflow uint64_t.
+    static bool parseSizeInBytes(const std::string& value, uint64_t& bytes);
   };
 
   using AppsContainer = std::unordered_map<std::string, std::string>;

--- a/src/docker/restorableappengine.cc
+++ b/src/docker/restorableappengine.cc
@@ -31,20 +31,27 @@ class InsufficientSpaceError : public std::runtime_error {
 
 const std::string RestorableAppEngine::ComposeFile{"docker-compose.yml"};
 
-RestorableAppEngine::StorageSpaceFunc RestorableAppEngine::GetDefStorageSpaceFunc(int watermark) {
-  const int low_watermark_limit{LowWatermarkLimit};
-  const int high_watermark_limit{HighWatermarkLimit};
+RestorableAppEngine::StorageSpaceFunc RestorableAppEngine::GetDefStorageSpaceFunc(uint64_t watermark,
+                                                                                  bool watermark_in_bytes) {
+  if (!watermark_in_bytes) {
+    const int low_watermark_limit{LowWatermarkLimit};
+    const int high_watermark_limit{HighWatermarkLimit};
 
-  if (watermark < low_watermark_limit || watermark > high_watermark_limit) {
-    throw std::invalid_argument(
-        "Unsupported value of a storage watermark (sota.toml:pacman:storage_watermark); should be within [" +
-        std::to_string(low_watermark_limit) + "," + std::to_string(high_watermark_limit) + "] range, got " +
-        std::to_string(watermark));
+    if (watermark < static_cast<uint64_t>(low_watermark_limit) ||
+        watermark > static_cast<uint64_t>(high_watermark_limit)) {
+      throw std::invalid_argument(
+          "Unsupported value of a storage watermark (sota.toml:pacman:storage_watermark); should be within [" +
+          std::to_string(low_watermark_limit) + "," + std::to_string(high_watermark_limit) + "] range, got " +
+          std::to_string(watermark));
+    }
   }
 
-  return [watermark](const boost::filesystem::path& path) {
-    storage::Volume::UsageInfo usage_info{storage::Volume::getUsageInfo(
-        path.string(), (100 > watermark) ? static_cast<unsigned int>(100 - watermark) : 0, "pacman:storage_watermark")};
+  return [watermark, watermark_in_bytes](const boost::filesystem::path& path) {
+    storage::Volume::UsageInfo usage_info{
+        watermark_in_bytes
+            ? storage::Volume::getUsageInfo(path.string(), watermark, "pacman:reserved_storage", true)
+            : storage::Volume::getUsageInfo(path.string(), (100 > watermark) ? (100 - watermark) : 0,
+                                            "pacman:storage_watermark")};
     if (!usage_info.isOk()) {
       LOG_ERROR << "Failed to obtain storage usage statistic: " << usage_info.err;
     }

--- a/src/docker/restorableappengine.h
+++ b/src/docker/restorableappengine.h
@@ -80,7 +80,7 @@ class RestorableAppEngine : public AppEngine {
 
   static const int LowWatermarkLimit{20};
   static const int HighWatermarkLimit{95};
-  static StorageSpaceFunc GetDefStorageSpaceFunc(int watermark = 80);
+  static StorageSpaceFunc GetDefStorageSpaceFunc(uint64_t watermark = 80, bool watermark_in_bytes = false);
   static const int SkopeoMaxParallelPullsHighLimit{10};
   static const int SkopeoMaxParallelPullsLowLimit{1};
 

--- a/src/storage/stat.cc
+++ b/src/storage/stat.cc
@@ -3,6 +3,7 @@
 #include <fcntl.h>
 #include <sys/statvfs.h>
 #include <unistd.h>
+#include <algorithm>
 #include <cmath>
 #include <cstring>
 #include <sstream>
@@ -35,25 +36,31 @@ static std::string getStat(const std::string& path, Stat& stat) {
   return "";
 }
 
-Volume::UsageInfo Volume::getUsageInfo(const std::string& path, unsigned int reserved_percentage,
-                                       const std::string& reserved_by) {
+Volume::UsageInfo Volume::getUsageInfo(const std::string& path, uint64_t reserved, const std::string& reserved_by,
+                                       bool reserved_in_bytes) {
   Stat stat{};
   if (std::string err = getStat(path, stat); !err.empty()) {
     return UsageInfo{.err = err};
   }
 
+  const uint64_t size_bytes{stat.blockSize * stat.blockNumb};
   UsageInfo::Type free{stat.blockSize * stat.freeBlockNumber,
                        (static_cast<double>(stat.freeBlockNumber) / stat.blockNumb) * 100};
-  UsageInfo::Type reserved{
-      stat.blockSize * static_cast<uint64_t>(std::ceil(stat.blockNumb * (reserved_percentage / 100.0))),
-      reserved_percentage};
-  UsageInfo::Type available{(free.first > reserved.first) ? (free.first - reserved.first) : 0,
-                            (free.second > reserved.second) ? (free.second - reserved.second) : 0};
+  UsageInfo::Type reserved_usage{};
+  if (reserved_in_bytes) {
+    const uint64_t reserved_bytes{std::min(reserved, size_bytes)};
+    reserved_usage = {reserved_bytes, size_bytes > 0 ? (static_cast<double>(reserved_bytes) / size_bytes) * 100 : 0};
+  } else {
+    reserved_usage = {stat.blockSize * static_cast<uint64_t>(std::ceil(stat.blockNumb * (reserved / 100.0))),
+                      static_cast<float>(reserved)};
+  }
+  UsageInfo::Type available{(free.first > reserved_usage.first) ? (free.first - reserved_usage.first) : 0,
+                            (free.second > reserved_usage.second) ? (free.second - reserved_usage.second) : 0};
   return {
       .path = path,
-      .size = {stat.blockSize * stat.blockNumb, 100},
+      .size = {size_bytes, 100},
       .free = free,
-      .reserved = reserved,
+      .reserved = reserved_usage,
       .reserved_by = reserved_by,
       .available = available,
       .required = {},

--- a/tests/aklite_offline_test.cc
+++ b/tests/aklite_offline_test.cc
@@ -169,10 +169,12 @@ class AkliteOffline : public ::testing::Test {
                            : std::make_shared<Docker::DockerClient>()};
 
 #ifdef USE_COMPOSEAPP_ENGINE
+    const auto storage_limit{pacman_cfg.storageSpaceLimit()};
     AppEngine::Ptr app_engine{std::make_shared<composeapp::AppEngine>(
         pacman_cfg.reset_apps_root, pacman_cfg.apps_root, pacman_cfg.images_data_root, nullptr, docker_client,
         docker_host, compose_cmd, pacman_cfg.composectl_bin.string(), pacman_cfg.storage_watermark,
-        Docker::RestorableAppEngine::GetDefStorageSpaceFunc(), nullptr,
+        pacman_cfg.reserved_storage,
+        Docker::RestorableAppEngine::GetDefStorageSpaceFunc(storage_limit.first, storage_limit.second), nullptr,
         false, /* don't create containers on install because it makes dockerd check if pinned images
       present in its store what we should avoid until images are registered (hacked) in dockerd store */
         local_update_source_.app_store)};

--- a/tests/composeapp_test.cc
+++ b/tests/composeapp_test.cc
@@ -178,6 +178,43 @@ TEST(ComposeApp, Config) {
   config.pacman.extra["storage_watermark"] = "50";
   cfg = ComposeAppManager::Config(config.pacman);
   ASSERT_EQ(cfg.storage_watermark, 50);
+  ASSERT_EQ(cfg.reserved_storage_bytes, 0U);
+
+  // reserved_storage reserves an absolute amount of free space in bytes and takes precedence over the
+  // percentage storage_watermark (which stays set to "50" here).
+  config.pacman.extra["reserved_storage"] = "2GiB";
+  cfg = ComposeAppManager::Config(config.pacman);
+  ASSERT_EQ(cfg.reserved_storage_bytes, 2ULL * 1024 * 1024 * 1024);
+  ASSERT_EQ(cfg.reserved_storage, "2GiB");
+
+  config.pacman.extra["reserved_storage"] = "500MiB";
+  cfg = ComposeAppManager::Config(config.pacman);
+  ASSERT_EQ(cfg.reserved_storage_bytes, 500ULL * 1024 * 1024);
+
+  // Decimal suffixes are accepted in addition to the binary ones; "GB" is 1000-based.
+  config.pacman.extra["reserved_storage"] = "2GB";
+  cfg = ComposeAppManager::Config(config.pacman);
+  ASSERT_EQ(cfg.reserved_storage_bytes, 2ULL * 1000 * 1000 * 1000);
+
+  config.pacman.extra["reserved_storage"] = "500MB";
+  cfg = ComposeAppManager::Config(config.pacman);
+  ASSERT_EQ(cfg.reserved_storage_bytes, 500ULL * 1000 * 1000);
+
+  // A reserved_storage value without a recognized size suffix is rejected.
+  config.pacman.extra["reserved_storage"] = "2XB";
+  EXPECT_THROW(ComposeAppManager::Config(config.pacman), std::invalid_argument);
+
+  // A scaled byte count that overflows uint64_t is rejected, not truncated. Casting an
+  // out-of-range double to an integer type is undefined, so the overflow guard must run before
+  // the cast.
+  config.pacman.extra["reserved_storage"] = "99999999999PiB";
+  EXPECT_THROW(ComposeAppManager::Config(config.pacman), std::invalid_argument);
+
+  // A numeric literal large enough to overflow double's parser must be rejected via the
+  // std::stod try/catch path rather than escaping as an exception.
+  config.pacman.extra["reserved_storage"] = std::string(400, '9') + "GiB";
+  EXPECT_THROW(ComposeAppManager::Config(config.pacman), std::invalid_argument);
+  config.pacman.extra.erase("reserved_storage");
 }
 
 class TestSysroot: public OSTree::Sysroot {
@@ -282,6 +319,66 @@ struct TestClient {
   std::shared_ptr<OSTree::Sysroot> sysroot;
   AppEngine::Ptr app_engine_;
 };
+
+TEST(ComposeApp, ParseSizeInBytes) {
+  using Config = ComposeAppManager::Config;
+  uint64_t bytes{0};
+
+  // Binary unit suffixes are 1024-based.
+  ASSERT_TRUE(Config::parseSizeInBytes("1KiB", bytes));
+  ASSERT_EQ(bytes, 1024ULL);
+  ASSERT_TRUE(Config::parseSizeInBytes("2MiB", bytes));
+  ASSERT_EQ(bytes, 2ULL * 1024 * 1024);
+  ASSERT_TRUE(Config::parseSizeInBytes("2GiB", bytes));
+  ASSERT_EQ(bytes, 2ULL * 1024 * 1024 * 1024);
+  ASSERT_TRUE(Config::parseSizeInBytes("3TiB", bytes));
+  ASSERT_EQ(bytes, 3ULL * 1024 * 1024 * 1024 * 1024);
+  ASSERT_TRUE(Config::parseSizeInBytes("1PiB", bytes));
+  ASSERT_EQ(bytes, 1ULL * 1024 * 1024 * 1024 * 1024 * 1024);
+
+  // Decimal unit suffixes are 1000-based.
+  ASSERT_TRUE(Config::parseSizeInBytes("1kB", bytes));
+  ASSERT_EQ(bytes, 1000ULL);
+  ASSERT_TRUE(Config::parseSizeInBytes("500MB", bytes));
+  ASSERT_EQ(bytes, 500ULL * 1000 * 1000);
+  ASSERT_TRUE(Config::parseSizeInBytes("2GB", bytes));
+  ASSERT_EQ(bytes, 2ULL * 1000 * 1000 * 1000);
+  ASSERT_TRUE(Config::parseSizeInBytes("3TB", bytes));
+  ASSERT_EQ(bytes, 3ULL * 1000 * 1000 * 1000 * 1000);
+
+  // The trailing "B" is optional; case in the unit letter and the optional "i"/"b" is ignored.
+  ASSERT_TRUE(Config::parseSizeInBytes("2G", bytes));
+  ASSERT_EQ(bytes, 2ULL * 1000 * 1000 * 1000);
+  ASSERT_TRUE(Config::parseSizeInBytes("2GI", bytes));
+  ASSERT_EQ(bytes, 2ULL * 1024 * 1024 * 1024);
+  ASSERT_TRUE(Config::parseSizeInBytes("2gib", bytes));
+  ASSERT_EQ(bytes, 2ULL * 1024 * 1024 * 1024);
+
+  // Fractional values, leading/trailing whitespace, and zero are all accepted.
+  ASSERT_TRUE(Config::parseSizeInBytes("1.5GiB", bytes));
+  ASSERT_EQ(bytes, static_cast<uint64_t>(1.5 * 1024 * 1024 * 1024));
+  ASSERT_TRUE(Config::parseSizeInBytes("  500MiB  ", bytes));
+  ASSERT_EQ(bytes, 500ULL * 1024 * 1024);
+  ASSERT_TRUE(Config::parseSizeInBytes("0GiB", bytes));
+  ASSERT_EQ(bytes, 0ULL);
+
+  // Inputs that do not match the size grammar are rejected. The output `bytes` is left untouched.
+  bytes = 0xDEADBEEF;
+  ASSERT_FALSE(Config::parseSizeInBytes("", bytes));
+  ASSERT_FALSE(Config::parseSizeInBytes("100", bytes));      // bare integer is a percentage, not a byte size
+  ASSERT_FALSE(Config::parseSizeInBytes("2XB", bytes));      // unrecognized unit letter
+  ASSERT_FALSE(Config::parseSizeInBytes("2 GiB extra", bytes));
+  ASSERT_FALSE(Config::parseSizeInBytes("-1GiB", bytes));
+  ASSERT_FALSE(Config::parseSizeInBytes("GiB", bytes));      // no numeric prefix
+  ASSERT_EQ(bytes, 0xDEADBEEFULL);
+
+  // Scaled byte counts that overflow uint64_t must be rejected, not truncated. Casting an
+  // out-of-range double to uint64_t is undefined behaviour; the helper must catch this before
+  // the cast.
+  ASSERT_FALSE(Config::parseSizeInBytes("99999999999PiB", bytes));
+  // Numeric literals that overflow double itself must be handled via the std::stod try/catch.
+  ASSERT_FALSE(Config::parseSizeInBytes(std::string(400, '9') + "GiB", bytes));
+}
 
 TEST(ComposeApp, getApps) {
   TemporaryDirectory dir;

--- a/tests/nospace_test.cc
+++ b/tests/nospace_test.cc
@@ -229,6 +229,43 @@ TEST(StorageStat, UsageInfo) {
     ASSERT_EQ(reserved, usage_info.reserved) << usage_info.reserved.first;
     ASSERT_EQ(storage::Volume::UsageInfo::Type(0, 0), usage_info.available) << usage_info.available.first;
   }
+  {
+    // Reserved space given as an absolute amount of bytes instead of a percentage.
+    unsigned int block_size{4096};
+    uint64_t block_numb{100};
+    unsigned int free_percentage{50};
+    const uint64_t total_bytes{block_size * block_numb};
+    const uint64_t reserved_bytes{block_size * 10};  // 10% of the volume expressed in bytes
+
+    storage::Volume::UsageInfo::Type free{std::ceil(block_numb * (free_percentage / 100.0)) * block_size,
+                                          free_percentage};
+    storage::Volume::UsageInfo::Type reserved{reserved_bytes,
+                                              (static_cast<double>(reserved_bytes) / total_bytes) * 100};
+
+    SetBlockSize(block_size);
+    SetFreeBlockNumb(std::ceil(block_numb * (free_percentage / 100.0)), block_numb);
+    storage::Volume::UsageInfo usage_info{
+        storage::Volume::getUsageInfo("./", reserved_bytes, "pacman:reserved_storage", true)};
+    ASSERT_TRUE(usage_info.isOk());
+    ASSERT_EQ(free, usage_info.free) << usage_info.free.first;
+    ASSERT_EQ(reserved, usage_info.reserved) << usage_info.reserved.first;
+    ASSERT_EQ((free.first - reserved.first), usage_info.available.first) << usage_info.available.first;
+  }
+  {
+    // Reserved bytes larger than the volume are capped at the volume size, leaving nothing available.
+    unsigned int block_size{4096};
+    uint64_t block_numb{100};
+    unsigned int free_percentage{50};
+    const uint64_t total_bytes{block_size * block_numb};
+
+    SetBlockSize(block_size);
+    SetFreeBlockNumb(std::ceil(block_numb * (free_percentage / 100.0)), block_numb);
+    storage::Volume::UsageInfo usage_info{
+        storage::Volume::getUsageInfo("./", total_bytes * 2, "pacman:reserved_storage", true)};
+    ASSERT_TRUE(usage_info.isOk());
+    ASSERT_EQ(total_bytes, usage_info.reserved.first) << usage_info.reserved.first;
+    ASSERT_EQ(storage::Volume::UsageInfo::Type(0, 0), usage_info.available) << usage_info.available.first;
+  }
   UnsetFreeBlockNumb();
 }
 

--- a/tests/restorableappengine_test.cc
+++ b/tests/restorableappengine_test.cc
@@ -312,6 +312,10 @@ TEST_F(RestorableAppEngineTest, CheckStorageWatermarkLimits) {
                std::invalid_argument);
   EXPECT_THROW(Docker::RestorableAppEngine::GetDefStorageSpaceFunc(Docker::RestorableAppEngine::LowWatermarkLimit - 1),
                std::invalid_argument);
+  // In bytes mode the percentage range limits do not apply.
+  EXPECT_NO_THROW(Docker::RestorableAppEngine::GetDefStorageSpaceFunc(2ULL * 1024 * 1024 * 1024, true));
+  EXPECT_NO_THROW(Docker::RestorableAppEngine::GetDefStorageSpaceFunc(
+      Docker::RestorableAppEngine::HighWatermarkLimit + 1, true));
 }
 
 TEST_F(RestorableAppEngineTest, FetchAndCheckSizeInsufficientSpace) {


### PR DESCRIPTION
pacman.storage_watermark stays a plain percentage. A new pacman.reserved_storage option accepts a byte size (e.g. "2GiB", "500MiB") and reserves that absolute amount of free space for non-Apps usage. When both are set, reserved_storage wins and a warning is logged.

The new option is forwarded to composectl as --reserved-storage, while storage_watermark continues to be forwarded as --storage-usage-watermark. getUsageInfo and the skopeo-engine storage space check use the parsed byte value when reserved_storage is set, and the percentage otherwise.


Assisted-by: Claude Code:claude-opus-4-8