### PR TITLE
liteclient: Respect a configured compose_apps_proxy_ca

### DIFF
--- a/src/liteclient.cc
+++ b/src/liteclient.cc
@@ -149,7 +149,13 @@ LiteClient::LiteClient(Config config_in, const AppEngine::Ptr& app_engine, const
       // Enforce the restorable app engine usage
       config.pacman.extra["reset_apps"] = "";
     }
-    config.pacman.extra["compose_apps_proxy_ca"] = config.storage.tls_cacert_path.get(config.storage.path).string();
+    // Default the app proxy CA to the device gateway CA, but let it be
+    // configured. A self-hosted gateway may terminate TLS with a certificate
+    // that does not chain to the CA the device uses for its own mTLS, in which
+    // case composectl needs a different bundle to reach the registry proxy.
+    if (config.pacman.extra.count("compose_apps_proxy_ca") == 0) {
+      config.pacman.extra["compose_apps_proxy_ca"] = config.storage.tls_cacert_path.get(config.storage.path).string();
+    }
     basepacman = std::make_shared<ComposeAppManager>(config.pacman, config.bootloader, storage, http_client,
                                                      ostree_sysroot, *key_manager_, app_engine);
   } else if (config.pacman.type == RootfsTreeManager::Name) {


### PR DESCRIPTION
## Problem

`ComposeAppManager::Config` parses `compose_apps_proxy_ca` from `sota.toml`:

```cpp
if (raw.count("compose_apps_proxy_ca") == 1) {
  apps_proxy_ca = raw.at("compose_apps_proxy_ca");
}
```

but `LiteClient` overwrites it unconditionally before the config is handed over:

```cpp
config.pacman.extra["compose_apps_proxy_ca"] = config.storage.tls_cacert_path.get(config.storage.path).string();
```

so the setting can never take effect.

## Why it matters

The implicit assumption is that the device gateway's server certificate chains
to the same CA the device already trusts as `root.crt`. That holds for a stock
deployment, but not necessarily for a self-hosted gateway that terminates TLS
with a certificate from a different issuer.

When it does not hold, the symptom is confusing: platform OTA and TUF keep
working, because aktualizr-lite's libcurl connections also consult the system CA
store, while app fetches fail. `composectl` honours the supplied bundle
strictly, cannot verify the registry proxy, falls back to the app URI host and
reports `x509: certificate signed by unknown authority` against that host — which
points at the wrong place entirely.

## Change

Treat the gateway CA as a default rather than a forced value, so an explicitly
configured `compose_apps_proxy_ca` is honoured. Behaviour is unchanged when the
key is absent.

## Testing

Verified by inspection; the guard uses the same `config.pacman.extra.count(...)`
construct as three adjacent lines in the same function. I have not added a unit
test — happy to add one under `tests/` if you can point me at the preferred
place for config-precedence coverage.

---

*This change was prepared with AI assistance (Cursor) and reviewed before submission.*

Made with [Cursor](https://cursor.com)